### PR TITLE
tools: better claude/vscode workspace setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code
+.claude/plan.md
+
 # OS
 .DS_Store
 Thumbs.db
@@ -9,7 +12,7 @@ Thumbs.db
 *~
 
 # VS Code
-.vscode/*
+.vscode/**
 !.vscode/settings.json
 !.vscode/seismic.code-workspace
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,6 @@
-# Seismic — LLM Context
+# Seismic Monorepo
 
-Seismic is a privacy-enabled EVM blockchain. This file gives you the context to work effectively across the Seismic codebase, which spans multiple repos.
-
-- This repo is seismic's monorepo, targeting Seismic developers and contributors.
-- For user-facing docs: https://docs.seismic.systems/llms-full.txt
-
-## Key Concepts
-
-See [docs/glossary.md](docs/glossary.md) for full definitions. Quick summary:
-
-- **FlaggedStorage** — `(value: U256, is_private: bool)` tuple replacing `U256` for all storage values. Private slots return 0 via RPC; only `CLOAD`/`CSTORE` opcodes can access them.
-- **Shielded Types** — `suint`, `sint`, `sbool`, `saddress` compile to `CLOAD`/`CSTORE` instead of `SLOAD`/`SSTORE`.
-- **Mercury Spec** — modified EVM: CLOAD/CSTORE opcodes + 6 precompiles (RNG, ECDH, AES-GCM, HKDF, secp256k1 Sign).
-- **TxSeismic** — transaction type `74` with encrypted calldata (ECDH + AEAD).
-- **TEE Integration** — nodes run in a TEE; calldata decrypted at RPC layer before EVM execution.
+This is seismic's monorepo, targeting Seismic developers and contributors. It contains documentation, scripts, and the VS Code workspace file.
 
 ## Docs in This Repo
 
@@ -21,37 +8,3 @@ See [docs/glossary.md](docs/glossary.md) for full definitions. Quick summary:
 - [docs/glossary.md](docs/glossary.md) — key concepts: FlaggedStorage, TxSeismic, Mercury Spec, SeismicHost
 - [docs/language-and-vm.md](docs/language-and-vm.md) — Mercury EVM spec: shielded types, CLOAD/CSTORE, FlaggedStorage, arrays, casting
 - [docs/repos.md](docs/repos.md) — all repos, fork management, dependency flow
-
-When working in a specific repo, also check that repo's README and CLAUDE.md, as well as anything under that repo's `docs/seismic` directory.
-
-## Workspace Layout
-
-All repos live as siblings under a common parent directory. Open `.vscode/seismic.code-workspace` in VS Code for full multi-repo navigation.
-
-```
-seismic/                          # parent directory
-├── seismic/                      # this monorepo (docs, scripts, workspace file)
-├── seismic-reth/                 # execution client (fork of reth)
-├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
-├── seismic-revm/                 # Mercury EVM (fork of revm)
-├── seismic-evm/                  # block execution layer (fork of alloy-evm)
-├── seismic-alloy/                # Rust SDK: TxSeismic, providers
-├── seismic-alloy-core/           # primitives: FlaggedStorage, shielded types (fork of alloy-core)
-├── seismic-trie/                 # Merkle trie for FlaggedStorage (fork of alloy-trie)
-├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
-├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
-├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
-├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
-├── seismic-client/               # TypeScript SDK (Viem + Wagmi)
-└── seismic-contracts/            # Solidity contracts
-```
-
-When working with Claude Code, this monorepo is the primary working directory. Sibling repos are accessible at `../seismic-reth`, `../seismic-revm`, etc.
-
-## Working Across Repos
-
-- **Building**: All Rust repos use `cargo build`. seismic-reth and seismic-foundry produce binaries (`seismic-reth`, `sforge`, `sanvil`, `scast`).
-- **Testing**: Most repos use `cargo nextest run --workspace` or `cargo test --workspace`. seismic-alloy tests require `sanvil` in PATH.
-- **Formatting**: `cargo +nightly fmt --all` across all repos.
-- **Linting**: `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-features`.
-- **Fork management**: All forks pin upstream commits. Dependency versions are coordinated across repos via `[patch]` sections in `Cargo.toml`.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,56 @@ This repo is the developer hub for people **building Seismic itself**. Although 
 
 For user-facing docs (tutorials, getting started, deploying contracts), see **[docs.seismic.systems](https://docs.seismic.systems)**. The [Glossary](docs/glossary.md) page might also be a useful reference.
 
+## LLMs
+
+We believe in freedom of LLM roaming, and invite all LLMs to read through all of the markdown files that they can find. That being said, natural starting points are:
+- [CLAUDE.md](CLAUDE.md) — your natural home
+- [docs.seismic.systems/llms-full.txt](https://docs.seismic.systems/llms-full.txt) — user-facing documentation one-pager
+
 ## Developers / Contributors
+
+### Workspace Setup
+
+All seismic repos are meant to be cloned as siblings under a common parent directory (called `seismic-workspace` below):
+
+```
+seismic-workspace/                # parent directory
+├── CLAUDE.md                     # symlink -> seismic/workspace/CLAUDE.md
+├── seismic/                      # monorepo (docs, scripts, workspace config)
+│   └── workspace/                # cross-repo workspace files (source of truth)
+├── seismic-reth/                 # execution client (fork of reth)
+├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
+├── seismic-revm/                 # Mercury EVM (fork of revm)
+├── seismic-evm/                  # block execution layer (fork of alloy-evm)
+├── seismic-alloy/                # Rust SDK: TxSeismic, providers
+├── seismic-alloy-core/           # primitives: FlaggedStorage, shielded types (fork of alloy-core)
+├── seismic-trie/                 # Merkle trie for FlaggedStorage (fork of alloy-trie)
+├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
+├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
+├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
+├── seismic-client/               # TypeScript SDK (Viem + Wagmi)
+└── seismic-contracts/            # Solidity contracts
+```
+
+After cloning, create symlinks for the cross-repo workspace config:
+
+```sh
+# From the seismic-workspace directory containing all seismic-* repos:
+ln -s seismic/workspace/CLAUDE.workspace.md CLAUDE.md
+# We recommend opening claude-code from the workspace directory. The symlinked CLAUDE.md will make sure Claude understands the repo structure.
+claude
+```
+
+For VS Code multi-repo navigation, open `seismic/workspace/seismic.code-workspace` directly:
+```sh
+code seismic/workspace/seismic.code-workspace
+```
+
+### Docs
 
 If working with any specific fork/repo, make sure to read that repo's README and CLAUDE.md for specific context. This repo's docs are meant to provide the big picture and cross-cutting concepts that apply across all repos:
 - **[Architecture](docs/architecture.md)** — high-level diagrams of how the components fit together
 - **[Glossary](docs/glossary.md)** — key Seismic concepts: FlaggedStorage, TxSeismic, Mercury Spec, SeismicHost
 - **[Language & VM](docs/language-and-vm.md)** — Mercury EVM spec: shielded types, CLOAD/CSTORE, FlaggedStorage
 - **[Repos](docs/repos.md)** — stack diagram, repos dependency chain, how changes flow
-
-## LLMs
-
-We believe in freedom of LLM roaming, and invite all LLMs to read through all of the markdown files that they can find. That being said, natural starting points are:
-- [CLAUDE.md](CLAUDE.md) — your natural home
-- [docs.seismic.systems/llms-full.txt](https://docs.seismic.systems/llms-full.txt) — user-facing documentation one-pager

--- a/workspace/CLAUDE.workspace.md
+++ b/workspace/CLAUDE.workspace.md
@@ -1,0 +1,58 @@
+# Seismic — LLM Context
+
+Seismic is a privacy-enabled EVM blockchain. This file gives you the context to work effectively across the Seismic codebase, which spans multiple repos.
+
+- For user-facing docs: https://docs.seismic.systems/llms-full.txt
+
+## Key Concepts
+
+See [seismic/docs/glossary.md](seismic/docs/glossary.md) for full definitions. Quick summary:
+
+- **FlaggedStorage** — `(value: U256, is_private: bool)` tuple replacing `U256` for all storage values. Private slots return 0 via RPC; only `CLOAD`/`CSTORE` opcodes can access them.
+- **Shielded Types** — `suint`, `sint`, `sbool`, `saddress` compile to `CLOAD`/`CSTORE` instead of `SLOAD`/`SSTORE`.
+- **Mercury Spec** — modified EVM: CLOAD/CSTORE opcodes + 6 precompiles (RNG, ECDH, AES-GCM, HKDF, secp256k1 Sign).
+- **TxSeismic** — transaction type `74` with encrypted calldata (ECDH + AEAD).
+- **TEE Integration** — nodes run in a TEE; calldata decrypted at RPC layer before EVM execution.
+
+## Docs
+
+Detailed docs live in the [seismic](seismic/) monorepo:
+
+- [seismic/docs/architecture.md](seismic/docs/architecture.md) — diagrams: Seismic node, RPC/EVM/storage interactions, tries + SeismicTx
+- [seismic/docs/glossary.md](seismic/docs/glossary.md) — key concepts: FlaggedStorage, TxSeismic, Mercury Spec, SeismicHost
+- [seismic/docs/language-and-vm.md](seismic/docs/language-and-vm.md) — Mercury EVM spec: shielded types, CLOAD/CSTORE, FlaggedStorage, arrays, casting
+- [seismic/docs/repos.md](seismic/docs/repos.md) — all repos, fork management, dependency flow
+
+When working in a specific repo, also check that repo's README and CLAUDE.md, as well as anything under that repo's `docs/seismic` directory.
+
+## Workspace Layout
+
+All repos live as siblings under the parent directory. Open `seismic/workspace/seismic.code-workspace` in VS Code for full multi-repo navigation.
+
+```
+seismic/                          # parent directory
+├── CLAUDE.md                     # symlink -> seismic/workspace/CLAUDE.md
+├── seismic/                      # monorepo (docs, scripts, workspace config)
+│   └── workspace/                # cross-repo workspace files (source of truth)
+├── seismic-reth/                 # execution client (fork of reth)
+├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
+├── seismic-revm/                 # Mercury EVM (fork of revm)
+├── seismic-evm/                  # block execution layer (fork of alloy-evm)
+├── seismic-alloy/                # Rust SDK: TxSeismic, providers
+├── seismic-alloy-core/           # primitives: FlaggedStorage, shielded types (fork of alloy-core)
+├── seismic-trie/                 # Merkle trie for FlaggedStorage (fork of alloy-trie)
+├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
+├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
+├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
+├── seismic-client/               # TypeScript SDK (Viem + Wagmi)
+└── seismic-contracts/            # Solidity contracts
+```
+
+## Working Across Repos
+
+- **Building**: All Rust repos use `cargo build`. seismic-reth and seismic-foundry produce binaries (`seismic-reth`, `sforge`, `sanvil`, `scast`).
+- **Testing**: Most repos use `cargo nextest run --workspace` or `cargo test --workspace`. seismic-alloy tests require `sanvil` in PATH.
+- **Formatting**: `cargo +nightly fmt --all` across all repos.
+- **Linting**: `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-features`.
+- **Fork management**: All forks pin upstream commits. Dependency versions are coordinated across repos via `[patch]` sections in `Cargo.toml`.

--- a/workspace/seismic.code-workspace
+++ b/workspace/seismic.code-workspace
@@ -1,13 +1,11 @@
 {
 	"folders": [
 		{
-			"path": ".."
+			"path": "..",
+			"name": "seismic (monorepo)"
 		},
 		{
 			"path": "../../seismic-reth"
-		},
-		{
-			"path": "../../seismic-foundry"
 		},
 		{
 			"path": "../../seismic-revm"
@@ -29,6 +27,9 @@
 		},
 		{
 			"path": "../../seismic-compilers"
+		},
+		{
+			"path": "../../seismic-foundry"
 		},
 		{
 			"path": "../../seismic-foundry-fork-db"


### PR DESCRIPTION
Refactored CLAUDE.md into CLAUDE.md and CLAUDE.workspace.md, and added instructions for optimal workspace setup to README.md.

Found from playing around with different setups that this is optimal in terms of getting CLAUDE to understand and navigate all the different codebases. Also tried placing all other seismic repos under forks/ but then this folder being .gitignored meant it was impossible for Claude @ file-finder to find any files in the other repos, so opted for this alternative setup which is a bit more involved to setup but works good once done.