### PR TITLE
feat(clients): add Mercury EVM precompile helpers for seismic-web3

### DIFF
--- a/clients/py/README.md
+++ b/clients/py/README.md
@@ -152,6 +152,42 @@ from seismic_web3.contract.abi import encode_shielded_calldata
 data = encode_shielded_calldata(abi, "setNumber", [42])
 ```
 
+## Precompiles
+
+Call Mercury EVM precompiles directly via `eth_call`. No encryption state needed — just a `Web3` instance connected to a Seismic node.
+
+```python
+from seismic_web3.precompiles import rng, ecdh, aes_gcm_encrypt, aes_gcm_decrypt, hkdf, secp256k1_sign
+from seismic_web3 import Bytes32, PrivateKey, CompressedPublicKey
+
+# On-chain random number generation (0x64)
+random_val = rng(w3, num_bytes=32)
+
+# On-chain ECDH key exchange (0x65)
+shared_secret = ecdh(w3, sk=my_private_key, pk=their_public_key)
+
+# On-chain AES-GCM encrypt/decrypt (0x66 / 0x67)
+ciphertext = aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"secret")
+plaintext = aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ciphertext))
+
+# On-chain HKDF key derivation (0x68)
+derived_key = hkdf(w3, b"input key material")
+
+# On-chain secp256k1 signing (0x69)
+signature = secp256k1_sign(w3, sk=my_private_key, message="hello")
+```
+
+All functions have async variants (`async_rng`, `async_ecdh`, etc.).
+
+| Precompile | Address | Function | Returns |
+|---|---|---|---|
+| RNG | `0x64` | `rng(w3, num_bytes=, pers=)` | `int` |
+| ECDH | `0x65` | `ecdh(w3, sk=, pk=)` | `Bytes32` |
+| AES Encrypt | `0x66` | `aes_gcm_encrypt(w3, aes_key=, nonce=, plaintext=)` | `HexBytes` |
+| AES Decrypt | `0x67` | `aes_gcm_decrypt(w3, aes_key=, nonce=, ciphertext=)` | `HexBytes` |
+| HKDF | `0x68` | `hkdf(w3, ikm)` | `Bytes32` |
+| secp256k1 Sign | `0x69` | `secp256k1_sign(w3, sk=, message=)` | `HexBytes` |
+
 ## Security Parameters
 
 Override per-transaction security defaults with `SeismicSecurityParams`:
@@ -271,6 +307,13 @@ clients/py/
 │       │   ├── ecdh.py              # ECDH key agreement
 │       │   ├── nonce.py             # Nonce generation
 │       │   └── secp.py              # secp256k1 utilities
+│       ├── precompiles/
+│       │   ├── _base.py             # Precompile framework (call, gas helpers)
+│       │   ├── rng.py               # RNG precompile (0x64)
+│       │   ├── ecdh.py              # ECDH precompile (0x65)
+│       │   ├── aes.py               # AES encrypt/decrypt (0x66, 0x67)
+│       │   ├── hkdf.py              # HKDF precompile (0x68)
+│       │   └── secp256k1.py         # secp256k1 sign precompile (0x69)
 │       └── transaction/
 │           ├── aead.py              # AAD construction
 │           ├── metadata.py          # Transaction metadata
@@ -288,6 +331,7 @@ clients/py/
     ├── test_send.py
     ├── test_serialize.py
     ├── test_transaction_types.py
+    ├── test_precompiles.py
     ├── test_types.py
     └── integration/
         ├── conftest.py
@@ -295,6 +339,7 @@ clients/py/
         ├── artifacts/                # Compiled contract JSON
         ├── test_client_factory.py
         ├── test_namespace.py
+        ├── test_precompiles.py
         ├── test_seismic_counter.py
         └── test_transparent_counter.py
 ```

--- a/clients/py/TODO.md
+++ b/clients/py/TODO.md
@@ -2,19 +2,9 @@
 
 Deferred features not included in the initial SDK implementation.
 
-## Precompiles
+## ~~Precompiles~~ (Done)
 
-Mercury EVM precompile wrappers (all on-chain, require a running node):
-
-- **RNG** (`0x64`) — on-chain random number generation
-- **ECDH** (`0x65`) — on-chain elliptic-curve Diffie-Hellman
-- **AES-GCM Encrypt** (`0x66`) — on-chain AES-256-GCM encryption
-- **AES-GCM Decrypt** (`0x67`) — on-chain AES-256-GCM decryption
-- **HKDF** (`0x68`) — on-chain HKDF-SHA256 key derivation
-- **secp256k1 Sign** (`0x69`) — on-chain ECDSA signing
-
-All precompile addresses, gas costs, and parameter encoding are documented in
-`seismic-client/packages/seismic-viem/src/precompiles/`.
+Implemented in `seismic_web3.precompiles` — see `src/seismic_web3/precompiles/`.
 
 ## EIP-712 Typed Data Signing
 

--- a/clients/py/src/seismic_web3/precompiles/__init__.py
+++ b/clients/py/src/seismic_web3/precompiles/__init__.py
@@ -1,0 +1,35 @@
+"""Mercury EVM precompile helpers.
+
+Standalone sync and async wrappers for the 6 on-chain precompiles
+at addresses ``0x64`` through ``0x69``.  Each function takes a
+``Web3`` or ``AsyncWeb3`` instance and returns the decoded result.
+
+No encryption state or private key is required -- these use plain
+``eth_call``.
+"""
+
+from seismic_web3.precompiles.aes import (
+    aes_gcm_decrypt,
+    aes_gcm_encrypt,
+    async_aes_gcm_decrypt,
+    async_aes_gcm_encrypt,
+)
+from seismic_web3.precompiles.ecdh import async_ecdh, ecdh
+from seismic_web3.precompiles.hkdf import async_hkdf, hkdf
+from seismic_web3.precompiles.rng import async_rng, rng
+from seismic_web3.precompiles.secp256k1 import async_secp256k1_sign, secp256k1_sign
+
+__all__ = [
+    "aes_gcm_decrypt",
+    "aes_gcm_encrypt",
+    "async_aes_gcm_decrypt",
+    "async_aes_gcm_encrypt",
+    "async_ecdh",
+    "async_hkdf",
+    "async_rng",
+    "async_secp256k1_sign",
+    "ecdh",
+    "hkdf",
+    "rng",
+    "secp256k1_sign",
+]

--- a/clients/py/src/seismic_web3/precompiles/_base.py
+++ b/clients/py/src/seismic_web3/precompiles/_base.py
@@ -1,0 +1,143 @@
+"""Base precompile framework.
+
+Defines the :class:`Precompile` descriptor and the shared
+:func:`call_precompile` / :func:`async_call_precompile` callers
+that handle gas estimation, encoding, RPC call, and decoding.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+from hexbytes import HexBytes
+from web3.types import RPCEndpoint, RPCResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from web3 import AsyncWeb3, Web3
+
+P = TypeVar("P")
+R = TypeVar("R")
+
+#: Every ``eth_call`` costs at least this much gas.
+BASE_TX_GAS_COST = 21_000
+
+
+def calldata_gas_cost(data: bytes) -> int:
+    """EVM calldata gas: 4 per zero byte + 16 per non-zero byte.
+
+    Equivalent to the viem formula:
+    ``4 * len(data) + 12 * nonZeroCount``.
+    """
+    non_zero = sum(1 for b in data if b != 0)
+    return 4 * len(data) + 12 * non_zero
+
+
+def calc_linear_gas_cost(
+    *,
+    bus: int,
+    length: int,
+    base: int,
+    word: int,
+) -> int:
+    """Linear gas cost: ``base + ceil(length / bus) * word``."""
+    words = math.ceil(length / bus) if length > 0 else 0
+    return words * word + base
+
+
+def calc_linear_gas_cost_u32(
+    *,
+    length: int,
+    base: int,
+    word: int,
+) -> int:
+    """Linear gas cost with ``bus=32``."""
+    return calc_linear_gas_cost(bus=32, length=length, base=base, word=word)
+
+
+@dataclass(frozen=True)
+class Precompile(Generic[P, R]):
+    """Descriptor for a Mercury EVM precompile.
+
+    Attributes:
+        address: Hex address (e.g. ``"0x…0064"``).
+        gas_cost: Compute execution gas for the given args.
+        encode_params: Encode Python args to raw calldata bytes.
+        decode_result: Decode raw result bytes to Python type.
+    """
+
+    address: str
+    gas_cost: Callable[[P], int]
+    encode_params: Callable[[P], bytes]
+    decode_result: Callable[[bytes], R]
+
+
+def _build_call_params(precompile: Precompile[P, R], args: P) -> dict[str, str]:
+    """Encode args into an ``eth_call`` transaction dict.
+
+    Gas is omitted so the node uses its default (block gas limit).
+    For cost estimation, use :func:`calldata_gas_cost` and
+    :attr:`Precompile.gas_cost` directly.
+    """
+    data = precompile.encode_params(args)
+    return {
+        "to": precompile.address,
+        "data": HexBytes(data).to_0x_hex(),
+    }
+
+
+def _extract_result(response: RPCResponse) -> bytes:
+    """Extract result bytes from an RPC response, raising on errors."""
+    if "error" in response:
+        err = response["error"]
+        msg = err.get("message", err) if isinstance(err, dict) else err
+        raise RuntimeError(f"Precompile call failed: {msg}")
+    raw: str = str(response.get("result", "0x"))
+    if not raw or raw == "0x":
+        raise ValueError("No data returned from precompile")
+    return bytes(HexBytes(raw))
+
+
+def call_precompile(
+    w3: Web3,
+    precompile: Precompile[P, R],
+    args: P,
+) -> R:
+    """Call a precompile via ``eth_call`` (sync).
+
+    Uses ``w3.provider.make_request`` directly to avoid web3.py
+    injecting a ``from`` address (Seismic nodes reject unsigned
+    calls with a non-zero sender).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        precompile: Precompile descriptor.
+        args: Precompile-specific input parameters.
+
+    Returns:
+        Decoded result.
+
+    Raises:
+        ValueError: If the precompile returns empty data.
+        RuntimeError: If the RPC returns an error.
+    """
+    tx = _build_call_params(precompile, args)
+    response = w3.provider.make_request(RPCEndpoint("eth_call"), [tx, "latest"])
+    return precompile.decode_result(_extract_result(response))
+
+
+async def async_call_precompile(
+    w3: AsyncWeb3,
+    precompile: Precompile[P, R],
+    args: P,
+) -> R:
+    """Call a precompile via ``eth_call`` (async).
+
+    Same as :func:`call_precompile` but for ``AsyncWeb3`` instances.
+    """
+    tx = _build_call_params(precompile, args)
+    response = await w3.provider.make_request(RPCEndpoint("eth_call"), [tx, "latest"])
+    return precompile.decode_result(_extract_result(response))

--- a/clients/py/src/seismic_web3/precompiles/aes.py
+++ b/clients/py/src/seismic_web3/precompiles/aes.py
@@ -1,0 +1,211 @@
+"""AES-GCM encrypt/decrypt precompiles (addresses ``0x66`` and ``0x67``).
+
+On-chain AES-256-GCM encryption and decryption.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from hexbytes import HexBytes
+
+from seismic_web3.precompiles._base import (
+    Precompile,
+    async_call_precompile,
+    calc_linear_gas_cost,
+    call_precompile,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3, Web3
+
+    from seismic_web3._types import Bytes32, EncryptionNonce
+
+AES_GCM_ENCRYPT_ADDRESS = "0x0000000000000000000000000000000000000066"
+AES_GCM_DECRYPT_ADDRESS = "0x0000000000000000000000000000000000000067"
+
+_AES_GCM_BASE_GAS = 1000
+_AES_GCM_PER_BLOCK = 30  # per 16-byte block
+
+
+def _nonce_to_bytes(nonce: int | EncryptionNonce) -> bytes:
+    """Convert a nonce to exactly 12 bytes."""
+    if isinstance(nonce, int):
+        return nonce.to_bytes(12, "big")
+    return bytes(nonce)
+
+
+# ---------------------------------------------------------------------------
+# Encryption
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AesGcmEncryptParams:
+    """Parameters for on-chain AES-GCM encryption.
+
+    Attributes:
+        aes_key: 32-byte AES-256 key.
+        nonce: 12-byte nonce (int or :class:`EncryptionNonce`).
+        plaintext: Data to encrypt.
+    """
+
+    aes_key: Bytes32
+    nonce: int | EncryptionNonce
+    plaintext: bytes
+
+
+def _encrypt_gas(params: AesGcmEncryptParams) -> int:
+    return calc_linear_gas_cost(
+        bus=16,
+        length=len(params.plaintext),
+        base=_AES_GCM_BASE_GAS,
+        word=_AES_GCM_PER_BLOCK,
+    )
+
+
+def _encrypt_encode(params: AesGcmEncryptParams) -> bytes:
+    return bytes(params.aes_key) + _nonce_to_bytes(params.nonce) + params.plaintext
+
+
+def _encrypt_decode(result: bytes) -> HexBytes:
+    return HexBytes(result)
+
+
+aes_gcm_encrypt_precompile: Precompile[AesGcmEncryptParams, HexBytes] = Precompile(
+    address=AES_GCM_ENCRYPT_ADDRESS,
+    gas_cost=_encrypt_gas,
+    encode_params=_encrypt_encode,
+    decode_result=_encrypt_decode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Decryption
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AesGcmDecryptParams:
+    """Parameters for on-chain AES-GCM decryption.
+
+    Attributes:
+        aes_key: 32-byte AES-256 key.
+        nonce: 12-byte nonce (int or :class:`EncryptionNonce`).
+        ciphertext: Data to decrypt (includes 16-byte auth tag).
+    """
+
+    aes_key: Bytes32
+    nonce: int | EncryptionNonce
+    ciphertext: bytes
+
+
+def _decrypt_gas(params: AesGcmDecryptParams) -> int:
+    return calc_linear_gas_cost(
+        bus=16,
+        length=len(params.ciphertext),
+        base=_AES_GCM_BASE_GAS,
+        word=_AES_GCM_PER_BLOCK,
+    )
+
+
+def _decrypt_encode(params: AesGcmDecryptParams) -> bytes:
+    return bytes(params.aes_key) + _nonce_to_bytes(params.nonce) + params.ciphertext
+
+
+def _decrypt_decode(result: bytes) -> HexBytes:
+    return HexBytes(result)
+
+
+aes_gcm_decrypt_precompile: Precompile[AesGcmDecryptParams, HexBytes] = Precompile(
+    address=AES_GCM_DECRYPT_ADDRESS,
+    gas_cost=_decrypt_gas,
+    encode_params=_decrypt_encode,
+    decode_result=_decrypt_decode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def aes_gcm_encrypt(
+    w3: Web3,
+    *,
+    aes_key: Bytes32,
+    nonce: int | EncryptionNonce,
+    plaintext: bytes,
+) -> HexBytes:
+    """On-chain AES-GCM encryption (sync).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        aes_key: 32-byte AES-256 key.
+        nonce: 12-byte nonce (int or :class:`EncryptionNonce`).
+        plaintext: Data to encrypt.
+
+    Returns:
+        Ciphertext bytes (includes 16-byte auth tag).
+    """
+    return call_precompile(
+        w3,
+        aes_gcm_encrypt_precompile,
+        AesGcmEncryptParams(aes_key, nonce, plaintext),
+    )
+
+
+def aes_gcm_decrypt(
+    w3: Web3,
+    *,
+    aes_key: Bytes32,
+    nonce: int | EncryptionNonce,
+    ciphertext: bytes,
+) -> HexBytes:
+    """On-chain AES-GCM decryption (sync).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        aes_key: 32-byte AES-256 key.
+        nonce: 12-byte nonce (int or :class:`EncryptionNonce`).
+        ciphertext: Data to decrypt (includes 16-byte auth tag).
+
+    Returns:
+        Decrypted plaintext bytes.
+    """
+    return call_precompile(
+        w3,
+        aes_gcm_decrypt_precompile,
+        AesGcmDecryptParams(aes_key, nonce, ciphertext),
+    )
+
+
+async def async_aes_gcm_encrypt(
+    w3: AsyncWeb3,
+    *,
+    aes_key: Bytes32,
+    nonce: int | EncryptionNonce,
+    plaintext: bytes,
+) -> HexBytes:
+    """On-chain AES-GCM encryption (async)."""
+    return await async_call_precompile(
+        w3,
+        aes_gcm_encrypt_precompile,
+        AesGcmEncryptParams(aes_key, nonce, plaintext),
+    )
+
+
+async def async_aes_gcm_decrypt(
+    w3: AsyncWeb3,
+    *,
+    aes_key: Bytes32,
+    nonce: int | EncryptionNonce,
+    ciphertext: bytes,
+) -> HexBytes:
+    """On-chain AES-GCM decryption (async)."""
+    return await async_call_precompile(
+        w3,
+        aes_gcm_decrypt_precompile,
+        AesGcmDecryptParams(aes_key, nonce, ciphertext),
+    )

--- a/clients/py/src/seismic_web3/precompiles/ecdh.py
+++ b/clients/py/src/seismic_web3/precompiles/ecdh.py
@@ -1,0 +1,84 @@
+"""ECDH precompile (address ``0x65``).
+
+Performs on-chain elliptic-curve Diffie-Hellman key exchange.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from seismic_web3._types import Bytes32, CompressedPublicKey, PrivateKey
+from seismic_web3.precompiles._base import (
+    Precompile,
+    async_call_precompile,
+    call_precompile,
+)
+from seismic_web3.precompiles.hkdf import HKDF_EXPAND_COST_GAS, SHARED_SECRET_GAS
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3, Web3
+
+ECDH_ADDRESS = "0x0000000000000000000000000000000000000065"
+
+
+@dataclass(frozen=True)
+class EcdhParams:
+    """Parameters for on-chain ECDH.
+
+    Attributes:
+        sk: 32-byte secret key.
+        pk: 33-byte compressed public key.
+    """
+
+    sk: PrivateKey
+    pk: CompressedPublicKey
+
+
+def _ecdh_gas_cost(_params: EcdhParams) -> int:
+    return SHARED_SECRET_GAS + HKDF_EXPAND_COST_GAS  # 3120
+
+
+def _ecdh_encode(params: EcdhParams) -> bytes:
+    return bytes(params.sk) + bytes(params.pk)
+
+
+def _ecdh_decode(result: bytes) -> Bytes32:
+    return Bytes32(result[:32])
+
+
+ecdh_precompile: Precompile[EcdhParams, Bytes32] = Precompile(
+    address=ECDH_ADDRESS,
+    gas_cost=_ecdh_gas_cost,
+    encode_params=_ecdh_encode,
+    decode_result=_ecdh_decode,
+)
+
+
+def ecdh(
+    w3: Web3,
+    *,
+    sk: PrivateKey,
+    pk: CompressedPublicKey,
+) -> Bytes32:
+    """On-chain ECDH key exchange (sync).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        sk: 32-byte secret key.
+        pk: 33-byte compressed public key.
+
+    Returns:
+        32-byte shared secret.
+    """
+    return call_precompile(w3, ecdh_precompile, EcdhParams(sk, pk))
+
+
+async def async_ecdh(
+    w3: AsyncWeb3,
+    *,
+    sk: PrivateKey,
+    pk: CompressedPublicKey,
+) -> Bytes32:
+    """On-chain ECDH key exchange (async)."""
+    return await async_call_precompile(w3, ecdh_precompile, EcdhParams(sk, pk))

--- a/clients/py/src/seismic_web3/precompiles/hkdf.py
+++ b/clients/py/src/seismic_web3/precompiles/hkdf.py
@@ -1,0 +1,71 @@
+"""HKDF precompile (address ``0x68``).
+
+On-chain HKDF-SHA256 key derivation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from seismic_web3._types import Bytes32
+from seismic_web3.precompiles._base import (
+    Precompile,
+    async_call_precompile,
+    calc_linear_gas_cost,
+    call_precompile,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3, Web3
+
+HKDF_ADDRESS = "0x0000000000000000000000000000000000000068"
+
+#: Gas constants shared with :mod:`seismic_web3.precompiles.ecdh`.
+SHA256_BASE_GAS = 60
+SHA256_PER_WORD = 12
+HKDF_EXPAND_COST_GAS = 2 * SHA256_BASE_GAS  # 120
+SHARED_SECRET_GAS = 3000
+
+
+def _hkdf_gas_cost(ikm: bytes) -> int:
+    linear = calc_linear_gas_cost(
+        bus=32,
+        length=len(ikm),
+        base=SHARED_SECRET_GAS,
+        word=SHA256_PER_WORD,
+    )
+    return 2 * linear + HKDF_EXPAND_COST_GAS
+
+
+def _hkdf_encode(ikm: bytes) -> bytes:
+    return bytes(ikm)
+
+
+def _hkdf_decode(result: bytes) -> Bytes32:
+    return Bytes32(result[:32])
+
+
+hkdf_precompile: Precompile[bytes, Bytes32] = Precompile(
+    address=HKDF_ADDRESS,
+    gas_cost=_hkdf_gas_cost,
+    encode_params=_hkdf_encode,
+    decode_result=_hkdf_decode,
+)
+
+
+def hkdf(w3: Web3, ikm: bytes) -> Bytes32:
+    """On-chain HKDF-SHA256 key derivation (sync).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        ikm: Input key material (arbitrary bytes).
+
+    Returns:
+        32-byte derived key.
+    """
+    return call_precompile(w3, hkdf_precompile, ikm)
+
+
+async def async_hkdf(w3: AsyncWeb3, ikm: bytes) -> Bytes32:
+    """On-chain HKDF-SHA256 key derivation (async)."""
+    return await async_call_precompile(w3, hkdf_precompile, ikm)

--- a/clients/py/src/seismic_web3/precompiles/rng.py
+++ b/clients/py/src/seismic_web3/precompiles/rng.py
@@ -1,0 +1,97 @@
+"""RNG precompile (address ``0x64``).
+
+Generates on-chain random bytes, returned as a Python ``int``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from seismic_web3.precompiles._base import (
+    Precompile,
+    async_call_precompile,
+    calc_linear_gas_cost_u32,
+    call_precompile,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3, Web3
+
+RNG_ADDRESS = "0x0000000000000000000000000000000000000064"
+_RNG_INIT_BASE_GAS = 3500
+_STROBE_128_WORD_GAS = 5
+
+
+@dataclass(frozen=True)
+class RngParams:
+    """Parameters for on-chain RNG.
+
+    Attributes:
+        num_bytes: Number of random bytes to generate (1--32).
+        pers: Optional personalization bytes to seed the RNG.
+    """
+
+    num_bytes: int
+    pers: bytes = b""
+
+
+def _rng_gas_cost(params: RngParams) -> int:
+    init_cost = calc_linear_gas_cost_u32(
+        length=len(params.pers),
+        base=_RNG_INIT_BASE_GAS,
+        word=_STROBE_128_WORD_GAS,
+    )
+    fill_cost = calc_linear_gas_cost_u32(
+        length=params.num_bytes,
+        base=0,
+        word=_STROBE_128_WORD_GAS,
+    )
+    return init_cost + fill_cost
+
+
+def _rng_encode(params: RngParams) -> bytes:
+    if not 1 <= params.num_bytes <= 32:
+        raise ValueError(f"num_bytes must be 1-32, got {params.num_bytes}")
+    encoded = params.num_bytes.to_bytes(4, "big")
+    if params.pers:
+        encoded += params.pers
+    return encoded
+
+
+def _rng_decode(result: bytes) -> int:
+    # Pad to 32 bytes then interpret as uint256.
+    padded = result.rjust(32, b"\x00")
+    return int.from_bytes(padded, "big")
+
+
+rng_precompile: Precompile[RngParams, int] = Precompile(
+    address=RNG_ADDRESS,
+    gas_cost=_rng_gas_cost,
+    encode_params=_rng_encode,
+    decode_result=_rng_decode,
+)
+
+
+def rng(w3: Web3, *, num_bytes: int, pers: bytes = b"") -> int:
+    """Generate random bytes on-chain (sync).
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        num_bytes: Number of random bytes (1--32).
+        pers: Optional personalization string.
+
+    Returns:
+        Random value as a Python integer.
+    """
+    return call_precompile(w3, rng_precompile, RngParams(num_bytes, pers))
+
+
+async def async_rng(
+    w3: AsyncWeb3,
+    *,
+    num_bytes: int,
+    pers: bytes = b"",
+) -> int:
+    """Generate random bytes on-chain (async)."""
+    return await async_call_precompile(w3, rng_precompile, RngParams(num_bytes, pers))

--- a/clients/py/src/seismic_web3/precompiles/secp256k1.py
+++ b/clients/py/src/seismic_web3/precompiles/secp256k1.py
@@ -1,0 +1,109 @@
+"""secp256k1 signing precompile (address ``0x69``).
+
+On-chain ECDSA signing using the secp256k1 curve.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from eth_abi import encode as abi_encode
+from eth_hash.auto import keccak
+from hexbytes import HexBytes
+
+from seismic_web3._types import Bytes32, PrivateKey
+from seismic_web3.precompiles._base import (
+    Precompile,
+    async_call_precompile,
+    call_precompile,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3, Web3
+
+SECP256K1_SIG_ADDRESS = "0x0000000000000000000000000000000000000069"
+_SECP256K1_SIG_BASE_GAS = 3000
+
+
+@dataclass(frozen=True)
+class Secp256k1SigParams:
+    """Parameters for on-chain secp256k1 signing.
+
+    Attributes:
+        sk: 32-byte private key.
+        message_hash: 32-byte message hash to sign.
+    """
+
+    sk: PrivateKey
+    message_hash: Bytes32
+
+
+def _sig_gas_cost(_params: Secp256k1SigParams) -> int:
+    return _SECP256K1_SIG_BASE_GAS
+
+
+def _sig_encode(params: Secp256k1SigParams) -> bytes:
+    return abi_encode(
+        ["bytes32", "bytes32"],
+        [bytes(params.sk), bytes(params.message_hash)],
+    )
+
+
+def _sig_decode(result: bytes) -> HexBytes:
+    return HexBytes(result)
+
+
+secp256k1_sig_precompile: Precompile[Secp256k1SigParams, HexBytes] = Precompile(
+    address=SECP256K1_SIG_ADDRESS,
+    gas_cost=_sig_gas_cost,
+    encode_params=_sig_encode,
+    decode_result=_sig_decode,
+)
+
+
+def _hash_message(message: str) -> Bytes32:
+    """Ethereum personal_sign message hash (EIP-191).
+
+    Equivalent to viem's ``hashMessage()``.
+    """
+    prefix = f"\x19Ethereum Signed Message:\n{len(message)}".encode()
+    return Bytes32(keccak(prefix + message.encode()))
+
+
+def secp256k1_sign(
+    w3: Web3,
+    *,
+    sk: PrivateKey,
+    message: str,
+) -> HexBytes:
+    """Sign a message on-chain using secp256k1 (sync).
+
+    The message is hashed with the EIP-191 personal-sign prefix
+    before being passed to the precompile.
+
+    Args:
+        w3: Sync ``Web3`` instance connected to a Seismic node.
+        sk: 32-byte private key.
+        message: Message string to sign.
+
+    Returns:
+        Signature bytes.
+    """
+    msg_hash = _hash_message(message)
+    return call_precompile(
+        w3, secp256k1_sig_precompile, Secp256k1SigParams(sk, msg_hash)
+    )
+
+
+async def async_secp256k1_sign(
+    w3: AsyncWeb3,
+    *,
+    sk: PrivateKey,
+    message: str,
+) -> HexBytes:
+    """Sign a message on-chain using secp256k1 (async)."""
+    msg_hash = _hash_message(message)
+    return await async_call_precompile(
+        w3, secp256k1_sig_precompile, Secp256k1SigParams(sk, msg_hash)
+    )

--- a/clients/py/tests/integration/test_precompiles.py
+++ b/clients/py/tests/integration/test_precompiles.py
@@ -1,0 +1,173 @@
+"""Integration tests for Mercury EVM precompiles.
+
+These tests call the actual on-chain precompiles against a running
+sanvil or seismic-reth node.
+"""
+
+import pytest
+from web3 import AsyncWeb3, Web3
+
+from seismic_web3._types import Bytes32, PrivateKey
+from seismic_web3.crypto.secp import private_key_to_compressed_public_key
+from seismic_web3.precompiles import (
+    aes_gcm_decrypt,
+    aes_gcm_encrypt,
+    async_aes_gcm_decrypt,
+    async_aes_gcm_encrypt,
+    async_ecdh,
+    async_hkdf,
+    async_rng,
+    async_secp256k1_sign,
+    ecdh,
+    hkdf,
+    rng,
+    secp256k1_sign,
+)
+
+# Re-use the dev key from conftest
+_DEV_SK = PrivateKey(
+    bytes.fromhex("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+)
+
+
+# ---------------------------------------------------------------------------
+# RNG
+# ---------------------------------------------------------------------------
+
+
+class TestRng:
+    def test_returns_nonzero(self, w3: Web3):
+        result = rng(w3, num_bytes=32)
+        assert result > 0
+
+    def test_respects_num_bytes(self, w3: Web3):
+        result = rng(w3, num_bytes=1)
+        assert 0 <= result <= 0xFF
+
+    def test_with_personalization(self, w3: Web3):
+        result = rng(w3, num_bytes=16, pers=b"test-seed")
+        assert result >= 0
+
+    @pytest.mark.asyncio
+    async def test_async(self, async_w3: AsyncWeb3):
+        result = await async_rng(async_w3, num_bytes=32)
+        assert result > 0
+
+
+# ---------------------------------------------------------------------------
+# ECDH
+# ---------------------------------------------------------------------------
+
+
+class TestEcdh:
+    def test_returns_shared_secret(self, w3: Web3):
+        sk = PrivateKey(b"\x01" * 32)
+        other_sk = PrivateKey(b"\x02" * 32)
+        pk = private_key_to_compressed_public_key(other_sk)
+        result = ecdh(w3, sk=sk, pk=pk)
+        assert isinstance(result, Bytes32)
+        assert len(result) == 32
+
+    def test_matches_client_side(self, w3: Web3):
+        """On-chain ECDH should produce the same result as client-side."""
+        from seismic_web3.crypto.ecdh import generate_aes_key
+
+        sk = PrivateKey(b"\x01" * 32)
+        other_sk = PrivateKey(b"\x02" * 32)
+        pk = private_key_to_compressed_public_key(other_sk)
+
+        on_chain = ecdh(w3, sk=sk, pk=pk)
+        client_side = generate_aes_key(sk, pk)
+
+        # The on-chain ECDH precompile does ECDH + HKDF together,
+        # which matches the client-side generate_aes_key pipeline.
+        assert bytes(on_chain) == bytes(client_side)
+
+    @pytest.mark.asyncio
+    async def test_async(self, async_w3: AsyncWeb3):
+        sk = PrivateKey(b"\x01" * 32)
+        other_sk = PrivateKey(b"\x02" * 32)
+        pk = private_key_to_compressed_public_key(other_sk)
+        result = await async_ecdh(async_w3, sk=sk, pk=pk)
+        assert isinstance(result, Bytes32)
+
+
+# ---------------------------------------------------------------------------
+# AES-GCM
+# ---------------------------------------------------------------------------
+
+
+class TestAesGcm:
+    def test_encrypt_decrypt_roundtrip(self, w3: Web3):
+        key = Bytes32(b"\x00" * 32)
+        nonce = 1
+        plaintext = b"Hello, precompile!"
+        ct = aes_gcm_encrypt(w3, aes_key=key, nonce=nonce, plaintext=plaintext)
+        pt = aes_gcm_decrypt(w3, aes_key=key, nonce=nonce, ciphertext=bytes(ct))
+        assert bytes(pt) == plaintext
+
+    def test_different_keys_produce_different_ciphertext(self, w3: Web3):
+        nonce = 42
+        plaintext = b"secret"
+        ct1 = aes_gcm_encrypt(
+            w3, aes_key=Bytes32(b"\x00" * 32), nonce=nonce, plaintext=plaintext
+        )
+        ct2 = aes_gcm_encrypt(
+            w3, aes_key=Bytes32(b"\x01" * 32), nonce=nonce, plaintext=plaintext
+        )
+        assert ct1 != ct2
+
+    @pytest.mark.asyncio
+    async def test_async_roundtrip(self, async_w3: AsyncWeb3):
+        key = Bytes32(b"\x00" * 32)
+        nonce = 1
+        plaintext = b"async test"
+        ct = await async_aes_gcm_encrypt(
+            async_w3, aes_key=key, nonce=nonce, plaintext=plaintext
+        )
+        pt = await async_aes_gcm_decrypt(
+            async_w3, aes_key=key, nonce=nonce, ciphertext=bytes(ct)
+        )
+        assert bytes(pt) == plaintext
+
+
+# ---------------------------------------------------------------------------
+# HKDF
+# ---------------------------------------------------------------------------
+
+
+class TestHkdf:
+    def test_deterministic(self, w3: Web3):
+        ikm = b"input key material"
+        r1 = hkdf(w3, ikm)
+        r2 = hkdf(w3, ikm)
+        assert r1 == r2
+        assert isinstance(r1, Bytes32)
+        assert len(r1) == 32
+
+    def test_different_inputs_different_outputs(self, w3: Web3):
+        r1 = hkdf(w3, b"input-1")
+        r2 = hkdf(w3, b"input-2")
+        assert r1 != r2
+
+    @pytest.mark.asyncio
+    async def test_async(self, async_w3: AsyncWeb3):
+        result = await async_hkdf(async_w3, b"async key material")
+        assert isinstance(result, Bytes32)
+
+
+# ---------------------------------------------------------------------------
+# secp256k1 Sign
+# ---------------------------------------------------------------------------
+
+
+class TestSecp256k1Sign:
+    def test_returns_signature(self, w3: Web3):
+        sig = secp256k1_sign(w3, sk=_DEV_SK, message="hello world")
+        # Expect at least r(32) + s(32) = 64 bytes
+        assert len(sig) >= 64
+
+    @pytest.mark.asyncio
+    async def test_async(self, async_w3: AsyncWeb3):
+        sig = await async_secp256k1_sign(async_w3, sk=_DEV_SK, message="hello world")
+        assert len(sig) >= 64

--- a/clients/py/tests/test_precompiles.py
+++ b/clients/py/tests/test_precompiles.py
@@ -1,0 +1,313 @@
+"""Tests for precompile param encoding, result decoding, gas, and validation.
+
+These test the pure-computation parts of each precompile without
+needing a running Seismic node.
+"""
+
+import pytest
+
+from seismic_web3._types import (
+    Bytes32,
+    CompressedPublicKey,
+    EncryptionNonce,
+    PrivateKey,
+)
+from seismic_web3.precompiles._base import (
+    calc_linear_gas_cost,
+    calc_linear_gas_cost_u32,
+    calldata_gas_cost,
+)
+from seismic_web3.precompiles.aes import (
+    AesGcmDecryptParams,
+    AesGcmEncryptParams,
+    _decrypt_encode,
+    _decrypt_gas,
+    _encrypt_decode,
+    _encrypt_encode,
+    _encrypt_gas,
+    _nonce_to_bytes,
+)
+from seismic_web3.precompiles.ecdh import (
+    EcdhParams,
+    _ecdh_encode,
+    _ecdh_gas_cost,
+)
+from seismic_web3.precompiles.hkdf import _hkdf_decode, _hkdf_encode, _hkdf_gas_cost
+from seismic_web3.precompiles.rng import (
+    RngParams,
+    _rng_decode,
+    _rng_encode,
+    _rng_gas_cost,
+)
+from seismic_web3.precompiles.secp256k1 import (
+    Secp256k1SigParams,
+    _hash_message,
+    _sig_encode,
+    _sig_gas_cost,
+)
+
+# ---------------------------------------------------------------------------
+# Gas helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCalldataGasCost:
+    def test_all_zeros(self):
+        data = b"\x00" * 10
+        # 4 * 10 + 12 * 0 = 40
+        assert calldata_gas_cost(data) == 40
+
+    def test_all_nonzero(self):
+        data = b"\xff" * 10
+        # 4 * 10 + 12 * 10 = 160
+        assert calldata_gas_cost(data) == 160
+
+    def test_mixed(self):
+        data = b"\x00\xff\x00\xff"
+        # 4 * 4 + 12 * 2 = 40
+        assert calldata_gas_cost(data) == 40
+
+    def test_empty(self):
+        assert calldata_gas_cost(b"") == 0
+
+
+class TestCalcLinearGasCost:
+    def test_empty_input(self):
+        assert calc_linear_gas_cost(bus=32, length=0, base=100, word=10) == 100
+
+    def test_exact_boundary(self):
+        # 32 bytes = 1 word
+        assert calc_linear_gas_cost(bus=32, length=32, base=100, word=10) == 110
+
+    def test_partial_word(self):
+        # 33 bytes = ceil(33/32) = 2 words
+        assert calc_linear_gas_cost(bus=32, length=33, base=100, word=10) == 120
+
+    def test_u32_shortcut(self):
+        result = calc_linear_gas_cost_u32(length=64, base=100, word=10)
+        expected = calc_linear_gas_cost(bus=32, length=64, base=100, word=10)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# RNG
+# ---------------------------------------------------------------------------
+
+
+class TestRngEncoding:
+    def test_encode_num_bytes_only(self):
+        data = _rng_encode(RngParams(num_bytes=16))
+        assert data == (16).to_bytes(4, "big")
+        assert len(data) == 4
+
+    def test_encode_with_pers(self):
+        pers = b"seed"
+        data = _rng_encode(RngParams(num_bytes=32, pers=pers))
+        assert data[:4] == (32).to_bytes(4, "big")
+        assert data[4:] == pers
+        assert len(data) == 8
+
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError, match="num_bytes must be 1-32"):
+            _rng_encode(RngParams(num_bytes=0))
+
+    def test_rejects_over_32(self):
+        with pytest.raises(ValueError, match="num_bytes must be 1-32"):
+            _rng_encode(RngParams(num_bytes=33))
+
+    def test_decode_pads_and_returns_int(self):
+        # 32 bytes of 0xff = 2^256 - 1
+        result = b"\xff" * 32
+        assert _rng_decode(result) == (2**256) - 1
+
+    def test_decode_short_result(self):
+        # 1 byte -> should be padded
+        assert _rng_decode(b"\x0a") == 10
+
+
+class TestRngGasCost:
+    def test_minimal_no_pers(self):
+        params = RngParams(num_bytes=1)
+        # init = 3500 + ceil(0/32)*5 = 3500
+        # fill = 0 + ceil(1/32)*5 = 5
+        assert _rng_gas_cost(params) == 3505
+
+    def test_32_bytes_no_pers(self):
+        params = RngParams(num_bytes=32)
+        # init = 3500
+        # fill = ceil(32/32)*5 = 5
+        assert _rng_gas_cost(params) == 3505
+
+    def test_with_pers(self):
+        params = RngParams(num_bytes=16, pers=b"x" * 64)
+        # init = 3500 + ceil(64/32)*5 = 3510
+        # fill = ceil(16/32)*5 = 5
+        assert _rng_gas_cost(params) == 3515
+
+
+# ---------------------------------------------------------------------------
+# ECDH
+# ---------------------------------------------------------------------------
+
+# Test vectors reused from test_crypto.py
+_TEST_SK = PrivateKey(
+    "0xa30363336e1bb949185292a2a302de86e447d98f3a43d823c8c234d9e3e5ad77"
+)
+_TEST_PK = CompressedPublicKey(
+    "0x028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0"
+)
+
+
+class TestEcdhEncoding:
+    def test_encode_length(self):
+        data = _ecdh_encode(EcdhParams(sk=_TEST_SK, pk=_TEST_PK))
+        # 32 (sk) + 33 (pk) = 65
+        assert len(data) == 65
+
+    def test_encode_layout(self):
+        data = _ecdh_encode(EcdhParams(sk=_TEST_SK, pk=_TEST_PK))
+        assert data[:32] == bytes(_TEST_SK)
+        assert data[32:] == bytes(_TEST_PK)
+
+
+class TestEcdhGasCost:
+    def test_constant(self):
+        params = EcdhParams(sk=_TEST_SK, pk=_TEST_PK)
+        assert _ecdh_gas_cost(params) == 3120
+
+
+# ---------------------------------------------------------------------------
+# AES
+# ---------------------------------------------------------------------------
+
+
+class TestAesEncoding:
+    def test_encrypt_layout(self):
+        key = Bytes32(b"\x00" * 32)
+        nonce = 1
+        plaintext = b"hello"
+        data = _encrypt_encode(AesGcmEncryptParams(key, nonce, plaintext))
+        assert len(data) == 32 + 12 + 5
+        assert data[:32] == b"\x00" * 32
+        assert data[32:44] == (1).to_bytes(12, "big")
+        assert data[44:] == b"hello"
+
+    def test_decrypt_layout(self):
+        key = Bytes32(b"\x01" * 32)
+        nonce = EncryptionNonce(b"\x02" * 12)
+        ct = b"\xab" * 32
+        data = _decrypt_encode(AesGcmDecryptParams(key, nonce, ct))
+        assert len(data) == 32 + 12 + 32
+        assert data[:32] == b"\x01" * 32
+        assert data[32:44] == b"\x02" * 12
+        assert data[44:] == ct
+
+    def test_nonce_int_to_bytes(self):
+        assert _nonce_to_bytes(256) == (256).to_bytes(12, "big")
+        assert len(_nonce_to_bytes(0)) == 12
+
+    def test_nonce_encryption_nonce_passthrough(self):
+        nonce = EncryptionNonce(b"\x03" * 12)
+        assert _nonce_to_bytes(nonce) == b"\x03" * 12
+
+    def test_encrypt_decode(self):
+        raw = b"\xaa\xbb\xcc"
+        result = _encrypt_decode(raw)
+        assert bytes(result) == raw
+
+
+class TestAesGasCost:
+    def test_empty_plaintext(self):
+        params = AesGcmEncryptParams(Bytes32(b"\x00" * 32), 0, b"")
+        # 1000 + 0 blocks = 1000
+        assert _encrypt_gas(params) == 1000
+
+    def test_16_bytes(self):
+        params = AesGcmEncryptParams(Bytes32(b"\x00" * 32), 0, b"\x00" * 16)
+        # 1000 + ceil(16/16)*30 = 1030
+        assert _encrypt_gas(params) == 1030
+
+    def test_17_bytes(self):
+        params = AesGcmEncryptParams(Bytes32(b"\x00" * 32), 0, b"\x00" * 17)
+        # 1000 + ceil(17/16)*30 = 1060
+        assert _encrypt_gas(params) == 1060
+
+    def test_decrypt_gas_matches_encrypt(self):
+        ct = b"\x00" * 32
+        d_params = AesGcmDecryptParams(Bytes32(b"\x00" * 32), 0, ct)
+        e_params = AesGcmEncryptParams(Bytes32(b"\x00" * 32), 0, ct)
+        assert _decrypt_gas(d_params) == _encrypt_gas(e_params)
+
+
+# ---------------------------------------------------------------------------
+# HKDF
+# ---------------------------------------------------------------------------
+
+
+class TestHkdfEncoding:
+    def test_passthrough(self):
+        ikm = b"input key material"
+        assert _hkdf_encode(ikm) == ikm
+
+    def test_decode_returns_bytes32(self):
+        raw = b"\xaa" * 32 + b"\x00" * 10  # extra bytes ignored
+        result = _hkdf_decode(raw)
+        assert isinstance(result, Bytes32)
+        assert len(result) == 32
+        assert bytes(result) == b"\xaa" * 32
+
+
+class TestHkdfGasCost:
+    def test_empty_input(self):
+        # linear = 3000 + 0*12 = 3000
+        # total = 2*3000 + 120 = 6120
+        assert _hkdf_gas_cost(b"") == 6120
+
+    def test_32_bytes(self):
+        # linear = 3000 + 1*12 = 3012
+        # total = 2*3012 + 120 = 6144
+        assert _hkdf_gas_cost(b"\x00" * 32) == 6144
+
+
+# ---------------------------------------------------------------------------
+# secp256k1
+# ---------------------------------------------------------------------------
+
+
+class TestSecp256k1Encoding:
+    def test_encode_length(self):
+        sk = PrivateKey(b"\x01" * 32)
+        msg_hash = Bytes32(b"\x02" * 32)
+        data = _sig_encode(Secp256k1SigParams(sk, msg_hash))
+        # ABI-encoded: 2 x bytes32 = 64 bytes
+        assert len(data) == 64
+
+    def test_encode_values(self):
+        sk = PrivateKey(b"\x01" * 32)
+        msg_hash = Bytes32(b"\x02" * 32)
+        data = _sig_encode(Secp256k1SigParams(sk, msg_hash))
+        assert data[:32] == b"\x01" * 32
+        assert data[32:] == b"\x02" * 32
+
+
+class TestSecp256k1GasCost:
+    def test_constant(self):
+        sk = PrivateKey(b"\x01" * 32)
+        msg_hash = Bytes32(b"\x02" * 32)
+        assert _sig_gas_cost(Secp256k1SigParams(sk, msg_hash)) == 3000
+
+
+class TestHashMessage:
+    def test_known_hash(self):
+        """Verify EIP-191 hash matches the known Ethereum personal_sign hash."""
+        from eth_hash.auto import keccak
+
+        msg = "hello"
+        expected_prefix = b"\x19Ethereum Signed Message:\n5"
+        expected = keccak(expected_prefix + b"hello")
+        assert bytes(_hash_message(msg)) == expected
+
+    def test_returns_bytes32(self):
+        result = _hash_message("test")
+        assert isinstance(result, Bytes32)
+        assert len(result) == 32


### PR DESCRIPTION
Implement Python wrappers for all 6 Mercury EVM precompiles (0x64–0x69), ported from the seismic-viem TypeScript reference:

- RNG (0x64): on-chain random number generation with optional personalization
- ECDH (0x65): elliptic-curve Diffie-Hellman key exchange
- AES-GCM encrypt/decrypt (0x66/0x67): on-chain symmetric encryption
- HKDF (0x68): key derivation from input key material
- secp256k1 sign (0x69): on-chain ECDSA signing with EIP-191 message hashing

Each precompile exposes both sync and async variants (e.g. `rng` / `async_rng`) and is importable directly from `seismic_web3.precompiles`. The shared framework uses `w3.provider.make_request` to call `eth_call` without injecting a sender address, which Seismic nodes require for unsigned precompile calls.

Includes 33 unit tests (encoding, decoding, gas calculation, validation) and 15 integration tests (roundtrip verification against sanvil).