### PR TITLE
docs(clients/python): audit precompiles docs

### DIFF
--- a/docs/gitbook/clients/python/precompiles/README.md
+++ b/docs/gitbook/clients/python/precompiles/README.md
@@ -5,34 +5,52 @@ icon: microchip
 
 # Precompiles
 
-Mercury EVM ships with precompiles for common cryptographic operations. They're callable via `eth_call` — no encryption state needed, just a `Web3` instance connected to a Seismic node.
+The Python SDK exposes wrappers for six Mercury EVM precompiles (`0x64` through `0x69`).
+
+These wrappers use plain `eth_call`, so you only need a `Web3` connection to a Seismic node. No wallet client or encryption state is required.
+
+## Quick Start
 
 ```python
-from seismic_web3.precompiles import (
-    rng, ecdh, aes_gcm_encrypt, aes_gcm_decrypt, hkdf, secp256k1_sign,
+import os
+from seismic_web3 import PrivateKey, create_public_client
+from seismic_web3.crypto.secp import private_key_to_compressed_public_key
+from seismic_web3 import precompiles as sp
+
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+
+# 1) Random bytes as int
+random_val = sp.rng(w3, num_bytes=32)
+
+# 2) Shared key from ECDH
+my_sk = PrivateKey(os.urandom(32))
+peer_sk = PrivateKey(os.urandom(32))
+peer_pk = private_key_to_compressed_public_key(peer_sk)
+shared_key = sp.ecdh(w3, sk=my_sk, pk=peer_pk)
+
+# 3) AES-GCM encrypt/decrypt
+ciphertext = sp.aes_gcm_encrypt(
+    w3,
+    aes_key=shared_key,
+    nonce=1,
+    plaintext=b"secret",
 )
-from seismic_web3 import Bytes32, PrivateKey, CompressedPublicKey
+plaintext = sp.aes_gcm_decrypt(
+    w3,
+    aes_key=shared_key,
+    nonce=1,
+    ciphertext=bytes(ciphertext),
+)
 
-# On-chain random number generation
-random_val = rng(w3, num_bytes=32)
+# 4) HKDF derivation
+derived_key = sp.hkdf(w3, b"input key material")
 
-# On-chain ECDH key exchange
-shared_secret = ecdh(w3, sk=my_private_key, pk=their_public_key)
-
-# On-chain AES-GCM encrypt / decrypt
-ciphertext = aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"secret")
-plaintext = aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ciphertext))
-
-# On-chain HKDF key derivation
-derived_key = hkdf(w3, b"input key material")
-
-# On-chain secp256k1 signing
-signature = secp256k1_sign(w3, sk=my_private_key, message="hello")
+# 5) secp256k1 signing
+signature = sp.secp256k1_sign(w3, sk=my_sk, message="hello")
 ```
 
-All functions have async variants: `async_rng`, `async_ecdh`, `async_aes_gcm_encrypt`, `async_aes_gcm_decrypt`, `async_hkdf`, `async_secp256k1_sign`.
-
-***
+All wrappers also have async variants:
+`async_rng`, `async_ecdh`, `async_aes_gcm_encrypt`, `async_aes_gcm_decrypt`, `async_hkdf`, `async_secp256k1_sign`.
 
 ## Reference
 

--- a/docs/gitbook/clients/python/precompiles/aes-gcm-decrypt.md
+++ b/docs/gitbook/clients/python/precompiles/aes-gcm-decrypt.md
@@ -5,11 +5,13 @@ icon: unlock
 
 # aes_gcm_decrypt
 
-Decrypt data on-chain using Mercury EVM's AES-GCM decryption precompile.
+Decrypt bytes with the AES-GCM precompile at `0x67`.
 
 ## Overview
 
-`aes_gcm_decrypt()` and `async_aes_gcm_decrypt()` call the AES-GCM decryption precompile at address `0x67` to decrypt ciphertext using AES-256-GCM. The ciphertext must include the 16-byte authentication tag.
+`aes_gcm_decrypt()` and `async_aes_gcm_decrypt()` accept a 32-byte key, a nonce, and ciphertext bytes that include the 16-byte authentication tag.
+
+If tag verification fails, the RPC call fails.
 
 ## Signature
 
@@ -34,16 +36,16 @@ async def async_aes_gcm_decrypt(
 ## Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `w3` | `Web3` or `AsyncWeb3` | Yes | Web3 instance connected to a Seismic node |
-| `aes_key` | [`Bytes32`](../api-reference/types/bytes32.md) | Yes | 32-byte AES-256 decryption key |
-| `nonce` | `int` or [`EncryptionNonce`](../api-reference/types/encryption-nonce.md) | Yes | 12-byte nonce (must match encryption nonce) |
-| `ciphertext` | `bytes` | Yes | Data to decrypt (includes 16-byte authentication tag) |
+|---|---|---|---|
+| `w3` | `Web3` / `AsyncWeb3` | Yes | Connected Seismic client |
+| `aes_key` | [`Bytes32`](../api-reference/types/bytes32.md) | Yes | 32-byte AES key |
+| `nonce` | `int` or [`EncryptionNonce`](../api-reference/types/encryption-nonce.md) | Yes | Must match encryption nonce |
+| `ciphertext` | `bytes` | Yes | Ciphertext including authentication tag |
 
 ## Returns
 
 | Type | Description |
-|------|-------------|
+|---|---|
 | `HexBytes` | Decrypted plaintext bytes |
 
 ## Examples
@@ -51,224 +53,64 @@ async def async_aes_gcm_decrypt(
 ### Basic Usage
 
 ```python
-from seismic_web3.precompiles import aes_gcm_encrypt, aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import Web3
 import os
+from seismic_web3 import Bytes32, create_public_client
+from seismic_web3 import precompiles as sp
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
 
-# Generate AES key
-aes_key = Bytes32(os.urandom(32))
+key = Bytes32(os.urandom(32))
+pt = b"secret"
+ct = sp.aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=pt)
 
-# Encrypt then decrypt
-plaintext = b"Secret message"
-ciphertext = aes_gcm_encrypt(w3, aes_key=aes_key, nonce=1, plaintext=plaintext)
-decrypted = aes_gcm_decrypt(w3, aes_key=aes_key, nonce=1, ciphertext=ciphertext)
-
-assert decrypted == plaintext
-print(f"Decrypted: {decrypted.decode()}")
+decrypted = sp.aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ct))
+assert bytes(decrypted) == pt
 ```
 
-### With Integer Nonce
+### Handle Authentication Failure
 
 ```python
-from seismic_web3.precompiles import aes_gcm_encrypt, aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-aes_key = Bytes32.from_hex("0x1234...")
-
-# Encrypt with integer nonce
-plaintext = b"Test message"
-ciphertext = aes_gcm_encrypt(w3, aes_key=aes_key, nonce=42, plaintext=plaintext)
-
-# Decrypt with same nonce
-decrypted = aes_gcm_decrypt(w3, aes_key=aes_key, nonce=42, ciphertext=ciphertext)
-print(f"Decrypted: {decrypted}")
-```
-
-### With EncryptionNonce
-
-```python
-from seismic_web3.precompiles import aes_gcm_encrypt, aes_gcm_decrypt
-from seismic_web3 import Bytes32, EncryptionNonce
-from web3 import Web3
-import os
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-aes_key = Bytes32.from_hex("0x1234...")
-nonce = EncryptionNonce(os.urandom(12))
-
-# Encrypt and decrypt with EncryptionNonce
-plaintext = b"Secure data"
-ciphertext = aes_gcm_encrypt(w3, aes_key=aes_key, nonce=nonce, plaintext=plaintext)
-decrypted = aes_gcm_decrypt(w3, aes_key=aes_key, nonce=nonce, ciphertext=ciphertext)
-
-assert decrypted == plaintext
+try:
+    sp.aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=b"not-valid")
+except RuntimeError as exc:
+    print(f"precompile failed: {exc}")
 ```
 
 ### Async Usage
 
 ```python
-from seismic_web3.precompiles import async_aes_gcm_encrypt, async_aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import AsyncWeb3
 import os
+from seismic_web3 import create_async_public_client
+from seismic_web3 import Bytes32
+from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-    aes_key = Bytes32(os.urandom(32))
-    plaintext = b"Async secret"
-
-    # Encrypt and decrypt asynchronously
-    ciphertext = await async_aes_gcm_encrypt(
-        w3, aes_key=aes_key, nonce=1, plaintext=plaintext
-    )
-    decrypted = await async_aes_gcm_decrypt(
-        w3, aes_key=aes_key, nonce=1, ciphertext=ciphertext
-    )
-
-    assert decrypted == plaintext
-    print(f"Decrypted: {decrypted}")
-
-# Run with asyncio.run(main())
+    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    key = Bytes32(os.urandom(32))
+    ct = sp.aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"async secret")
+    pt = await sp.async_aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ct))
+    print(bytes(pt))
 ```
-
-### Decrypt Multiple Messages
-
-```python
-from seismic_web3.precompiles import aes_gcm_encrypt, aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import Web3
-import os
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-aes_key = Bytes32(os.urandom(32))
-
-# Encrypt multiple messages
-messages = [b"Message 1", b"Message 2", b"Message 3"]
-ciphertexts = [
-    aes_gcm_encrypt(w3, aes_key=aes_key, nonce=i, plaintext=msg)
-    for i, msg in enumerate(messages)
-]
-
-# Decrypt all messages
-decrypted = [
-    aes_gcm_decrypt(w3, aes_key=aes_key, nonce=i, ciphertext=ct)
-    for i, ct in enumerate(ciphertexts)
-]
-
-for i, msg in enumerate(decrypted):
-    print(f"Message {i}: {msg}")
-```
-
-### Handle Decryption Failure
-
-```python
-from seismic_web3.precompiles import aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-aes_key = Bytes32.from_hex("0x1234...")
-bad_ciphertext = b"invalid ciphertext data"
-
-# Decryption will fail if authentication tag doesn't verify
-try:
-    decrypted = aes_gcm_decrypt(w3, aes_key=aes_key, nonce=1, ciphertext=bad_ciphertext)
-except Exception as e:
-    print(f"Decryption failed: {e}")
-```
-
-### With ECDH-Derived Key
-
-```python
-from seismic_web3.precompiles import ecdh, aes_gcm_encrypt, aes_gcm_decrypt
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Alice encrypts for Bob
-alice_sk = PrivateKey.from_hex("0x1234...")
-bob_pk = CompressedPublicKey.from_hex("0x03...")
-alice_key = ecdh(w3, sk=alice_sk, pk=bob_pk)
-
-plaintext = b"Message for Bob"
-ciphertext = aes_gcm_encrypt(w3, aes_key=alice_key, nonce=1, plaintext=plaintext)
-
-# Bob decrypts from Alice
-bob_sk = PrivateKey.from_hex("0x5678...")
-alice_pk = CompressedPublicKey.from_hex("0x02...")
-bob_key = ecdh(w3, sk=bob_sk, pk=alice_pk)
-
-decrypted = aes_gcm_decrypt(w3, aes_key=bob_key, nonce=1, ciphertext=ciphertext)
-assert decrypted == plaintext
-print(f"Bob received: {decrypted}")
-```
-
-### Convert Result to String
-
-```python
-from seismic_web3.precompiles import aes_gcm_decrypt
-from seismic_web3 import Bytes32
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-aes_key = Bytes32.from_hex("0x1234...")
-ciphertext = bytes.fromhex("...")  # From previous encryption
-
-# Decrypt and convert to string
-decrypted = aes_gcm_decrypt(w3, aes_key=aes_key, nonce=1, ciphertext=ciphertext)
-message = decrypted.decode("utf-8")
-print(f"Message: {message}")
-```
-
-## How It Works
-
-1. **Encode parameters** - Concatenates 32-byte key + 12-byte nonce + ciphertext (with tag)
-2. **Call precompile** - Issues an `eth_call` to address `0x67` with estimated gas
-3. **Decrypt and verify** - Precompile performs AES-256-GCM decryption and verifies authentication tag
-4. **Return plaintext** - Returns decrypted data if tag verification succeeds
 
 ## Gas Cost
 
-Gas cost is calculated as:
+The SDK uses:
+
 ```python
-base_gas = 1000
-per_block = 30  # per 16-byte block
-num_blocks = (len(ciphertext) + 15) // 16
-total_gas = base_gas + (num_blocks * per_block)
+from math import ceil
+
+total_gas = 1000 + ceil(len(ciphertext) / 16) * 30
 ```
 
-The gas cost is proportional to ciphertext length (including the 16-byte tag).
+`len(ciphertext)` includes the 16-byte authentication tag.
 
 ## Notes
 
-- Uses AES-256-GCM authenticated decryption
-- Nonce must exactly match the nonce used during encryption
-- Ciphertext must include the 16-byte authentication tag (appended by encryption)
-- Decryption fails if the authentication tag doesn't verify
-- Plaintext length = ciphertext length - 16 bytes (authentication tag)
-
-## Warnings
-
-- **Authentication failure** - If the tag doesn't verify, the precompile reverts (wrong key/nonce/tampered data)
-- **Nonce mismatch** - Using a different nonce than encryption will cause decryption to fail
-- **Key mismatch** - Using a different key than encryption will cause authentication failure
-- **Ciphertext integrity** - Any modification to ciphertext causes authentication failure
+- Use the same key and nonce used for encryption.
+- The decrypt wrapper returns `HexBytes`; cast with `bytes(...)` if needed.
+- Failed authentication/tag validation is surfaced as an RPC error.
 
 ## See Also
 
-- [aes-gcm-encrypt](aes-gcm-encrypt.md) - Encrypt with AES-GCM
-- [ecdh](ecdh.md) - Derive shared decryption keys
-- [Bytes32](../api-reference/types/bytes32.md) - 32-byte AES key type
-- [EncryptionNonce](../api-reference/types/encryption-nonce.md) - 12-byte nonce type
+- [aes-gcm-encrypt](aes-gcm-encrypt.md)
+- [ecdh](ecdh.md)

--- a/docs/gitbook/clients/python/precompiles/ecdh.md
+++ b/docs/gitbook/clients/python/precompiles/ecdh.md
@@ -5,11 +5,13 @@ icon: key
 
 # ecdh
 
-Perform on-chain ECDH key exchange using Mercury EVM's ECDH precompile.
+Compute a shared key with the ECDH precompile at `0x65`.
 
 ## Overview
 
-`ecdh()` and `async_ecdh()` call the ECDH precompile at address `0x65` to compute a shared secret from a private key and a public key using elliptic-curve Diffie-Hellman. The result is a 32-byte shared secret derived via HKDF.
+`ecdh()` and `async_ecdh()` take a `PrivateKey` and a `CompressedPublicKey` and return a `Bytes32` shared key.
+
+The on-chain precompile performs ECDH and an HKDF derivation step, so the returned `Bytes32` is ready to use as an AES key.
 
 ## Signature
 
@@ -32,158 +34,82 @@ async def async_ecdh(
 ## Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `w3` | `Web3` or `AsyncWeb3` | Yes | Web3 instance connected to a Seismic node |
-| `sk` | [`PrivateKey`](../api-reference/types/private-key.md) | Yes | 32-byte secret key |
-| `pk` | [`CompressedPublicKey`](../api-reference/types/compressed-public-key.md) | Yes | 33-byte compressed public key |
+|---|---|---|---|
+| `w3` | `Web3` / `AsyncWeb3` | Yes | Connected Seismic client |
+| `sk` | [`PrivateKey`](../api-reference/types/private-key.md) | Yes | Local 32-byte private key |
+| `pk` | [`CompressedPublicKey`](../api-reference/types/compressed-public-key.md) | Yes | Peer compressed public key (33 bytes) |
 
 ## Returns
 
 | Type | Description |
-|------|-------------|
-| [`Bytes32`](../api-reference/types/bytes32.md) | 32-byte shared secret |
+|---|---|
+| [`Bytes32`](../api-reference/types/bytes32.md) | Derived shared key |
 
 ## Examples
-
-### Basic Usage
-
-```python
-from seismic_web3.precompiles import ecdh
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Alice's keys
-alice_sk = PrivateKey.from_hex("0x1234...")
-alice_pk = CompressedPublicKey.from_hex("0x02...")
-
-# Bob's public key
-bob_pk = CompressedPublicKey.from_hex("0x03...")
-
-# Alice computes shared secret with Bob's public key
-shared_secret = ecdh(w3, sk=alice_sk, pk=bob_pk)
-print(f"Shared secret: {shared_secret.to_0x_hex()}")
-```
 
 ### Two-Party Key Exchange
 
 ```python
-from seismic_web3.precompiles import ecdh
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
+import os
+from seismic_web3 import PrivateKey, create_public_client
+from seismic_web3.crypto.secp import private_key_to_compressed_public_key
+from seismic_web3 import precompiles as sp
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
 
-# Alice's keypair
-alice_sk = PrivateKey.from_hex("0x1234...")
-alice_pk = CompressedPublicKey.from_private_key(alice_sk)
+alice_sk = PrivateKey(os.urandom(32))
+bob_sk = PrivateKey(os.urandom(32))
 
-# Bob's keypair
-bob_sk = PrivateKey.from_hex("0x5678...")
-bob_pk = CompressedPublicKey.from_private_key(bob_sk)
+alice_pk = private_key_to_compressed_public_key(alice_sk)
+bob_pk = private_key_to_compressed_public_key(bob_sk)
 
-# Both parties compute the same shared secret
-alice_shared = ecdh(w3, sk=alice_sk, pk=bob_pk)
-bob_shared = ecdh(w3, sk=bob_sk, pk=alice_pk)
+alice_shared = sp.ecdh(w3, sk=alice_sk, pk=bob_pk)
+bob_shared = sp.ecdh(w3, sk=bob_sk, pk=alice_pk)
 
 assert alice_shared == bob_shared
-print(f"Shared secret: {alice_shared.to_0x_hex()}")
+```
+
+### Use Shared Key for AES-GCM
+
+```python
+from seismic_web3 import precompiles as sp
+
+key = sp.ecdh(w3, sk=alice_sk, pk=bob_pk)
+ct = sp.aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"secret")
+pt = sp.aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ct))
+assert bytes(pt) == b"secret"
 ```
 
 ### Async Usage
 
 ```python
-from seismic_web3.precompiles import async_ecdh
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import AsyncWeb3
+import os
+from seismic_web3 import create_async_public_client
+from seismic_web3 import PrivateKey
+from seismic_web3.crypto.secp import private_key_to_compressed_public_key
+from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-    alice_sk = PrivateKey.from_hex("0x1234...")
-    bob_pk = CompressedPublicKey.from_hex("0x03...")
-
-    # Compute shared secret asynchronously
-    shared_secret = await async_ecdh(w3, sk=alice_sk, pk=bob_pk)
-    print(f"Shared secret: {shared_secret.to_0x_hex()}")
-
-# Run with asyncio.run(main())
+    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    alice_sk = PrivateKey(os.urandom(32))
+    bob_sk = PrivateKey(os.urandom(32))
+    bob_pk = private_key_to_compressed_public_key(bob_sk)
+    shared = await sp.async_ecdh(w3, sk=alice_sk, pk=bob_pk)
+    print(shared.to_0x_hex())
 ```
-
-### Use with AES Encryption
-
-```python
-from seismic_web3.precompiles import ecdh, aes_gcm_encrypt
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Derive shared AES key via ECDH
-alice_sk = PrivateKey.from_hex("0x1234...")
-bob_pk = CompressedPublicKey.from_hex("0x03...")
-aes_key = ecdh(w3, sk=alice_sk, pk=bob_pk)
-
-# Use shared key for encryption
-plaintext = b"Secret message for Bob"
-ciphertext = aes_gcm_encrypt(w3, aes_key=aes_key, nonce=1, plaintext=plaintext)
-print(f"Ciphertext: {ciphertext.hex()}")
-```
-
-### Generate Keypair from Private Key
-
-```python
-from seismic_web3.precompiles import ecdh
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
-import os
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Generate new private key
-my_sk = PrivateKey(os.urandom(32))
-
-# Derive public key from private key
-my_pk = CompressedPublicKey.from_private_key(my_sk)
-
-# Exchange with peer
-peer_pk = CompressedPublicKey.from_hex("0x03...")
-shared_secret = ecdh(w3, sk=my_sk, pk=peer_pk)
-```
-
-## How It Works
-
-1. **Encode parameters** - Concatenates 32-byte private key and 33-byte public key
-2. **Call precompile** - Issues an `eth_call` to address `0x65` with 3120 gas
-3. **Compute ECDH** - Precompile performs scalar multiplication on secp256k1 curve
-4. **Derive key** - Applies HKDF to the ECDH point to produce a 32-byte secret
 
 ## Gas Cost
 
-Fixed gas cost: **3120 gas**
-- 3000 gas for ECDH scalar multiplication
-- 120 gas for HKDF key derivation
+Fixed cost: `3120`.
 
 ## Notes
 
-- Uses the secp256k1 elliptic curve (same as Ethereum)
-- Public keys must be in compressed format (33 bytes starting with `0x02` or `0x03`)
-- The ECDH point is passed through HKDF for key uniformity
-- Both parties compute the same shared secret: `ecdh(sk_A, pk_B) == ecdh(sk_B, pk_A)`
-- The shared secret can be used as an AES-256 key
-
-## Warnings
-
-- **Private key security** - Never expose or log private keys
-- **Public key validation** - Invalid public keys will cause the precompile to revert
-- **Key reuse** - Using the same keypair for multiple sessions reduces forward secrecy
+- Input layout is `sk(32) || pk(33)`.
+- Invalid keys cause the call to fail.
+- Keep private keys out of logs and telemetry.
 
 ## See Also
 
-- [aes-gcm-encrypt](aes-gcm-encrypt.md) - Encrypt with derived key
-- [aes-gcm-decrypt](aes-gcm-decrypt.md) - Decrypt with derived key
-- [hkdf](hkdf.md) - Key derivation function
-- [PrivateKey](../api-reference/types/private-key.md) - 32-byte private key type
-- [CompressedPublicKey](../api-reference/types/compressed-public-key.md) - 33-byte public key type
-- [Bytes32](../api-reference/types/bytes32.md) - 32-byte value type
+- [aes-gcm-encrypt](aes-gcm-encrypt.md)
+- [aes-gcm-decrypt](aes-gcm-decrypt.md)
+- [hkdf](hkdf.md)

--- a/docs/gitbook/clients/python/precompiles/hkdf.md
+++ b/docs/gitbook/clients/python/precompiles/hkdf.md
@@ -5,11 +5,11 @@ icon: fingerprint
 
 # hkdf
 
-Derive cryptographic keys on-chain using Mercury EVM's HKDF precompile.
+Derive a 32-byte key with the HKDF precompile at `0x68`.
 
 ## Overview
 
-`hkdf()` and `async_hkdf()` call the HKDF precompile at address `0x68` to perform HKDF-SHA256 key derivation on input key material (IKM). The result is a uniformly distributed 32-byte derived key.
+`hkdf()` and `async_hkdf()` accept arbitrary input key material (`ikm`) and return a `Bytes32` derived key.
 
 ## Signature
 
@@ -28,14 +28,14 @@ async def async_hkdf(
 ## Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `w3` | `Web3` or `AsyncWeb3` | Yes | Web3 instance connected to a Seismic node |
-| `ikm` | `bytes` | Yes | Input key material (arbitrary bytes) |
+|---|---|---|---|
+| `w3` | `Web3` / `AsyncWeb3` | Yes | Connected Seismic client |
+| `ikm` | `bytes` | Yes | Input key material |
 
 ## Returns
 
 | Type | Description |
-|------|-------------|
+|---|---|
 | [`Bytes32`](../api-reference/types/bytes32.md) | 32-byte derived key |
 
 ## Examples
@@ -43,212 +43,59 @@ async def async_hkdf(
 ### Basic Usage
 
 ```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
+from seismic_web3 import create_public_client
+from seismic_web3 import precompiles as sp
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
 
-# Derive key from input material
-ikm = b"my-input-key-material"
-derived_key = hkdf(w3, ikm)
-print(f"Derived key: {derived_key.to_0x_hex()}")
+key = sp.hkdf(w3, b"input key material")
+print(key.to_0x_hex())
 ```
 
-### Derive from Password
+### Context Separation
 
 ```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Derive key from password (not recommended for real password hashing)
-password = b"user-password-123"
-derived_key = hkdf(w3, password)
-print(f"Derived key: {derived_key.to_0x_hex()}")
+master = b"shared-secret"
+encryption_key = sp.hkdf(w3, master + b"\x01encryption")
+auth_key = sp.hkdf(w3, master + b"\x02auth")
+assert encryption_key != auth_key
 ```
 
 ### Async Usage
 
 ```python
-from seismic_web3.precompiles import async_hkdf
-from web3 import AsyncWeb3
+from seismic_web3 import create_async_public_client
+from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-    ikm = b"input-key-material"
-    derived_key = await async_hkdf(w3, ikm)
-    print(f"Derived key: {derived_key.to_0x_hex()}")
-
-# Run with asyncio.run(main())
+    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    key = await sp.async_hkdf(w3, b"async input")
+    print(key.to_0x_hex())
 ```
-
-### Derive Multiple Keys
-
-```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Derive different keys by varying input
-base_ikm = b"shared-secret"
-contexts = [b"encryption", b"authentication", b"signing"]
-
-for ctx in contexts:
-    ikm = base_ikm + ctx
-    key = hkdf(w3, ikm)
-    print(f"Key for {ctx.decode()}: {key.to_0x_hex()}")
-```
-
-### Use as AES Key
-
-```python
-from seismic_web3.precompiles import hkdf, aes_gcm_encrypt
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Derive AES key from input material
-ikm = b"my-master-secret"
-aes_key = hkdf(w3, ikm)
-
-# Use derived key for encryption
-plaintext = b"Encrypted with derived key"
-ciphertext = aes_gcm_encrypt(w3, aes_key=aes_key, nonce=1, plaintext=plaintext)
-print(f"Ciphertext: {ciphertext.hex()}")
-```
-
-### Derive from ECDH Output
-
-```python
-from seismic_web3.precompiles import ecdh, hkdf
-from seismic_web3 import PrivateKey, CompressedPublicKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# First perform ECDH
-my_sk = PrivateKey.from_hex("0x1234...")
-peer_pk = CompressedPublicKey.from_hex("0x03...")
-shared_secret = ecdh(w3, sk=my_sk, pk=peer_pk)
-
-# Further derive key from shared secret
-ikm = bytes(shared_secret) + b"application-context"
-derived_key = hkdf(w3, ikm)
-print(f"Derived key: {derived_key.to_0x_hex()}")
-```
-
-### Deterministic Key Derivation
-
-```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Same input always produces same output
-ikm = b"deterministic-input"
-key1 = hkdf(w3, ikm)
-key2 = hkdf(w3, ikm)
-
-assert key1 == key2
-print(f"Deterministic key: {key1.to_0x_hex()}")
-```
-
-### Variable-Length Input
-
-```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# HKDF accepts arbitrary-length input
-inputs = [
-    b"short",
-    b"medium length input",
-    b"very long input key material " * 10,
-]
-
-for ikm in inputs:
-    key = hkdf(w3, ikm)
-    print(f"Input length {len(ikm)}: {key.to_0x_hex()}")
-```
-
-### Key Separation by Context
-
-```python
-from seismic_web3.precompiles import hkdf
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-master_secret = b"shared-master-key"
-
-# Derive separate keys for different purposes
-encryption_key = hkdf(w3, master_secret + b"\x01encryption")
-auth_key = hkdf(w3, master_secret + b"\x02authentication")
-signing_key = hkdf(w3, master_secret + b"\x03signing")
-
-print(f"Encryption: {encryption_key.to_0x_hex()}")
-print(f"Auth: {auth_key.to_0x_hex()}")
-print(f"Signing: {signing_key.to_0x_hex()}")
-```
-
-## How It Works
-
-1. **Encode parameters** - Passes input key material as-is
-2. **Call precompile** - Issues an `eth_call` to address `0x68` with gas proportional to input length
-3. **HKDF derivation** - Precompile performs HKDF-SHA256 extract and expand phases
-4. **Return key** - Returns first 32 bytes of derived key material
 
 ## Gas Cost
 
-Gas cost is calculated as:
+The SDK computes gas as:
+
 ```python
-sha256_base = 60
-sha256_per_word = 12  # per 32-byte word
-hkdf_expand = 120
+from math import ceil
 
-# Extract phase (twice)
-extract_cost = 2 * (sha256_base + (len(ikm) // 32) * sha256_per_word + 3000)
-
-# Expand phase
-total_gas = extract_cost + hkdf_expand
+linear = 3000 + ceil(len(ikm) / 32) * 12
+total_gas = 2 * linear + 120
 ```
 
-For example:
-- 32 bytes IKM: ~6144 gas
-- 64 bytes IKM: ~6168 gas
-- 128 bytes IKM: ~6216 gas
+Examples:
+- `len(ikm)=0`: `6120`
+- `len(ikm)=32`: `6144`
 
 ## Notes
 
-- Uses HKDF-SHA256 from RFC 5869
-- Always returns exactly 32 bytes regardless of input length
-- Input key material can be any length
-- The derivation is deterministic: same IKM always produces same output
-- Internally performs both HKDF-Extract and HKDF-Expand phases
-- The derived key has uniform distribution suitable for cryptographic use
-
-## Use Cases
-
-- Derive encryption keys from shared secrets
-- Convert non-uniform entropy into uniform keys
-- Key separation: derive multiple keys from one master secret
-- Post-process ECDH output for additional security
-
-## Warnings
-
-- **Not for password hashing** - Use proper password hashing algorithms (bcrypt, argon2) for passwords
-- **Input entropy** - Output security depends entirely on input entropy
-- **Deterministic** - Same input always yields same output (no salt/randomness added)
+- Deterministic: the same `ikm` always produces the same output.
+- Good for deriving protocol keys from shared secrets.
+- Not a password hashing function; use `argon2`/`bcrypt` for password storage.
 
 ## See Also
 
-- [ecdh](ecdh.md) - Often used before HKDF to derive keys
-- [aes-gcm-encrypt](aes-gcm-encrypt.md) - Use derived keys for encryption
-- [rng](rng.md) - Generate random input material
-- [Bytes32](../api-reference/types/bytes32.md) - 32-byte derived key type
+- [ecdh](ecdh.md)
+- [aes-gcm-encrypt](aes-gcm-encrypt.md)
+- [rng](rng.md)

--- a/docs/gitbook/clients/python/precompiles/rng.md
+++ b/docs/gitbook/clients/python/precompiles/rng.md
@@ -5,11 +5,15 @@ icon: dice
 
 # rng
 
-Generate random bytes on-chain using Mercury EVM's RNG precompile.
+Generate random bytes on-chain using the RNG precompile at `0x64`.
 
 ## Overview
 
-`rng()` and `async_rng()` call the RNG precompile at address `0x64` to generate cryptographically secure random bytes directly on the Seismic node. The random value is returned as a Python integer.
+`rng()` and `async_rng()` return randomness as a Python `int`.
+
+Input encoding is:
+- `num_bytes` as a 4-byte big-endian `uint32`
+- optional `pers` bytes appended after it
 
 ## Signature
 
@@ -32,122 +36,73 @@ async def async_rng(
 ## Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `w3` | `Web3` or `AsyncWeb3` | Yes | Web3 instance connected to a Seismic node |
-| `num_bytes` | `int` | Yes | Number of random bytes to generate (1-32) |
-| `pers` | `bytes` | No | Optional personalization bytes to seed the RNG |
+|---|---|---|---|
+| `w3` | `Web3` / `AsyncWeb3` | Yes | Connected Seismic client |
+| `num_bytes` | `int` | Yes | Number of random bytes to request (`1..32`) |
+| `pers` | `bytes` | No | Optional personalization bytes |
 
 ## Returns
 
 | Type | Description |
-|------|-------------|
-| `int` | Random value as a Python integer (derived from `num_bytes` random bytes) |
+|---|---|
+| `int` | Random value interpreted as big-endian unsigned integer |
 
 ## Examples
 
 ### Basic Usage
 
 ```python
-from seismic_web3.precompiles import rng
-from web3 import Web3
+from seismic_web3 import create_public_client
+from seismic_web3 import precompiles as sp
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
 
-# Generate 32 random bytes
-random_value = rng(w3, num_bytes=32)
-print(f"Random: {random_value}")
+value = sp.rng(w3, num_bytes=32)
+print(value)
 ```
 
 ### With Personalization
 
 ```python
-from seismic_web3.precompiles import rng
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Generate random bytes with personalization string
-random_value = rng(w3, num_bytes=16, pers=b"my-app-seed")
-print(f"Random: {random_value}")
+value = sp.rng(w3, num_bytes=16, pers=b"my-domain")
 ```
 
 ### Async Usage
 
 ```python
-from seismic_web3.precompiles import async_rng
-from web3 import AsyncWeb3
+from seismic_web3 import create_async_public_client
+from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-    # Generate random bytes asynchronously
-    random_value = await async_rng(w3, num_bytes=32)
-    print(f"Random: {random_value}")
-
-# Run with asyncio.run(main())
+    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    value = await sp.async_rng(w3, num_bytes=32)
+    print(value)
 ```
-
-### Generate Multiple Random Values
-
-```python
-from seismic_web3.precompiles import rng
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Generate multiple random values
-randoms = [rng(w3, num_bytes=32) for _ in range(5)]
-for i, val in enumerate(randoms):
-    print(f"Random {i}: {val}")
-```
-
-### Convert to Bytes
-
-```python
-from seismic_web3.precompiles import rng
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Generate random value and convert back to bytes
-random_int = rng(w3, num_bytes=32)
-random_bytes = random_int.to_bytes(32, "big")
-print(f"Random bytes: {random_bytes.hex()}")
-```
-
-## How It Works
-
-1. **Encode parameters** - `num_bytes` is encoded as a 4-byte big-endian integer, followed by optional `pers` bytes
-2. **Call precompile** - Issues an `eth_call` to address `0x64` with estimated gas
-3. **Decode result** - Result bytes are padded to 32 bytes and interpreted as a big-endian unsigned integer
 
 ## Gas Cost
 
-The gas cost is calculated as:
+The SDK uses:
+
 ```python
-init_cost = 3500 + (len(pers) // 136) * 5
-fill_cost = (num_bytes // 136) * 5
+from math import ceil
+
+init_cost = 3500 + ceil(len(pers) / 32) * 5
+fill_cost = ceil(num_bytes / 32) * 5
 total_gas = init_cost + fill_cost
 ```
 
-The base cost is 3500 gas, with 5 gas per 136-byte block for personalization and output.
+Examples:
+- `num_bytes=1`, empty `pers`: `3505`
+- `num_bytes=32`, empty `pers`: `3505`
+- `num_bytes=16`, `len(pers)=64`: `3515`
 
 ## Notes
 
-- `num_bytes` must be between 1 and 32 (inclusive)
-- The RNG uses Strobe128 internally for cryptographic security
-- Each call generates independent random values
-- Personalization string can be used to domain-separate random values
-- The returned integer represents the random bytes as a big-endian unsigned value
-
-## Warnings
-
-- **Range validation** - `num_bytes` outside 1-32 will raise `ValueError`
-- **Node connectivity** - Requires a working connection to a Seismic node
-- **Not for consensus** - Results may differ across nodes due to timing
+- `num_bytes` outside `1..32` raises `ValueError` before RPC.
+- Output is right-padded to 32 bytes and decoded as a `uint256`-style integer.
+- This function is for node-provided randomness; do not use it as consensus-critical randomness.
 
 ## See Also
 
-- [ecdh](ecdh.md) - On-chain ECDH key exchange
-- [hkdf](hkdf.md) - On-chain HKDF key derivation
-- [Bytes32](../api-reference/types/bytes32.md) - 32-byte value type
+- [ecdh](ecdh.md)
+- [hkdf](hkdf.md)

--- a/docs/gitbook/clients/python/precompiles/secp256k1-sign.md
+++ b/docs/gitbook/clients/python/precompiles/secp256k1-sign.md
@@ -5,11 +5,14 @@ icon: signature
 
 # secp256k1_sign
 
-Sign messages on-chain using Mercury EVM's secp256k1 signing precompile.
+Sign a message with the secp256k1 signing precompile at `0x69`.
 
 ## Overview
 
-`secp256k1_sign()` and `async_secp256k1_sign()` call the secp256k1 signing precompile at address `0x69` to create ECDSA signatures. The message is hashed with the EIP-191 personal-sign prefix before signing.
+`secp256k1_sign()` and `async_secp256k1_sign()`:
+- hash the input `message` with an EIP-191 personal-sign prefix
+- sign the hash using the provided private key
+- return signature bytes (`HexBytes`)
 
 ## Signature
 
@@ -32,266 +35,93 @@ async def async_secp256k1_sign(
 ## Parameters
 
 | Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `w3` | `Web3` or `AsyncWeb3` | Yes | Web3 instance connected to a Seismic node |
+|---|---|---|---|
+| `w3` | `Web3` / `AsyncWeb3` | Yes | Connected Seismic client |
 | `sk` | [`PrivateKey`](../api-reference/types/private-key.md) | Yes | 32-byte secp256k1 private key |
-| `message` | `str` | Yes | Message string to sign |
+| `message` | `str` | Yes | Message text to sign |
 
 ## Returns
 
 | Type | Description |
-|------|-------------|
-| `HexBytes` | ECDSA signature bytes (65 bytes: r + s + v) |
+|---|---|
+| `HexBytes` | Signature bytes (r/s plus recovery byte) |
 
 ## Examples
 
 ### Basic Usage
 
 ```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3
+import os
+from seismic_web3 import PrivateKey, create_public_client
+from seismic_web3 import precompiles as sp
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
 
-# Sign a message
-private_key = PrivateKey.from_hex("0x1234...")
-message = "Hello, Seismic!"
-signature = secp256k1_sign(w3, sk=private_key, message=message)
-print(f"Signature: {signature.hex()}")
-print(f"Length: {len(signature)} bytes")
+sk = PrivateKey(os.urandom(32))
+sig = sp.secp256k1_sign(w3, sk=sk, message="hello")
+print(sig.hex())
+```
+
+### Verify Off-Chain
+
+```python
+from eth_account import Account
+from eth_account.messages import encode_defunct
+
+message = "hello"
+sig = sp.secp256k1_sign(w3, sk=sk, message=message)
+
+recovered = Account.recover_message(encode_defunct(text=message), signature=sig)
+expected = Account.from_key(bytes(sk)).address
+assert recovered == expected
 ```
 
 ### Async Usage
 
 ```python
-from seismic_web3.precompiles import async_secp256k1_sign
+import os
+from seismic_web3 import create_async_public_client
 from seismic_web3 import PrivateKey
-from web3 import AsyncWeb3
+from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = AsyncWeb3(AsyncWeb3.AsyncHTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-    private_key = PrivateKey.from_hex("0x1234...")
-    message = "Async signing"
-    signature = await async_secp256k1_sign(w3, sk=private_key, message=message)
-    print(f"Signature: {signature.hex()}")
-
-# Run with asyncio.run(main())
+    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    sk = PrivateKey(os.urandom(32))
+    sig = await sp.async_secp256k1_sign(w3, sk=sk, message="async hello")
+    print(sig.hex())
 ```
 
-### Sign Multiple Messages
+### Read Signature Components
 
 ```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-private_key = PrivateKey.from_hex("0x1234...")
-messages = ["Message 1", "Message 2", "Message 3"]
-
-for msg in messages:
-    signature = secp256k1_sign(w3, sk=private_key, message=msg)
-    print(f"Signature for '{msg}': {signature.hex()[:20]}...")
+r = int.from_bytes(sig[0:32], "big")
+s = int.from_bytes(sig[32:64], "big")
+v = sig[64] if len(sig) > 64 else None
 ```
 
-### Verify Signature Off-Chain
+## Hashing Behavior
+
+The SDK hashes with:
 
 ```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3, Account
 from eth_hash.auto import keccak
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Sign message on-chain
-private_key = PrivateKey.from_hex("0x1234...")
-message = "Verify me"
-signature = secp256k1_sign(w3, sk=private_key, message=message)
-
-# Verify signature off-chain using web3.py
-# Compute EIP-191 message hash
 prefix = f"\x19Ethereum Signed Message:\n{len(message)}".encode()
 message_hash = keccak(prefix + message.encode())
-
-# Recover signer address
-recovered_address = Account.recover_message_hash(message_hash, signature=signature)
-expected_address = Account.from_key(bytes(private_key)).address
-
-assert recovered_address == expected_address
-print(f"Signature verified! Signer: {recovered_address}")
 ```
-
-### Extract Signature Components
-
-```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-private_key = PrivateKey.from_hex("0x1234...")
-signature = secp256k1_sign(w3, sk=private_key, message="Extract components")
-
-# Signature is 65 bytes: r (32) + s (32) + v (1)
-r = signature[:32]
-s = signature[32:64]
-v = signature[64]
-
-print(f"r: {r.hex()}")
-print(f"s: {s.hex()}")
-print(f"v: {v}")
-```
-
-### Generate Private Key
-
-```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3
-import os
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-# Generate random private key
-private_key = PrivateKey(os.urandom(32))
-
-message = "Signed with generated key"
-signature = secp256k1_sign(w3, sk=private_key, message=message)
-print(f"Signature: {signature.hex()}")
-```
-
-### Sign Transaction Hash
-
-```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey, Bytes32
-from web3 import Web3
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-private_key = PrivateKey.from_hex("0x1234...")
-
-# Sign a transaction hash (as a hex string)
-tx_hash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-signature = secp256k1_sign(w3, sk=private_key, message=tx_hash)
-print(f"Transaction signature: {signature.hex()}")
-```
-
-### Compare On-Chain vs Off-Chain Signing
-
-```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3, Account
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-private_key = PrivateKey.from_hex("0x1234...")
-message = "Compare signing methods"
-
-# On-chain signing (via precompile)
-onchain_sig = secp256k1_sign(w3, sk=private_key, message=message)
-
-# Off-chain signing (via web3.py)
-account = Account.from_key(bytes(private_key))
-offchain_sig = account.sign_message(
-    {"message": message.encode(), "version": "E"}
-).signature
-
-# Signatures will differ due to randomness in 'k' value
-# But both are valid signatures for the same message
-print(f"On-chain:  {onchain_sig.hex()[:40]}...")
-print(f"Off-chain: {offchain_sig.hex()[:40]}...")
-```
-
-### Sign with Message Context
-
-```python
-from seismic_web3.precompiles import secp256k1_sign
-from seismic_web3 import PrivateKey
-from web3 import Web3
-import json
-
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
-
-private_key = PrivateKey.from_hex("0x1234...")
-
-# Sign structured message
-context = {
-    "action": "transfer",
-    "amount": 1000,
-    "recipient": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
-}
-message = json.dumps(context, sort_keys=True)
-signature = secp256k1_sign(w3, sk=private_key, message=message)
-print(f"Context signature: {signature.hex()}")
-```
-
-## How It Works
-
-1. **Hash message** - Applies EIP-191 personal-sign prefix and keccak256 hash:
-   ```python
-   prefix = f"\x19Ethereum Signed Message:\n{len(message)}"
-   message_hash = keccak256(prefix + message)
-   ```
-
-2. **Encode parameters** - ABI-encodes the private key and message hash
-
-3. **Call precompile** - Issues an `eth_call` to address `0x69` with 3000 gas
-
-4. **Sign hash** - Precompile performs ECDSA signing on secp256k1 curve
-
-5. **Return signature** - Returns 65-byte signature (r + s + v)
 
 ## Gas Cost
 
-Fixed gas cost: **3000 gas**
-
-The cost is constant regardless of message length (since the message is hashed before signing).
-
-## EIP-191 Message Hashing
-
-The precompile follows EIP-191 personal-sign format, equivalent to:
-
-```python
-prefix = f"\x19Ethereum Signed Message:\n{len(message)}"
-message_hash = keccak256(prefix.encode() + message.encode())
-```
-
-This ensures compatibility with standard Ethereum message signing (e.g., MetaMask's `personal_sign`).
-
-## Signature Format
-
-The returned signature is 65 bytes:
-- **r** (32 bytes): Signature component
-- **s** (32 bytes): Signature component
-- **v** (1 byte): Recovery ID (27 or 28)
-
-This format is compatible with `ecrecover` and standard Ethereum signature verification.
+Fixed cost: `3000`.
 
 ## Notes
 
-- Uses secp256k1 curve (same as Ethereum)
-- Message is automatically prefixed with EIP-191 header
-- Signatures are non-deterministic (random 'k' value)
-- Compatible with MetaMask and other Ethereum wallets
-- Can be verified on-chain using `ecrecover` precompile
-
-## Warnings
-
-- **Private key security** - Never expose or log private keys
-- **Message format** - Message is treated as UTF-8 string
-- **Signature malleability** - Standard ECDSA signatures are malleable (use EIP-2098 compact signatures if needed)
-- **Non-deterministic** - Multiple signatures of the same message will differ
+- `message` is UTF-8 encoded before hashing/signing.
+- Keep private keys out of logs and telemetry.
+- The output format is suitable for typical Ethereum signature verification flows.
 
 ## See Also
 
-- [PrivateKey](../api-reference/types/private-key.md) - 32-byte private key type
-- [Bytes32](../api-reference/types/bytes32.md) - 32-byte value type
-- [ecdh](ecdh.md) - ECDH key exchange
-- [EIP-191](https://eips.ethereum.org/EIPS/eip-191) - Signed data standard
+- [PrivateKey](../api-reference/types/private-key.md)
+- [EIP-191](https://eips.ethereum.org/EIPS/eip-191)
+- [ecdh](ecdh.md)


### PR DESCRIPTION
## Summary
- audit and rewrite python precompiles docs for accuracy and clarity
- remove incorrect or low-signal examples
- correct documented gas formulas to match SDK behavior
- standardize examples to `from seismic_web3 import precompiles as sp`

## Files
- docs/gitbook/clients/python/precompiles/*