### PR TITLE
fix(contracts): new stricter typecast rules

### DIFF
--- a/contracts/src/directory/Directory.sol
+++ b/contracts/src/directory/Directory.sol
@@ -20,11 +20,11 @@ contract Directory is IDirectory {
     }
 
     function checkHasKey(address _addr) public view returns (bool) {
-        return keys[_addr] != suint256(0);
+        return bool(keys[_addr] != suint256(0));
     }
 
     function keyHash(address to) public view returns (bytes32) {
-        return keccak256(abi.encodePacked(keys[to]));
+        return keccak256(abi.encodePacked(uint256(keys[to])));
     }
 
     function encrypt(address to, bytes memory _plaintext) public returns (bytes memory) {

--- a/contracts/src/seismic-std-lib/utils/precompiles/CryptoUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/precompiles/CryptoUtils.sol
@@ -80,7 +80,7 @@ library CryptoUtils {
         view
         returns (bytes memory ciphertext)
     {
-        bytes memory input = abi.encodePacked(key, nonce, plaintext);
+        bytes memory input = abi.encodePacked(uint256(key), nonce, plaintext);
         (bool success, bytes memory output) = AES_ENCRYPT_PRECOMPILE.staticcall(input);
         if (!success) revert AESPrecompileCallFailed();
         if (output.length == 0) revert EncryptionReturnedNoOutput();
@@ -98,7 +98,7 @@ library CryptoUtils {
         returns (bytes memory plaintext)
     {
         if (ciphertext.length == 0) revert CiphertextCannotBeEmpty();
-        bytes memory input = abi.encodePacked(key, nonce, ciphertext);
+        bytes memory input = abi.encodePacked(uint256(key), nonce, ciphertext);
         (bool success, bytes memory output) = AES_DECRYPT_PRECOMPILE.staticcall(input);
         if (!success) revert AESPrecompileCallFailed();
         return output;

--- a/contracts/test/Intelligence.t.sol
+++ b/contracts/test/Intelligence.t.sol
@@ -52,8 +52,8 @@ contract IntelligenceTest is Test {
         assertEq(extractCT(encryptedData[1]), directCiphertext[1]);
 
         bytes32[] memory directHashes = new bytes32[](2);
-        directHashes[0] = keccak256(abi.encodePacked(aliceKey));
-        directHashes[1] = keccak256(abi.encodePacked(bobKey));
+        directHashes[0] = keccak256(abi.encodePacked(uint256(aliceKey)));
+        directHashes[1] = keccak256(abi.encodePacked(uint256(bobKey)));
         assertEq(hashes[0], directHashes[0]);
         assertEq(hashes[1], directHashes[1]);
     }
@@ -73,7 +73,7 @@ contract IntelligenceTest is Test {
 
         assertEq(intelligence.numProviders(), 3);
         assertEq(extractCT(encryptedData[2]), directCiphertext);
-        assertEq(hashes[2], keccak256(abi.encodePacked(charlieKey)));
+        assertEq(hashes[2], keccak256(abi.encodePacked(uint256(charlieKey))));
 
         vm.prank(intelligence.owner());
         vm.expectRevert("DUPLICATE_PROVIDER");
@@ -93,7 +93,7 @@ contract IntelligenceTest is Test {
         assertEq(extractCT(encryptedData[0]), directCiphertext);
 
         bytes32 h = directory.keyHash(bob);
-        assertEq(h, keccak256(abi.encodePacked(bobKey)));
+        assertEq(h, keccak256(abi.encodePacked(uint256(bobKey))));
     }
 
     function test_RevertIfRemoveUnkownProvider() public {

--- a/contracts/test/ShieldedDelegationAccount.t.sol
+++ b/contracts/test/ShieldedDelegationAccount.t.sol
@@ -250,7 +250,7 @@ contract ShieldedDelegationAccountTest is Test, ShieldedDelegationAccount {
     function _createTokenTransferCall(address recipient, uint256 amount) internal view returns (bytes memory calls) {
         // Create the transfer function call data
         bytes memory transferData =
-            abi.encodeWithSelector(SRC20.transfer.selector, saddress(recipient), suint256(amount));
+            abi.encodeWithSelector(SRC20.transfer.selector, recipient, amount);
 
         // Format it for MultiSend
         return abi.encodePacked(


### PR DESCRIPTION
New rules were enforced in https://github.com/SeismicSystems/seismic-solidity/pull/204, such as not being allowed to abi.encode a shielded type.

Fixed these mindlessly, but I think we should take some time to look at the devex related to our current rules. It looks like we force a lot of manual typecasts which might confuse more than help. For example, we disallow abi encoding shielded types; I think a more intuitive rule would be to allow abi encoding shielded types but forcing the output to be sbytes instead of bytes?