### PR TITLE
docs(clients/python): audit Namespaces section

### DIFF
--- a/docs/gitbook/clients/python/namespaces/README.md
+++ b/docs/gitbook/clients/python/namespaces/README.md
@@ -43,3 +43,8 @@ w3 = SEISMIC_TESTNET.wallet_client(pk)
 tee_key = w3.seismic.get_tee_public_key()
 print(tee_key.hex())
 ```
+
+## See Also
+
+- [Namespace Methods](methods/) — Detailed method reference
+- [Contract Namespaces](../contract/namespaces/) — Contract method reference

--- a/docs/gitbook/clients/python/namespaces/async-seismic-namespace.md
+++ b/docs/gitbook/clients/python/namespaces/async-seismic-namespace.md
@@ -1,6 +1,6 @@
 ---
 description: Async wallet Seismic namespace
-icon: lock
+icon: wallet
 ---
 
 # AsyncSeismicNamespace
@@ -20,6 +20,19 @@ class AsyncSeismicNamespace(AsyncSeismicPublicNamespace):
     async def deposit(..., address: str = DEPOSIT_CONTRACT_ADDRESS) -> HexBytes: ...
 ```
 
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`send_shielded_transaction`](methods/send-shielded-transaction.md) | `HexBytes` | Encrypt, sign, and broadcast a shielded transaction |
+| [`signed_call`](methods/signed-call.md) | `HexBytes` | Execute a signed read with encrypted calldata |
+| [`debug_send_shielded_transaction`](methods/debug-send-shielded-transaction.md) | `DebugWriteResult` | Send shielded transaction and return debug artifacts |
+| [`deposit`](methods/deposit.md) | `HexBytes` | Submit a validator deposit (transparent) |
+| [`contract`](../contract/shielded-contract.md) | `AsyncShieldedContract` | Create an async shielded contract wrapper |
+| `get_tee_public_key` | `CompressedPublicKey` | Inherited from [`AsyncSeismicPublicNamespace`](async-seismic-public-namespace.md) |
+| `get_deposit_root` | `bytes` | Inherited from [`AsyncSeismicPublicNamespace`](async-seismic-public-namespace.md) |
+| `get_deposit_count` | `int` | Inherited from [`AsyncSeismicPublicNamespace`](async-seismic-public-namespace.md) |
+
 ## Example
 
 ```python
@@ -36,6 +49,13 @@ raw = await token.read.balanceOf()
 
 ## Notes
 
-- Includes every async public namespace method.
-- `signed_call()` always returns `HexBytes`; empty responses are `HexBytes(b"")`.
-- `deposit()` validates byte lengths and raises `ValueError` on mismatch.
+- Includes every async public namespace method
+- `signed_call()` always returns `HexBytes`; empty responses are `HexBytes(b"")`
+- `deposit()` validates byte lengths and raises `ValueError` on mismatch
+- Attached as `w3.seismic` by `await CHAIN.async_wallet_client(pk)`
+
+## See Also
+
+- [SeismicNamespace](seismic-namespace.md) — Sync equivalent
+- [AsyncSeismicPublicNamespace](async-seismic-public-namespace.md) — Read-only base class
+- [AsyncShieldedContract](../contract/shielded-contract.md) — Contract wrapper returned by `contract()`

--- a/docs/gitbook/clients/python/namespaces/async-seismic-public-namespace.md
+++ b/docs/gitbook/clients/python/namespaces/async-seismic-public-namespace.md
@@ -17,6 +17,15 @@ class AsyncSeismicPublicNamespace:
     async def get_deposit_count(self, *, address: str = DEPOSIT_CONTRACT_ADDRESS) -> int: ...
 ```
 
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`get_tee_public_key`](methods/get-tee-public-key.md) | `CompressedPublicKey` | Fetch the TEE's compressed secp256k1 public key |
+| [`get_deposit_root`](methods/get-deposit-root.md) | `bytes` | Read the deposit Merkle root (32 bytes) |
+| [`get_deposit_count`](methods/get-deposit-count.md) | `int` | Read the total validator deposit count |
+| `contract` | `AsyncPublicContract` | Create an async read-only contract wrapper (`.tread` only) |
+
 ## Example
 
 ```python
@@ -31,5 +40,11 @@ count = await public.seismic.get_deposit_count()
 
 ## Notes
 
-- No private key is required.
-- `contract()` returns `AsyncPublicContract` with `.tread` only.
+- No private key is required
+- `contract()` returns `AsyncPublicContract` with `.tread` only
+
+## See Also
+
+- [SeismicPublicNamespace](seismic-public-namespace.md) — Sync equivalent
+- [AsyncSeismicNamespace](async-seismic-namespace.md) — Wallet namespace (extends this with write operations)
+- [AsyncPublicContract](../contract/public-contract.md) — Contract wrapper returned by `contract()`

--- a/docs/gitbook/clients/python/namespaces/methods/README.md
+++ b/docs/gitbook/clients/python/namespaces/methods/README.md
@@ -11,7 +11,7 @@ icon: list
 - [get_deposit_root](get-deposit-root.md)
 - [get_deposit_count](get-deposit-count.md)
 
-These are available on both public and wallet clients.
+Available on both public and wallet clients.
 
 ## Wallet methods
 
@@ -20,10 +20,12 @@ These are available on both public and wallet clients.
 - [signed_call](signed-call.md)
 - [deposit](deposit.md)
 
-These are available only on wallet clients.
+Available only on wallet clients.
 
 ## Utility
 
 - [encode_shielded_calldata](encode-shielded-calldata.md)
 
 Used internally by contract/namespace methods, and available directly when needed.
+
+All methods have both sync and async variants. Async variants use `await`.

--- a/docs/gitbook/clients/python/namespaces/methods/debug-send-shielded-transaction.md
+++ b/docs/gitbook/clients/python/namespaces/methods/debug-send-shielded-transaction.md
@@ -19,13 +19,15 @@ await w3.seismic.debug_send_shielded_transaction(...same args...) -> DebugWriteR
 
 ## Returns
 
-`DebugWriteResult` with:
+[`DebugWriteResult`](../../api-reference/transaction-types/debug-write-result.md) with:
 
-- `plaintext_tx`
-- `shielded_tx`
-- `tx_hash`
+| Field | Type | Description |
+|-------|------|-------------|
+| `tx_hash` | `HexBytes` | Transaction hash from the network |
+| `plaintext_tx` | [`PlaintextTx`](../../api-reference/transaction-types/plaintext-tx.md) | Transaction with **unencrypted** calldata |
+| `shielded_tx` | [`UnsignedSeismicTx`](../../api-reference/transaction-types/unsigned-seismic-tx.md) | Full `TxSeismic` with **encrypted** calldata |
 
-The transaction is still broadcast.
+The transaction **is** broadcast — this is not a dry run.
 
 ## Example
 
@@ -35,3 +37,15 @@ print(result.tx_hash.hex())
 print(result.plaintext_tx.data.hex())
 print(result.shielded_tx.data.hex())
 ```
+
+## Notes
+
+- Parameters are identical to [`send_shielded_transaction`](send-shielded-transaction.md)
+- For contract interactions, prefer `contract.dwrite.functionName(...)` which handles ABI encoding automatically
+- Be careful logging `plaintext_tx` in production — it contains unencrypted calldata
+
+## See Also
+
+- [send_shielded_transaction](send-shielded-transaction.md) — Same pipeline without debug info
+- [contract.dwrite](../../contract/namespaces/dwrite.md) — High-level debug write API
+- [DebugWriteResult](../../api-reference/transaction-types/debug-write-result.md) — Return type reference

--- a/docs/gitbook/clients/python/namespaces/methods/deposit.md
+++ b/docs/gitbook/clients/python/namespaces/methods/deposit.md
@@ -1,6 +1,6 @@
 ---
 description: Submit a validator deposit transaction
-icon: banknote
+icon: coins
 ---
 
 # deposit
@@ -29,12 +29,14 @@ await w3.seismic.deposit(...same args...) -> HexBytes
 
 ## Required byte lengths
 
-- `node_pubkey`: 32
-- `consensus_pubkey`: 48
-- `withdrawal_credentials`: 32
-- `node_signature`: 64
-- `consensus_signature`: 96
-- `deposit_data_root`: 32
+| Parameter | Length |
+|-----------|--------|
+| `node_pubkey` | 32 |
+| `consensus_pubkey` | 48 |
+| `withdrawal_credentials` | 32 |
+| `node_signature` | 64 |
+| `consensus_signature` | 96 |
+| `deposit_data_root` | 32 |
 
 `ValueError` is raised on length mismatch.
 
@@ -54,5 +56,11 @@ tx_hash = w3.seismic.deposit(
 
 ## Notes
 
-- Uses transparent `eth_sendTransaction` semantics.
-- `value` is deposit amount in wei.
+- Uses transparent `eth_sendTransaction` semantics — deposit data is public, not shielded
+- `value` is deposit amount in wei (typically `32 * 10**18` for a full validator)
+- All parameters are keyword-only to prevent mix-ups between the many `bytes` arguments
+
+## See Also
+
+- [get_deposit_count](get-deposit-count.md) — Read total deposits
+- [get_deposit_root](get-deposit-root.md) — Read deposit Merkle root

--- a/docs/gitbook/clients/python/namespaces/methods/encode-shielded-calldata.md
+++ b/docs/gitbook/clients/python/namespaces/methods/encode-shielded-calldata.md
@@ -1,6 +1,6 @@
 ---
 description: Encode calldata for ABI entries with Seismic shielded types
-icon: brackets
+icon: code
 ---
 
 # encode_shielded_calldata
@@ -19,9 +19,9 @@ def encode_shielded_calldata(
 
 ## Behavior
 
-- Selector is computed from original ABI type names (including shielded types).
-- Parameter encoding remaps shielded types to standard ABI types.
-- Raises `ValueError` if function is not found.
+- **Selector** is computed from original ABI type names (e.g. `setNumber(suint256)`) so it matches the on-chain contract
+- **Parameter encoding** remaps shielded types to standard ABI types (e.g. `suint256` → `uint256`) because the values are structurally identical
+- Raises `ValueError` if function is not found
 
 ## Example
 
@@ -29,3 +29,14 @@ def encode_shielded_calldata(
 calldata = encode_shielded_calldata(SRC20_ABI, "transfer", ["0xRecipient", 100])
 tx_hash = w3.seismic.send_shielded_transaction(to="0xToken", data=calldata)
 ```
+
+## Notes
+
+- For contract interactions, prefer `contract.write.functionName(...)` or `contract.read.functionName(...)` which call this internally
+- Handles arrays (`suint256[]`, `suint256[5]`), `sbool`, `saddress`, and recursive tuple components
+
+## See Also
+
+- [send_shielded_transaction](send-shielded-transaction.md) — Send encrypted transactions using manually encoded calldata
+- [signed_call](signed-call.md) — Execute encrypted reads using manually encoded calldata
+- [Contract Namespaces](../../contract/namespaces/) — High-level API that handles encoding automatically

--- a/docs/gitbook/clients/python/namespaces/methods/get-deposit-count.md
+++ b/docs/gitbook/clients/python/namespaces/methods/get-deposit-count.md
@@ -1,6 +1,6 @@
 ---
 description: Read deposit count from deposit contract
-icon: hash
+icon: hashtag
 ---
 
 # get_deposit_count
@@ -35,3 +35,8 @@ print(count)
 ## Implementation detail
 
 SDK decodes bytes `[64:72]` as little-endian `uint64`.
+
+## See Also
+
+- [get_deposit_root](get-deposit-root.md) — Read the deposit Merkle root
+- [deposit](deposit.md) — Submit a validator deposit

--- a/docs/gitbook/clients/python/namespaces/methods/get-deposit-root.md
+++ b/docs/gitbook/clients/python/namespaces/methods/get-deposit-root.md
@@ -1,6 +1,6 @@
 ---
 description: Read deposit Merkle root from deposit contract
-icon: hash
+icon: tree
 ---
 
 # get_deposit_root
@@ -31,3 +31,8 @@ await w3.seismic.get_deposit_root(*, address: str = DEPOSIT_CONTRACT_ADDRESS) ->
 root = w3.seismic.get_deposit_root()
 print(root.hex())
 ```
+
+## See Also
+
+- [get_deposit_count](get-deposit-count.md) — Read the total deposit count
+- [deposit](deposit.md) — Submit a validator deposit

--- a/docs/gitbook/clients/python/namespaces/methods/get-tee-public-key.md
+++ b/docs/gitbook/clients/python/namespaces/methods/get-tee-public-key.md
@@ -26,5 +26,15 @@ print(tee_key.hex())
 
 ## Behavior
 
-- Calls custom RPC method `seismic_getTeePublicKey`.
-- Validates return value as `CompressedPublicKey` (33 bytes, prefix `0x02` or `0x03`).
+- Calls custom RPC method `seismic_getTeePublicKey`
+- Validates return value as `CompressedPublicKey` (33 bytes, prefix `0x02` or `0x03`)
+
+## Notes
+
+- Wallet clients call this automatically during construction to derive the ECDH shared key for calldata encryption — you don't need to call it manually unless implementing custom encryption
+- The TEE's key is ephemeral and regenerated on node restart
+
+## See Also
+
+- [CompressedPublicKey](../../api-reference/types/compressed-public-key.md) — Return type
+- [send_shielded_transaction](send-shielded-transaction.md) — Uses the TEE key for encryption

--- a/docs/gitbook/clients/python/namespaces/methods/send-shielded-transaction.md
+++ b/docs/gitbook/clients/python/namespaces/methods/send-shielded-transaction.md
@@ -1,6 +1,6 @@
 ---
 description: Send encrypted TxSeismic transaction
-icon: send
+icon: shield-halved
 ---
 
 # send_shielded_transaction
@@ -26,12 +26,21 @@ w3.seismic.send_shielded_transaction(
 await w3.seismic.send_shielded_transaction(...same args...) -> HexBytes
 ```
 
-## Behavior
+## Parameters
 
-- `data` is plaintext calldata; SDK encrypts it.
-- Default gas is `30_000_000` when `gas` is omitted.
-- If `gas_price` is omitted, SDK fetches current chain gas price.
-- `eip712=True` uses typed-data signing hash path.
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `to` | `ChecksumAddress` | Required | Recipient contract address |
+| `data` | `HexBytes` | Required | Plaintext calldata (SDK encrypts it) |
+| `value` | `int` | `0` | Wei to transfer |
+| `gas` | `int \| None` | `None` | Gas limit (defaults to `30_000_000`) |
+| `gas_price` | `int \| None` | `None` | Gas price in wei (fetched from chain if `None`) |
+| `security` | [`SeismicSecurityParams`](../../api-reference/transaction-types/seismic-security-params.md) `\| None` | `None` | Override default security parameters |
+| `eip712` | `bool` | `False` | Use EIP-712 typed-data signing path |
+
+## Returns
+
+`HexBytes` — transaction hash from `eth_sendRawTransaction`.
 
 ## Example
 
@@ -41,3 +50,20 @@ from seismic_web3.contract.abi import encode_shielded_calldata
 data = encode_shielded_calldata(SRC20_ABI, "transfer", ["0xRecipient", 100])
 tx_hash = w3.seismic.send_shielded_transaction(to="0xTokenAddress", data=data)
 ```
+
+## What's encrypted
+
+The SDK encrypts the `data` field (function selector + arguments) using AES-GCM with the ECDH-derived key. An observer can see `from`, `to`, `value`, and gas parameters, but **not** which function was called or what arguments were passed.
+
+## Notes
+
+- For contract interactions, prefer `contract.write.functionName(...)` which handles ABI encoding and encryption automatically
+- Creates a `TxSeismic` (type `0x4a`) transaction
+- SDK auto-fetches nonce via `eth_getTransactionCount`
+
+## See Also
+
+- [debug_send_shielded_transaction](debug-send-shielded-transaction.md) — Same pipeline with debug artifacts
+- [signed_call](signed-call.md) — Read-only equivalent (no state change)
+- [contract.write](../../contract/namespaces/write.md) — High-level contract write API
+- [SeismicSecurityParams](../../api-reference/transaction-types/seismic-security-params.md) — Security parameter reference

--- a/docs/gitbook/clients/python/namespaces/methods/signed-call.md
+++ b/docs/gitbook/clients/python/namespaces/methods/signed-call.md
@@ -25,13 +25,20 @@ w3.seismic.signed_call(
 await w3.seismic.signed_call(...same args...) -> HexBytes
 ```
 
-## Behavior
+## Parameters
 
-- Encrypts request calldata.
-- Signs an unsigned Seismic transaction payload.
-- Calls `eth_call` with raw signed bytes.
-- Decrypts result before returning.
-- Empty RPC result (`"0x"`) returns `HexBytes(b"")`.
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `to` | `ChecksumAddress` | Required | Contract address to call |
+| `data` | `HexBytes` | Required | Plaintext calldata (SDK encrypts it) |
+| `value` | `int` | `0` | Wei to include in the call context |
+| `gas` | `int` | `30_000_000` | Gas limit |
+| `security` | [`SeismicSecurityParams`](../../api-reference/transaction-types/seismic-security-params.md) `\| None` | `None` | Override default security parameters |
+| `eip712` | `bool` | `False` | Use EIP-712 typed-data signing path |
+
+## Returns
+
+`HexBytes` — decrypted response bytes. Empty RPC result (`"0x"`) returns `HexBytes(b"")`.
 
 ## Example
 
@@ -40,3 +47,17 @@ raw = w3.seismic.signed_call(to="0xTarget", data=calldata)
 if raw:
     print(raw.hex())
 ```
+
+## Notes
+
+- Does **not** modify blockchain state — this is a read-only `eth_call`
+- Both request and response are encrypted end-to-end (calldata, function selector, arguments, and the returned data)
+- Does not increment your account nonce
+- For contract interactions, prefer `contract.read.functionName(...)` which handles ABI encoding/decoding automatically
+
+## See Also
+
+- [send_shielded_transaction](send-shielded-transaction.md) — Write equivalent (modifies state)
+- [contract.read](../../contract/namespaces/read.md) — High-level signed read API
+- [contract.tread](../../contract/namespaces/tread.md) — Transparent reads (no encryption)
+- [SeismicSecurityParams](../../api-reference/transaction-types/seismic-security-params.md) — Security parameter reference

--- a/docs/gitbook/clients/python/namespaces/seismic-namespace.md
+++ b/docs/gitbook/clients/python/namespaces/seismic-namespace.md
@@ -1,6 +1,6 @@
 ---
 description: Sync wallet Seismic namespace
-icon: lock
+icon: wallet
 ---
 
 # SeismicNamespace
@@ -20,6 +20,19 @@ class SeismicNamespace(SeismicPublicNamespace):
     def deposit(..., address: str = DEPOSIT_CONTRACT_ADDRESS) -> HexBytes: ...
 ```
 
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`send_shielded_transaction`](methods/send-shielded-transaction.md) | `HexBytes` | Encrypt, sign, and broadcast a shielded transaction |
+| [`signed_call`](methods/signed-call.md) | `HexBytes` | Execute a signed read with encrypted calldata |
+| [`debug_send_shielded_transaction`](methods/debug-send-shielded-transaction.md) | `DebugWriteResult` | Send shielded transaction and return debug artifacts |
+| [`deposit`](methods/deposit.md) | `HexBytes` | Submit a validator deposit (transparent) |
+| [`contract`](../contract/shielded-contract.md) | `ShieldedContract` | Create a shielded contract wrapper |
+| `get_tee_public_key` | `CompressedPublicKey` | Inherited from [`SeismicPublicNamespace`](seismic-public-namespace.md) |
+| `get_deposit_root` | `bytes` | Inherited from [`SeismicPublicNamespace`](seismic-public-namespace.md) |
+| `get_deposit_count` | `int` | Inherited from [`SeismicPublicNamespace`](seismic-public-namespace.md) |
+
 ## Example
 
 ```python
@@ -36,6 +49,13 @@ raw = token.read.balanceOf()
 
 ## Notes
 
-- Includes every public namespace method.
-- `signed_call()` always returns `HexBytes`; empty responses are `HexBytes(b"")`.
-- `deposit()` validates byte lengths and raises `ValueError` on mismatch.
+- Includes every public namespace method
+- `signed_call()` always returns `HexBytes`; empty responses are `HexBytes(b"")`
+- `deposit()` validates byte lengths and raises `ValueError` on mismatch
+- Attached as `w3.seismic` by `CHAIN.wallet_client(pk)`
+
+## See Also
+
+- [AsyncSeismicNamespace](async-seismic-namespace.md) — Async equivalent
+- [SeismicPublicNamespace](seismic-public-namespace.md) — Read-only base class
+- [ShieldedContract](../contract/shielded-contract.md) — Contract wrapper returned by `contract()`

--- a/docs/gitbook/clients/python/namespaces/seismic-public-namespace.md
+++ b/docs/gitbook/clients/python/namespaces/seismic-public-namespace.md
@@ -17,6 +17,15 @@ class SeismicPublicNamespace:
     def get_deposit_count(self, *, address: str = DEPOSIT_CONTRACT_ADDRESS) -> int: ...
 ```
 
+## Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| [`get_tee_public_key`](methods/get-tee-public-key.md) | `CompressedPublicKey` | Fetch the TEE's compressed secp256k1 public key |
+| [`get_deposit_root`](methods/get-deposit-root.md) | `bytes` | Read the deposit Merkle root (32 bytes) |
+| [`get_deposit_count`](methods/get-deposit-count.md) | `int` | Read the total validator deposit count |
+| `contract` | `PublicContract` | Create a read-only contract wrapper (`.tread` only) |
+
 ## Example
 
 ```python
@@ -31,6 +40,12 @@ count = public.seismic.get_deposit_count()
 
 ## Notes
 
-- No private key is required.
-- `contract()` returns `PublicContract` with `.tread` only.
-- `get_deposit_count()` decodes an 8-byte little-endian value from contract return data.
+- No private key is required
+- `contract()` returns `PublicContract` with `.tread` only
+- `get_deposit_count()` decodes an 8-byte little-endian value from contract return data
+
+## See Also
+
+- [AsyncSeismicPublicNamespace](async-seismic-public-namespace.md) — Async equivalent
+- [SeismicNamespace](seismic-namespace.md) — Wallet namespace (extends this with write operations)
+- [PublicContract](../contract/public-contract.md) — Contract wrapper returned by `contract()`


### PR DESCRIPTION
## Summary
- audit docs/gitbook/clients/python/namespaces against module/rpc/send source
- correct method signatures/defaults/returns (including signed_call empty response semantics)
- simplify method and class pages to focused, source-accurate reference
