### PR TITLE
docs(clients/python): audit ABIs section

### DIFF
--- a/docs/gitbook/clients/python/abis/README.md
+++ b/docs/gitbook/clients/python/abis/README.md
@@ -5,28 +5,41 @@ icon: file-code
 
 # ABIs
 
-The SDK exports protocol ABI/constants under `seismic_web3.abis` plus deposit helper utilities.
+The SDK exports protocol ABIs, genesis contract addresses, and deposit helper utilities.
 
-## Built-in constants
+## Constants
 
-- `SRC20_ABI`
-- `DEPOSIT_CONTRACT_ABI`
-- `DEPOSIT_CONTRACT_ADDRESS`
-- `DIRECTORY_ABI`
-- `DIRECTORY_ADDRESS`
+| Constant | Type | Description |
+| --- | --- | --- |
+| [`SRC20_ABI`](src20-abi.md) | `list[dict]` | SRC20 token interface (7 functions, 2 events) |
+| [`DEPOSIT_CONTRACT_ABI`](deposit-contract.md) | `list[dict]` | Validator deposit contract (4 functions, 1 event) |
+| [`DEPOSIT_CONTRACT_ADDRESS`](deposit-contract.md) | `str` | `0x00000000219ab540356cBB839Cbe05303d7705Fa` |
+| [`DIRECTORY_ABI`](directory.md) | `list[dict]` | Viewing key directory (4 functions) |
+| [`DIRECTORY_ADDRESS`](directory.md) | `str` | `0x1000000000000000000000000000000000000004` |
 
-## Helper functions
+## Helper Functions
 
-- `make_withdrawal_credentials(address: str) -> bytes`
-- `compute_deposit_data_root(...) -> bytes`
+| Function | Returns | Description |
+| --- | --- | --- |
+| [`compute_deposit_data_root`](compute-deposit-data-root.md) | `bytes` | SHA-256 SSZ hash tree root for deposit data |
+| [`make_withdrawal_credentials`](make-withdrawal-credentials.md) | `bytes` | 32-byte ETH1 withdrawal credentials from address |
 
-## Quick usage
+## Example
 
 ```python
-from seismic_web3 import SEISMIC_TESTNET, PrivateKey, SRC20_ABI
+import os
+from eth_abi import decode
+from seismic_web3 import PrivateKey, SEISMIC_TESTNET, SRC20_ABI
 
-w3 = SEISMIC_TESTNET.wallet_client(PrivateKey.from_hex_str("0x..."))
-token = w3.seismic.contract("0xYourTokenAddress", SRC20_ABI)
+pk = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
+w3 = SEISMIC_TESTNET.wallet_client(pk)
+
+token = w3.seismic.contract("0x00000000219ab540356cBB839Cbe05303d7705Fa", SRC20_ABI)
+balance = decode(["uint256"], bytes(token.read.balanceOf()))[0]
 ```
 
-See individual pages for signatures and required byte lengths.
+## See Also
+
+- [SRC20](../src20/) — SRC20 token usage guide
+- [Contract](../contract/) — Contract interaction patterns
+- [Namespaces](../namespaces/) — `w3.seismic` methods including `deposit`, `get_deposit_count`, `get_deposit_root`

--- a/docs/gitbook/clients/python/abis/compute-deposit-data-root.md
+++ b/docs/gitbook/clients/python/abis/compute-deposit-data-root.md
@@ -1,11 +1,11 @@
 ---
-description: Compute SSZ-style deposit data root
+description: Compute SSZ-style deposit data root for validator deposits
 icon: calculator
 ---
 
-# compute_deposit_data_root
+# compute\_deposit\_data\_root
 
-Compute the 32-byte deposit data root expected by the deposit contract.
+Compute the 32-byte deposit data root hash (SHA-256 SSZ hash tree root) for validator deposits. This value must be passed as the `deposit_data_root` parameter when calling `deposit()`.
 
 ## Signature
 
@@ -21,36 +21,60 @@ def compute_deposit_data_root(
 ) -> bytes
 ```
 
-## Required byte lengths
+All parameters are keyword-only.
 
-- `node_pubkey`: 32
-- `consensus_pubkey`: 48
-- `withdrawal_credentials`: 32
-- `node_signature`: 64
-- `consensus_signature`: 96
+## Parameters
 
-Raises `ValueError` on length mismatch.
+| Parameter | Type | Bytes | Description |
+| --- | --- | --- | --- |
+| `node_pubkey` | `bytes` | 32 | ED25519 public key for node identity |
+| `consensus_pubkey` | `bytes` | 48 | BLS12-381 public key for consensus |
+| `withdrawal_credentials` | `bytes` | 32 | Use [`make_withdrawal_credentials`](make-withdrawal-credentials.md) |
+| `node_signature` | `bytes` | 64 | ED25519 signature over deposit data |
+| `consensus_signature` | `bytes` | 96 | BLS12-381 signature over deposit data |
+| `amount_gwei` | `int` | — | Deposit amount in gwei (e.g. `32 * 1000000000`) |
+
+## Returns
+
+`bytes` — 32-byte deposit data root hash.
+
+Raises `ValueError` if any byte-length parameter has the wrong size.
+
+## How It Works
+
+The function computes the SSZ hash tree root, mirroring the on-chain verification in `DepositContract.sol`:
+
+```
+pubkey_root         = SHA256(node_pubkey + SHA256(consensus_pubkey + pad_16))
+signature_root      = SHA256(SHA256(node_sig) + SHA256(SHA256(con_sig[:64]) + SHA256(con_sig[64:] + pad_32)))
+deposit_data_root   = SHA256(SHA256(pubkey_root + withdrawal_credentials) + SHA256(amount_le8 + pad_24 + signature_root))
+```
+
+Where `amount_le8` is the gwei value encoded as 8-byte little-endian, and `pad_N` extends data to chunk boundaries.
 
 ## Example
 
 ```python
-from seismic_web3 import (
-    compute_deposit_data_root,
-    make_withdrawal_credentials,
-)
+from seismic_web3 import compute_deposit_data_root, make_withdrawal_credentials
 
 withdrawal_credentials = make_withdrawal_credentials(
     "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 )
 
 root = compute_deposit_data_root(
-    node_pubkey=bytes.fromhex("00" * 32),
-    consensus_pubkey=bytes.fromhex("00" * 48),
+    node_pubkey=bytes(32),
+    consensus_pubkey=bytes(48),
     withdrawal_credentials=withdrawal_credentials,
-    node_signature=bytes.fromhex("00" * 64),
-    consensus_signature=bytes.fromhex("00" * 96),
-    amount_gwei=32_000_000_000,
+    node_signature=bytes(64),
+    consensus_signature=bytes(96),
+    amount_gwei=32 * 1000000000,
 )
 
-print(root.hex())
+print(root.hex())  # 32-byte hex string
 ```
+
+## See Also
+
+- [make\_withdrawal\_credentials](make-withdrawal-credentials.md) — Build the `withdrawal_credentials` input
+- [Deposit Contract](deposit-contract.md) — ABI, address, and deposit requirements
+- [deposit](../namespaces/methods/deposit.md) — Namespace method for making deposits

--- a/docs/gitbook/clients/python/abis/deposit-contract.md
+++ b/docs/gitbook/clients/python/abis/deposit-contract.md
@@ -1,43 +1,65 @@
 ---
-description: Deposit contract address and ABI constant
-icon: file-code
+description: Validator deposit contract ABI and address constants
+icon: vault
 ---
 
 # Deposit Contract
 
+ABI and address for Seismic's Eth2-style validator deposit contract at `0x00000000219ab540356cBB839Cbe05303d7705Fa`. Validators deposit ETH along with their public keys, signatures, and withdrawal credentials.
+
 ## Constants
 
 ```python
+from seismic_web3 import DEPOSIT_CONTRACT_ABI, DEPOSIT_CONTRACT_ADDRESS
+
 DEPOSIT_CONTRACT_ADDRESS: str = "0x00000000219ab540356cBB839Cbe05303d7705Fa"
 DEPOSIT_CONTRACT_ABI: list[dict[str, Any]]
 ```
 
-## ABI entries
+## Functions
 
-Functions:
+| Function | Parameters | Returns | Mutability | Description |
+| --- | --- | --- | --- | --- |
+| `deposit` | `node_pubkey`, `consensus_pubkey`, `withdrawal_credentials`, `node_signature`, `consensus_signature`, `deposit_data_root` | — | `payable` | Deposit ETH to become a validator |
+| `get_deposit_count` | — | `bytes` | `view` | Total number of deposits |
+| `get_deposit_root` | — | `bytes32` | `view` | Merkle root of all deposits |
+| `supportsInterface` | `interfaceId: bytes4` | `bool` | `pure` | ERC-165 interface check |
 
-- `deposit(bytes,bytes,bytes,bytes,bytes,bytes32)` (`payable`)
-- `get_deposit_count()` (`view`)
-- `get_deposit_root()` (`view`)
-- `supportsInterface(bytes4)` (`pure`)
+## Events
 
-Events:
+| Event | Parameters | Description |
+| --- | --- | --- |
+| `DepositEvent` | `node_pubkey`, `consensus_pubkey`, `withdrawal_credentials`, `amount`, `node_signature`, `consensus_signature`, `index` | Emitted on successful deposit |
 
-- `DepositEvent`
+## Deposit Requirements
 
-## Namespace usage example
+| Requirement | Details |
+| --- | --- |
+| Minimum deposit | 1 ETH (standard validator: 32 ETH) |
+| `node_pubkey` | 32-byte ED25519 public key |
+| `consensus_pubkey` | 48-byte BLS12-381 public key |
+| `withdrawal_credentials` | 32 bytes — use [`make_withdrawal_credentials`](make-withdrawal-credentials.md) |
+| `node_signature` | 64-byte ED25519 signature |
+| `consensus_signature` | 96-byte BLS12-381 signature |
+| `deposit_data_root` | 32 bytes — use [`compute_deposit_data_root`](compute-deposit-data-root.md) |
+| Transaction value | Must match `amount_gwei * 10**9` in wei |
+
+## Example
 
 ```python
-from seismic_web3 import SEISMIC_TESTNET, PrivateKey
+import os
+from seismic_web3 import PrivateKey, SEISMIC_TESTNET
 
-pk = PrivateKey.from_hex_str("0x...")
+pk = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 w3 = SEISMIC_TESTNET.wallet_client(pk)
 
+# Query deposit state via namespace methods
 count = w3.seismic.get_deposit_count()
 root = w3.seismic.get_deposit_root()
 ```
 
-## Related docs
+## See Also
 
-- [make_withdrawal_credentials](make-withdrawal-credentials.md)
-- [compute_deposit_data_root](compute-deposit-data-root.md)
+- [compute\_deposit\_data\_root](compute-deposit-data-root.md) — Compute the SSZ hash tree root
+- [make\_withdrawal\_credentials](make-withdrawal-credentials.md) — Build ETH1 withdrawal credentials
+- [deposit](../namespaces/methods/deposit.md) — Namespace method for making deposits

--- a/docs/gitbook/clients/python/abis/directory.md
+++ b/docs/gitbook/clients/python/abis/directory.md
@@ -1,22 +1,39 @@
 ---
-description: Directory ABI function signatures
-icon: file-code
+description: Directory contract ABI and address for viewing key management
+icon: address-book
 ---
 
 # Directory
 
+ABI and address for Seismic's Directory genesis contract at `0x1000000000000000000000000000000000000004`. Stores per-user AES-256 viewing keys using shielded storage (`suint256`).
+
 ## Constants
 
 ```python
+from seismic_web3 import DIRECTORY_ABI, DIRECTORY_ADDRESS
+
 DIRECTORY_ADDRESS: str = "0x1000000000000000000000000000000000000004"
 DIRECTORY_ABI: list[dict[str, Any]]
 ```
 
 ## Functions
 
-| Function | ABI Signature | Returns |
-| --- | --- | --- |
-| `checkHasKey` | `checkHasKey(_addr: address)` | `bool` |
-| `keyHash` | `keyHash(to: address)` | `bytes32` |
-| `getKey` | `getKey()` | `uint256` |
-| `setKey` | `setKey(_key: suint256)` | `None` |
+| Function | Parameters | Returns | Mutability | Description |
+| --- | --- | --- | --- | --- |
+| `checkHasKey` | `_addr: address` | `bool` | `view` | Check if address has a viewing key |
+| `keyHash` | `to: address` | `bytes32` | `view` | Get keccak256 hash of address's key |
+| `getKey` | — | `uint256` | `view` | Get caller's viewing key (shielded read) |
+| `setKey` | `_key: suint256` | — | `nonpayable` | Register or update viewing key (shielded write) |
+
+## Notes
+
+- `checkHasKey` and `keyHash` are public reads — no authentication needed
+- `getKey` returns the caller's own key and requires a signed read (uses `msg.sender`)
+- `setKey` uses a shielded type (`suint256`) so the key value is encrypted in the transaction
+- Only the 4 functions needed by the Python SDK are included; the full contract may have additional functions
+
+## See Also
+
+- [Intelligence Providers](../src20/intelligence-providers/) — Higher-level viewing key management (register, fetch, query)
+- [SRC20\_ABI](src20-abi.md) — Token standard that uses Directory keys
+- [Event Watching](../src20/event-watching/) — Decrypt events using viewing keys

--- a/docs/gitbook/clients/python/abis/make-withdrawal-credentials.md
+++ b/docs/gitbook/clients/python/abis/make-withdrawal-credentials.md
@@ -1,11 +1,11 @@
 ---
-description: Build 32-byte ETH1 withdrawal credentials
-icon: wrench
+description: Build 32-byte ETH1 withdrawal credentials from an address
+icon: key
 ---
 
-# make_withdrawal_credentials
+# make\_withdrawal\_credentials
 
-Build withdrawal credentials from an Ethereum address.
+Build 32-byte ETH1 withdrawal credentials from an Ethereum address. The returned value is passed as `withdrawal_credentials` when calling [`compute_deposit_data_root`](compute-deposit-data-root.md) and the deposit contract's `deposit()` function.
 
 ## Signature
 
@@ -13,22 +13,53 @@ Build withdrawal credentials from an Ethereum address.
 def make_withdrawal_credentials(address: str) -> bytes
 ```
 
-## Output format
+## Parameters
 
-`0x01 || 11 zero bytes || 20-byte address` (32 bytes total).
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `address` | `str` | Hex-encoded Ethereum address (with or without `0x` prefix) |
 
-## Input rules
+## Returns
 
-- Accepts address with or without `0x`/`0X` prefix
-- Raises `ValueError` if decoded address is not exactly 20 bytes
+`bytes` — 32-byte withdrawal credentials.
+
+Raises `ValueError` if the decoded address is not exactly 20 bytes.
+
+## Output Format
+
+```
+┌──────┬──────────────┬──────────────────────┐
+│ 0x01 │ 11 zero bytes│ 20-byte address      │
+└──────┴──────────────┴──────────────────────┘
+ 1 byte  11 bytes       20 bytes = 32 total
+```
+
+- **`0x01`** — ETH1-style withdrawal credential type byte
+- **11 zero bytes** — reserved padding
+- **20-byte address** — the Ethereum address that can withdraw funds
 
 ## Example
 
 ```python
 from seismic_web3 import make_withdrawal_credentials
 
-withdrawal_credentials = make_withdrawal_credentials(
+credentials = make_withdrawal_credentials(
     "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 )
-print(len(withdrawal_credentials))  # 32
+
+assert len(credentials) == 32
+assert credentials[0] == 0x01
+assert credentials[1:12] == b"\x00" * 11
+print(credentials.hex())
 ```
+
+## Notes
+
+- Accepts addresses with or without `0x`/`0X` prefix
+- Case-insensitive — both checksummed and lowercase addresses produce the same result
+- This function only creates ETH1 credentials (type `0x01`), not BLS credentials (type `0x00`)
+
+## See Also
+
+- [compute\_deposit\_data\_root](compute-deposit-data-root.md) — Uses `withdrawal_credentials` as input
+- [Deposit Contract](deposit-contract.md) — ABI, address, and deposit requirements

--- a/docs/gitbook/clients/python/abis/src20-abi.md
+++ b/docs/gitbook/clients/python/abis/src20-abi.md
@@ -1,44 +1,79 @@
 ---
-description: SRC20 interface ABI constant
-icon: file-code
+description: SRC20 token interface ABI constant
+icon: coins
 ---
 
-# SRC20_ABI
+# SRC20\_ABI
+
+ABI for the `ISRC20` interface — Seismic's privacy-preserving ERC20 standard. Token amounts use shielded types (`suint256`) and `balanceOf()` takes no arguments (uses `msg.sender` internally).
 
 ```python
+from seismic_web3 import SRC20_ABI
+
 SRC20_ABI: list[dict[str, Any]]
 ```
 
-## Included functions
+## Functions
 
-- `name()`
-- `symbol()`
-- `decimals()`
-- `balanceOf()`
-- `approve(address,suint256)`
-- `transfer(address,suint256)`
-- `transferFrom(address,address,suint256)`
+| Function | Parameters | Returns | Mutability | Description |
+| --- | --- | --- | --- | --- |
+| `name()` | — | `string` | `view` | Token name |
+| `symbol()` | — | `string` | `view` | Token symbol |
+| `decimals()` | — | `uint8` | `view` | Token decimals |
+| `balanceOf()` | — | `uint256` | `view` | Caller's balance (no address arg) |
+| `approve` | `spender: address`, `amount: suint256` | `bool` | `nonpayable` | Approve shielded amount |
+| `transfer` | `to: address`, `amount: suint256` | `bool` | `nonpayable` | Transfer shielded amount |
+| `transferFrom` | `from: address`, `to: address`, `amount: suint256` | `bool` | `nonpayable` | Transfer from approved account |
 
-## Included events
+## Events
 
-- `Transfer(address,address,bytes32,bytes)`
-- `Approval(address,address,bytes32,bytes)`
+| Event | Indexed Parameters | Data |
+| --- | --- | --- |
+| `Transfer` | `from: address`, `to: address`, `encryptKeyHash: bytes32` | `encryptedAmount: bytes` |
+| `Approval` | `owner: address`, `spender: address`, `encryptKeyHash: bytes32` | `encryptedAmount: bytes` |
 
-## Notes
+## balanceOf — SRC20 vs ERC20
 
-- `balanceOf()` takes no address argument in this interface.
-- Amount arguments use shielded types in the ABI (`suint256`).
+Standard ERC20:
+
+```solidity
+function balanceOf(address account) external view returns (uint256);
+```
+
+SRC20:
+
+```solidity
+function balanceOf() external view returns (uint256);
+```
+
+In SRC20, `balanceOf()` always returns the **caller's** balance. Use `.read` (a signed read that proves identity), not `.tread`.
 
 ## Example
 
 ```python
+import os
 from eth_abi import decode
-from seismic_web3 import SEISMIC_TESTNET, PrivateKey, SRC20_ABI
+from seismic_web3 import PrivateKey, SEISMIC_TESTNET, SRC20_ABI
 
-pk = PrivateKey.from_hex_str("0x...")
+pk = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 w3 = SEISMIC_TESTNET.wallet_client(pk)
-token = w3.seismic.contract("0xTokenAddress", SRC20_ABI)
 
-raw = token.read.balanceOf()
-balance = decode(["uint256"], bytes(raw))[0]
+token = w3.seismic.contract("0x00000000219ab540356cBB839Cbe05303d7705Fa", SRC20_ABI)
+
+# Transparent metadata (no auth needed)
+name = decode(["string"], bytes(token.tread.name()))[0]
+symbol = decode(["string"], bytes(token.tread.symbol()))[0]
+
+# Shielded balance (signed read)
+balance = decode(["uint256"], bytes(token.read.balanceOf()))[0]
+
+# Shielded transfer
+tx_hash = token.write.transfer("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", 100)
+w3.eth.wait_for_transaction_receipt(tx_hash)
 ```
+
+## See Also
+
+- [SRC20](../src20/) — Token usage guide
+- [Event Watching](../src20/event-watching/) — Decrypt Transfer/Approval events
+- [ShieldedContract](../contract/shielded-contract.md) — `.read`, `.write`, `.tread` namespaces


### PR DESCRIPTION
## Summary
- audit docs/gitbook/clients/python/abis against seismic_web3.abis source
- correct exported constants, helper signatures, and byte-length constraints
- remove unnecessary commentary and keep ABI docs compact
