### PR TITLE
chore(code-workspace): ignore foundry git submodules

### DIFF
--- a/workspace/seismic.code-workspace
+++ b/workspace/seismic.code-workspace
@@ -41,5 +41,16 @@
 			"path": "../../seismic-client"
 		},
 	],
-	"settings": {}
+	"settings": {
+		// We ignore all contract submodules because we basically never make changes to them.
+		// The paths seem to be relative to the seismic root (first repo in the workspace).
+		"git.ignoredRepositories": [
+			"contracts/lib/forge-std",
+			"contracts/lib/openzeppelin-contracts",
+			"contracts/lib/solady",
+			"../seismic-solidity/deps/nlohmann-json",
+			"../seismic-solidity/deps/range-v3",
+			"../seismic-solidity/deps/fmtlib",
+		]
+	}
 }


### PR DESCRIPTION
These are most of the time just getting in the way, as we almost never need to make modifications to external libs we use.