### PR TITLE
test(ts-client): remove dependency on sfoundry repo

### DIFF
--- a/clients/ts/.env.example
+++ b/clients/ts/.env.example
@@ -1,5 +1,4 @@
 SRETH_ROOT=/Users/yourusername/path/to/seismic-reth
-SFOUNDRY_ROOT=/Users/yourusername/path/to/seismic-foundry
 
 # Optional: if you set these args, reth will use these directories
 # to store chain state and static files

--- a/clients/ts/CLAUDE.md
+++ b/clients/ts/CLAUDE.md
@@ -51,7 +51,7 @@ bun run viem:test:anvil  # CHAIN=anvil — needs sanvil (from sfoundryup)
 bun run viem:test:reth   # CHAIN=reth  — needs seismic-reth binary
 ```
 
-**Anvil tests** require `SFOUNDRY_ROOT` env var pointing to a [seismic-foundry](https://github.com/SeismicSystems/seismic-foundry) checkout (with Rust/Cargo installed), OR the `sanvil` binary in PATH. If `SFOUNDRY_ROOT` is set, the test harness builds sanvil from source via `cargo build --bin sanvil`.
+**Anvil tests** require `sanvil` on PATH (install via `mise` or `sfoundryup`).
 
 **Reth tests** require `SRETH_ROOT` pointing to a [seismic-reth](https://github.com/SeismicSystems/seismic-reth) checkout.
 
@@ -115,7 +115,7 @@ GitHub Actions (`.github/workflows/ci.yml`):
 
 - **lint**: ESLint + Prettier on ubuntu-24.04 (Bun 1.2.5)
 - **typecheck**: tsc on ubuntu-24.04
-- **test-anvil**: Self-hosted runner, builds sanvil from `SFOUNDRY_ROOT`, runs anvil tests
+- **test-anvil**: Self-hosted runner, runs anvil tests (sanvil from PATH)
 - **test-devnet**: Self-hosted runner (after test-anvil), builds seismic-reth from `SRETH_ROOT`, runs reth tests
 
 ## Key Concepts
@@ -130,9 +130,7 @@ GitHub Actions (`.github/workflows/ci.yml`):
 
 | Problem                                                     | Fix                                                                                                                                                                                                     |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SFOUNDRY_ROOT env variable must be set to build sanvil`    | Set `SFOUNDRY_ROOT` to your seismic-foundry repo path, or install `sanvil` via `sfoundryup` and modify the test to skip the build step                                                                  |
 | `SRETH_ROOT env variable must be set to build reth`         | Set `SRETH_ROOT` to your seismic-reth repo path (with Rust/Cargo installed)                                                                                                                             |
-| `ENOENT: posix_spawn 'cargo'` when running tests            | `SFOUNDRY_ROOT` is set but Cargo/Rust is not installed. Either install Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh`) or unset `SFOUNDRY_ROOT` if `sanvil` is already in PATH |
 | `react:typecheck` fails with missing types                  | Run `bun run viem:build` first — react typecheck depends on built viem types                                                                                                                            |
 | `Browserslist: browsers data is X months old` on docs build | Harmless warning. Fix with `npx update-browserslist-db@latest` if desired                                                                                                                               |
 | `hideExternalIcon` React prop warning during docs build     | Harmless VoCs warning — safe to ignore                                                                                                                                                                  |

--- a/clients/ts/README.md
+++ b/clients/ts/README.md
@@ -16,7 +16,6 @@ View the docs [here](https://client.seismic.systems)
 Create a `.env` file in the repo root. These variables are only used for running tests. This file should have:
 
 - `SRETH_ROOT`: the path to your local `seismic-reth` directory
-- `SFOUNDRY_ROOT`: the path to your local `seismic-foundry` directory
 
 Optionally, you may set these variables to specify where `reth` will store its state:
 

--- a/clients/ts/packages/seismic-viem-tests/src/process/chains/anvil.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/process/chains/anvil.ts
@@ -1,10 +1,8 @@
 import type { ChildProcess } from 'node:child_process'
-import { existsSync } from 'node:fs'
 
 import {
   killProcess,
   runProcess,
-  waitForProcessExit,
 } from '@sviem-tests/process/manage.ts'
 import {
   NodeProcess,
@@ -14,20 +12,6 @@ import {
 } from '@sviem-tests/process/node.ts'
 
 const DEFAULT_PORT = 8545
-
-export const buildAnvil = async (sfoundryDir: string) => {
-  if (!sfoundryDir || !existsSync(sfoundryDir)) {
-    return
-  }
-
-  const buildProcess = await runProcess('cargo', {
-    args: ['build', '--bin', 'sanvil'],
-    cwd: sfoundryDir,
-    stdio: 'inherit',
-    waitMs: 0,
-  })
-  await waitForProcessExit(buildProcess)
-}
 
 const spawnAnvil = async (
   options: NodeProcessOptions = {}
@@ -46,20 +30,10 @@ const spawnAnvil = async (
     ...parseVerbosity(verbosity),
   ]
 
-  const sfoundryDir = process.env.SFOUNDRY_ROOT
-  if (!sfoundryDir) {
-    return runProcess('sanvil', {
-      args,
-      waitMs,
-      stdio: 'ignore',
-    })
-  }
-
-  await buildAnvil(sfoundryDir)
-  return runProcess('cargo', {
-    args: ['run', '--bin', 'sanvil', '--', ...args],
-    cwd: sfoundryDir,
+  return runProcess('sanvil', {
+    args,
     waitMs,
+    stdio: 'ignore',
   })
 }
 

--- a/clients/ts/packages/seismic-viem-tests/src/process/node.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/process/node.ts
@@ -1,10 +1,7 @@
 import { localSeismicDevnet, sanvil } from 'seismic-viem'
 import type { Chain } from 'viem'
 
-import {
-  buildAnvil,
-  setupAnvilNode,
-} from '@sviem-tests/process/chains/anvil.ts'
+import { setupAnvilNode } from '@sviem-tests/process/chains/anvil.ts'
 import { buildReth, setupRethNode } from '@sviem-tests/process/chains/reth.ts'
 import { ServerProcess } from '@sviem-tests/process/manage.ts'
 
@@ -70,15 +67,6 @@ export const setupNode = async (
 
 export const buildNode = async (chain: Chain) => {
   switch (chain.id) {
-    case sanvil.id: {
-      const sfoundryDir = process.env.SFOUNDRY_ROOT
-      if (!sfoundryDir) {
-        throw new Error(
-          'SFOUNDRY_ROOT env variable must be set to build sanvil'
-        )
-      }
-      return buildAnvil(sfoundryDir)
-    }
     case localSeismicDevnet.id: {
       const srethDir = process.env.SRETH_ROOT
       if (!srethDir) {
@@ -87,6 +75,6 @@ export const buildNode = async (chain: Chain) => {
       return buildReth(srethDir)
     }
     default:
-      throw new Error(`CHAIN should be one of ${CHAIN_OPTIONS}`)
+      return
   }
 }


### PR DESCRIPTION
Running the ts-client's anvil test had the option to pass a seismic-foundry path, and the test framework would cd and run cargo build.
Think keeping this outside and assuming the environment has a sanvil binary installed is better practice. This way we can have mise manage the installation, which will be cached in CI (see massive simplifications in upcoming PR).

Only downside is that with this simplification we can't test against a local build if we have changes to seismic-foundry or its dependency. Think that should be managed by mise as well, the same way we do it for contract tests [here](https://github.com/SeismicSystems/seismic/blob/b9b5cd4902ab0b7e11be422de6e19f819ab73b43/contracts/mise.toml#L49). This way is purely managed by the dev-env (mise) and imo is much cleaner/simpler.