### PR TITLE
tool(claude): update CLAUDE.workspace.md with new client paths

### DIFF
--- a/workspace/CLAUDE.workspace.md
+++ b/workspace/CLAUDE.workspace.md
@@ -34,19 +34,20 @@ seismic/                          # parent directory
 ├── CLAUDE.md                     # symlink -> seismic/workspace/CLAUDE.md
 ├── seismic/                      # monorepo (docs, scripts, workspace config)
 │   ├── workspace/                # cross-repo workspace files (source of truth)
-│   └── contracts/                # Solidity contracts
+│   ├── contracts/                # Solidity contracts
+│   ├── clients/ts/               # TypeScript client (Viem + React)
+│   └── clients/py/               # Python client (Web3.py) 
 ├── seismic-reth/                 # execution client (fork of reth)
-├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
-├── seismic-revm/                 # Mercury EVM (fork of revm)
 ├── seismic-evm/                  # block execution layer (fork of alloy-evm)
+├── seismic-revm/                 # Mercury EVM (fork of revm)
+├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
 ├── seismic-alloy/                # Rust SDK: TxSeismic, providers
 ├── seismic-alloy-core/           # primitives: FlaggedStorage, shielded types (fork of alloy-core)
 ├── seismic-trie/                 # Merkle trie for FlaggedStorage (fork of alloy-trie)
-├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
-├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
 ├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
-├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
-└── seismic-client/               # TypeScript SDK (Viem + Wagmi)
+├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+└── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
 ```
 
 ## Working Across Repos


### PR DESCRIPTION
updating paths after having moved seismic-client to the monorepo.