### PR TITLE
docs: add enclave repo to code workspace and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,20 @@ seismic-workspace/                # parent directory
 ├── seismic/                      # monorepo (docs, scripts, workspace config)
 │   ├── workspace/                # cross-repo workspace files (source of truth)
 │   └── contracts/                # Solidity contracts
+│   ├── clients/ts/               # TypeScript client (Viem + React)
+│   └── clients/py/               # Python client (Web3.py) 
 ├── seismic-reth/                 # execution client (fork of reth)
-├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
-├── seismic-revm/                 # Mercury EVM (fork of revm)
 ├── seismic-evm/                  # block execution layer (fork of alloy-evm)
+├── seismic-revm/                 # Mercury EVM (fork of revm)
+├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
 ├── seismic-alloy/                # Rust SDK: TxSeismic, providers
 ├── seismic-alloy-core/           # primitives: FlaggedStorage, shielded types (fork of alloy-core)
 ├── seismic-trie/                 # Merkle trie for FlaggedStorage (fork of alloy-trie)
-├── seismic-revm-inspectors/      # EVM tracing (fork of revm-inspectors)
-├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
 ├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
-├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
-└── seismic-client/               # TypeScript SDK (Viem + Wagmi)
+├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
+├── enclave/                      # TEE enclave server and contracts
+└── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
 ```
 
 After cloning, create symlinks for the cross-repo workspace config:

--- a/workspace/CLAUDE.workspace.md
+++ b/workspace/CLAUDE.workspace.md
@@ -47,7 +47,8 @@ seismic/                          # parent directory
 ├── seismic-foundry/              # dev tools: sforge, sanvil, scast (fork of foundry)
 ├── seismic-foundry-fork-db/      # fork DB with FlaggedStorage (fork of foundry-fork-db)
 ├── seismic-compilers/            # compiler integration for sforge (fork of foundry-compilers)
-└── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
+├── enclave/                      # TEE enclave server and contracts
+├── seismic-solidity/             # Solidity compiler with shielded types (fork of solidity)
 ```
 
 ## Working Across Repos

--- a/workspace/cargo-local-patches.toml
+++ b/workspace/cargo-local-patches.toml
@@ -56,3 +56,8 @@ alloy-seismic-evm = { path = "./seismic-evm/crates/seismic-evm" }
 
 # seismic-foundry-fork-db
 foundry-fork-db = { path = "./seismic-foundry-fork-db" }
+
+# enclave
+seismic-enclave = { path = "./enclave/crates/enclave" }
+seismic-enclave-server = { path = "./enclave/crates/enclave-server" }
+enclave-contract = { path = "./enclave/crates/enclave-contract" }

--- a/workspace/seismic.code-workspace
+++ b/workspace/seismic.code-workspace
@@ -26,6 +26,9 @@
 			"path": "../../seismic-trie"
 		},
 		{
+			"path": "../../enclave"
+		},
+		{
 			"path": "../../seismic-foundry"
 		},
 		{


### PR DESCRIPTION
Realized enclave repo was missing in code.workspace, readme, and CLAUDE.md.