### PR TITLE
pin axios to 1.8.3 to block supply chain attack

### DIFF
--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -49,5 +49,8 @@
   },
   "dependencies": {
     "caniuse-lite": "^1.0.30001751"
+  },
+  "overrides": {
+    "axios": "1.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- Axios 1.14.1 contains a supply chain attack. We don't use axios directly, but `@slack/web-api` pulls it in transitively with a `^1.7.8` range that would resolve to the compromised version on next `bun install`.
- Adds an `overrides` section pinning axios to 1.8.3 (the version currently in our lock file) so installs are a no-op until this is resolved upstream.

## Test plan
- [ ] Verify `bun install` produces no lock file changes