### PR TITLE
docs(seismic-viem): update gitbook for smart routing

### DIFF
--- a/docs/gitbook/clients/typescript/viem/README.md
+++ b/docs/gitbook/clients/typescript/viem/README.md
@@ -26,21 +26,20 @@ const client = await createShieldedWalletClient({
   account: privateKeyToAccount("0x..."),
 });
 
-// Shielded write — calldata encrypted automatically
+// Smart write — auto-detects shielded params, encrypts only when needed
 const hash = await client.writeContract({
   address: "0x...",
   abi: myContractAbi,
-  functionName: "transfer",
+  functionName: "transfer", // has suint256/saddress params → encrypted automatically
   args: ["0x...", 100n],
 });
 
-// Signed read — proves caller identity
+// Smart read — auto-detects shielded params, uses signed read only when needed
 const balance = await client.readContract({
   address: "0x...",
   abi: myContractAbi,
-  functionName: "balanceOf",
+  functionName: "balanceOf", // has saddress param → signed read automatically
   args: ["0x..."],
-  account: client.account,
 });
 ```
 
@@ -52,7 +51,7 @@ seismic-viem
 │   ├── createShieldedPublicClient  — read-only, TEE key, precompiles
 │   └── createShieldedWalletClient  — full capabilities, encryption pipeline
 ├── Contract Layer
-│   ├── getShieldedContract          — .read / .write / .tread / .twrite / .dwrite
+│   ├── getShieldedContract          — .read / .write (smart) / .sread / .swrite (force shielded) / .tread / .twrite (force transparent) / .dwrite
 │   ├── shieldedWriteContract        — standalone encrypted write
 │   └── signedReadContract           — standalone signed read
 ├── Chain Configs
@@ -90,7 +89,7 @@ seismic-viem
 
 | Section               | Description                                                                 |
 | --------------------- | --------------------------------------------------------------------------- |
-| **Contract Instance** | `getShieldedContract` for `.read`, `.write`, `.tread`, `.twrite`, `.dwrite` |
+| **Contract Instance** | `getShieldedContract` for `.read`, `.write` (smart), `.sread`, `.swrite` (force shielded), `.tread`, `.twrite` (force transparent), `.dwrite` |
 | **Shielded Writes**   | Encrypt calldata and send Seismic transactions (type 0x4A)                  |
 | **Signed Reads**      | Prove caller identity in `eth_call` via `seismic_call`                      |
 
@@ -107,7 +106,8 @@ seismic-viem
 - **Shielded Transactions** -- Encrypt calldata with TEE public key via AES-GCM before sending
 - **Signed Reads** -- Prove identity in `eth_call` with signed read requests
 - **Two Client Types** -- `createShieldedPublicClient` (read-only) and `createShieldedWalletClient` (full capabilities)
-- **Contract Abstraction** -- `getShieldedContract` provides `.read`, `.write`, `.tread`, `.twrite`, and `.dwrite` methods
+- **Smart Routing** -- `.read` and `.write` auto-detect shielded parameters and route to the correct path
+- **Contract Abstraction** -- `getShieldedContract` provides `.read`, `.write` (smart), `.sread`, `.swrite` (force shielded), `.tread`, `.twrite` (force transparent), and `.dwrite` methods
 - **Automatic Encryption Pipeline** -- Calldata encryption handled transparently in the client layer
 - **Type 0x4A Transactions** -- Native support for Seismic transaction type with custom chain formatters
 - **Precompile Bindings** -- TypeScript wrappers for all Seismic precompiles (RNG, ECDH, AES-GCM, HKDF, secp256k1)

--- a/docs/gitbook/clients/typescript/viem/contract-instance.md
+++ b/docs/gitbook/clients/typescript/viem/contract-instance.md
@@ -1,11 +1,11 @@
 ---
-description: Type-safe shielded contract instances with read/write/tread/twrite/dwrite namespaces
+description: Type-safe shielded contract instances with smart routing and read/write/sread/swrite/tread/twrite/dwrite namespaces
 icon: file-contract
 ---
 
 # Contract Instance
 
-`getShieldedContract` creates a type-safe contract instance with five namespaces for interacting with shielded contracts. It extends viem's `getContract` with Seismic-specific read and write patterns, giving you a single object that covers encrypted writes, signed reads, transparent operations, and debug inspection.
+`getShieldedContract` creates a type-safe contract instance with seven namespaces for interacting with shielded contracts. It extends viem's `getContract` with Seismic-specific read and write patterns, giving you a single object that covers smart routing, encrypted writes, signed reads, transparent operations, and debug inspection.
 
 ```typescript
 import { getShieldedContract } from "seismic-viem";
@@ -27,7 +27,7 @@ const abi = [
     name: "balanceOf",
     type: "function",
     stateMutability: "view",
-    inputs: [{ name: "account", type: "address" }],
+    inputs: [{ name: "account", type: "saddress" }],
     outputs: [{ name: "", type: "uint256" }],
   },
   {
@@ -35,8 +35,8 @@ const abi = [
     type: "function",
     stateMutability: "nonpayable",
     inputs: [
-      { name: "to", type: "address" },
-      { name: "amount", type: "uint256" },
+      { name: "to", type: "saddress" },
+      { name: "amount", type: "suint256" },
     ],
     outputs: [{ name: "", type: "bool" }],
   },
@@ -52,8 +52,8 @@ const abi = [
     type: "function",
     stateMutability: "nonpayable",
     inputs: [
-      { name: "spender", type: "address" },
-      { name: "amount", type: "uint256" },
+      { name: "spender", type: "saddress" },
+      { name: "amount", type: "suint256" },
     ],
     outputs: [{ name: "", type: "bool" }],
   },
@@ -68,40 +68,65 @@ const contract = getShieldedContract({
 
 ## Namespaces
 
-The returned `ShieldedContract` exposes five namespaces. Each namespace provides every function defined in the ABI, but differs in how calldata is handled and who appears as `msg.sender` on-chain.
+The returned `ShieldedContract` exposes seven namespaces. Each namespace provides every function defined in the ABI, but differs in how calldata is handled and who appears as `msg.sender` on-chain.
 
-| Namespace | Operation Type    | Calldata  | msg.sender       | Description                             |
-| --------- | ----------------- | --------- | ---------------- | --------------------------------------- |
-| `.read`   | Signed Read       | Encrypted | Signer's address | Authenticated read -- proves identity   |
-| `.write`  | Shielded Write    | Encrypted | Signer's address | Encrypted transaction                   |
-| `.tread`  | Transparent Read  | Plaintext | Zero address     | Standard viem read                      |
-| `.twrite` | Transparent Write | Plaintext | Signer's address | Standard viem write                     |
-| `.dwrite` | Debug Write       | Encrypted | Signer's address | Returns plaintext + encrypted tx + hash |
+| Namespace | Operation Type    | Calldata        | msg.sender       | Description                                         |
+| --------- | ----------------- | --------------- | ---------------- | --------------------------------------------------- |
+| `.read`   | Smart Read        | Auto-detected   | Auto-detected    | Inspects ABI -- shielded if shielded params, else transparent |
+| `.write`  | Smart Write       | Auto-detected   | Signer's address | Inspects ABI -- shielded if shielded params, else transparent |
+| `.sread`  | Force Signed Read | Encrypted       | Signer's address | Always authenticated read -- proves identity        |
+| `.swrite` | Force Shielded    | Encrypted       | Signer's address | Always encrypted transaction                        |
+| `.tread`  | Transparent Read  | Plaintext       | Zero address     | Always standard read                                |
+| `.twrite` | Transparent Write | Plaintext       | Signer's address | Always standard write                               |
+| `.dwrite` | Debug Write       | Encrypted       | Signer's address | Returns plaintext + encrypted tx + hash             |
 
 ---
 
-### `.read` -- Signed Read
+### `.read` / `.write` -- Smart Routing
 
-Sends an encrypted, signed `eth_call` that proves your identity to the contract. Use this when the contract checks `msg.sender` in a view function to gate access to shielded data.
+The default `.read` and `.write` namespaces **auto-detect** whether a function has shielded parameters (`suint*`, `sint*`, `sbool`, `saddress`, `sbytes*`, including nested in tuples and arrays). If any input parameter is shielded, the call is routed to the shielded path; otherwise it uses the transparent path.
 
 ```typescript
+// transfer() has saddress and suint256 params → shielded write (type 0x4A)
+const hash = await contract.write.transfer(["0x1234...", 100n]);
+
+// totalSupply() has no shielded params → transparent read
+const supply = await contract.read.totalSupply();
+
+// balanceOf() has saddress param → signed read (encrypted, proves identity)
 const balance = await contract.read.balanceOf(["0x1234..."]);
 ```
 
 {% hint style="info" %}
-The `.read` namespace always sets `account` to `client.account` for security. This ensures the signed read is authenticated with the wallet's address, regardless of any `account` override you pass.
+Smart routing inspects **input parameters** only. If a function has no shielded inputs but you still want an encrypted read (e.g., because the return value is sensitive), use `.sread` instead.
+{% endhint %}
+
+---
+
+### `.sread` -- Force Signed Read
+
+Always sends an encrypted, signed `eth_call` that proves your identity to the contract, regardless of whether the function has shielded parameters. Use this when you want the response encrypted or when the contract checks `msg.sender` in a view function with no shielded inputs.
+
+```typescript
+// Force signed read even though totalSupply() has no shielded params
+const supply = await contract.sread.totalSupply();
+```
+
+{% hint style="info" %}
+The `.sread` namespace always sets `account` to `client.account` for security. This ensures the signed read is authenticated with the wallet's address, regardless of any `account` override you pass.
 {% endhint %}
 
 See [Signed Reads](signed-reads.md) for details on how signed reads work under the hood.
 
 ---
 
-### `.write` -- Shielded Write
+### `.swrite` -- Force Shielded Write
 
-Encrypts calldata before broadcasting the transaction. The calldata is not visible on-chain.
+Always encrypts calldata before broadcasting the transaction, regardless of whether the function has shielded parameters. The calldata is not visible on-chain.
 
 ```typescript
-const hash = await contract.write.transfer(["0x1234...", 100n], {
+// Force shielded write even though approve() might not need encryption
+const hash = await contract.swrite.approve(["0x1234...", 100n], {
   gas: 100_000n,
 });
 ```
@@ -112,7 +137,7 @@ See [Shielded Writes](shielded-writes.md) for the encryption lifecycle and secur
 
 ### `.tread` -- Transparent Read
 
-Standard viem `readContract` call with plaintext calldata. The `from` address is set to the zero address, so `msg.sender` inside the contract will be `0x0000...0000`.
+Standard read call with plaintext calldata. The `from` address is set to the zero address, so `msg.sender` inside the contract will be `0x0000...0000`. Works with both standard and shielded-typed functions (the ABI types are remapped automatically for encoding).
 
 ```typescript
 const supply = await contract.tread.totalSupply();
@@ -124,7 +149,7 @@ Use `.tread` for public view functions that do not depend on `msg.sender`.
 
 ### `.twrite` -- Transparent Write
 
-Standard viem `writeContract` call with plaintext (unencrypted) calldata. The transaction is signed by the wallet, so `msg.sender` is the signer's address.
+Standard write call with plaintext (unencrypted) calldata. The transaction is signed by the wallet, so `msg.sender` is the signer's address. Works with both standard and shielded-typed functions (the ABI types are remapped automatically for encoding).
 
 ```typescript
 const hash = await contract.twrite.approve(["0x1234...", 100n]);
@@ -136,7 +161,7 @@ Use `.twrite` when you intentionally want calldata to be visible on-chain (e.g.,
 
 ### `.dwrite` -- Debug Write
 
-Builds the same encrypted transaction as `.write`, but returns the plaintext transaction, the shielded transaction, and the transaction hash without broadcasting. Useful for inspecting what the SDK produces before sending.
+Builds the same encrypted transaction as `.swrite`, but returns the plaintext transaction, the shielded transaction, and the transaction hash. Useful for inspecting what the SDK produces before sending.
 
 ```typescript
 const { plaintextTx, shieldedTx, txHash } = await contract.dwrite.transfer([

--- a/docs/gitbook/clients/typescript/viem/shielded-wallet-client.md
+++ b/docs/gitbook/clients/typescript/viem/shielded-wallet-client.md
@@ -57,7 +57,8 @@ const walletClient = await createShieldedWalletClient({
   account: privateKeyToAccount("0x..."),
 });
 
-// Shielded write -- calldata is encrypted
+// Smart write -- auto-detects shielded params in the ABI
+// transfer(saddress, suint256) has shielded params → encrypted seismic tx
 const hash = await walletClient.writeContract({
   address: "0xContractAddress",
   abi: contractAbi,
@@ -65,7 +66,8 @@ const hash = await walletClient.writeContract({
   args: ["0xRecipient", 1000n],
 });
 
-// Signed read -- authenticated eth_call
+// Smart read -- auto-detects shielded params in the ABI
+// balanceOf(saddress) has shielded params → signed read
 const balance = await walletClient.readContract({
   address: "0xContractAddress",
   abi: contractAbi,
@@ -88,15 +90,17 @@ When you call `createShieldedWalletClient()`, the following steps happen:
 
 ### Shielded Wallet Actions
 
-| Action                            | Description                                                                             |
-| --------------------------------- | --------------------------------------------------------------------------------------- |
-| `writeContract(params)`           | Shielded write -- encrypts calldata with the AES key before sending                     |
-| `twriteContract(params)`          | Transparent write -- standard viem `writeContract` (unencrypted calldata)               |
-| `dwriteContract(params)`          | Debug write -- returns the plaintext tx, encrypted tx, and tx hash without broadcasting |
-| `readContract(params)`            | Signed read -- authenticated `eth_call` that proves the caller's identity               |
-| `treadContract(params)`           | Transparent read -- standard viem `readContract` (unsigned call)                        |
-| `signedCall(params)`              | Low-level signed `eth_call`                                                             |
-| `sendShieldedTransaction(params)` | Low-level shielded transaction send                                                     |
+| Action                            | Description                                                                                                        |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `writeContract(params)`           | Smart write -- inspects ABI for shielded params; encrypts if shielded, sends transparent otherwise                 |
+| `swriteContract(params)`          | Force shielded write -- always encrypts calldata with the AES key before sending                                   |
+| `twriteContract(params)`          | Transparent write -- always sends with plaintext calldata (unencrypted)                                            |
+| `dwriteContract(params)`          | Debug write -- returns the plaintext tx, encrypted tx, and tx hash without broadcasting                            |
+| `readContract(params)`            | Smart read -- inspects ABI for shielded params; uses signed read if shielded, transparent read otherwise            |
+| `sreadContract(params)`           | Force signed read -- always authenticated `eth_call` that proves the caller's identity                             |
+| `treadContract(params)`           | Transparent read -- always standard unsigned call                                                                  |
+| `signedCall(params)`              | Low-level signed `eth_call`                                                                                        |
+| `sendShieldedTransaction(params)` | Low-level shielded transaction send                                                                                |
 
 ### Encryption Actions
 

--- a/docs/gitbook/clients/typescript/viem/shielded-writes.md
+++ b/docs/gitbook/clients/typescript/viem/shielded-writes.md
@@ -7,12 +7,15 @@ icon: pen
 
 Shielded writes encrypt transaction calldata before submission. This prevents calldata from being visible on-chain -- an observer can see that a transaction was sent to a particular contract address, but not what function was called or what arguments were passed.
 
-seismic-viem provides two approaches:
+seismic-viem provides several approaches:
 
-- **`shieldedWriteContract()`** -- standalone function, same API shape as viem's `writeContract`
-- **`contract.write.functionName()`** -- via a `ShieldedContract` from [getShieldedContract](contract-instance.md)
+- **`contract.write.functionName()`** -- smart routing via [getShieldedContract](contract-instance.md). Auto-detects shielded parameters and encrypts only when needed.
+- **`contract.swrite.functionName()`** -- force shielded via [getShieldedContract](contract-instance.md). Always encrypts, regardless of parameter types.
+- **`shieldedWriteContract()`** -- standalone function, same API shape as viem's `writeContract`. Always encrypts.
+- **`walletClient.writeContract()`** -- smart routing via the wallet client. Same auto-detection as `contract.write`.
+- **`walletClient.swriteContract()`** -- force shielded via the wallet client. Always encrypts.
 
-Both produce the same on-chain result: an encrypted type `0x4A` Seismic transaction.
+The shielded paths all produce the same on-chain result: an encrypted type `0x4A` Seismic transaction.
 
 ## Standalone: `shieldedWriteContract`
 
@@ -94,7 +97,7 @@ const hash = await client.sendShieldedTransaction({
 
 ## How It Works
 
-When you call `shieldedWriteContract` (or `contract.write.functionName`), the SDK performs the following steps:
+When you call `shieldedWriteContract` (or `contract.swrite.functionName`), the SDK performs the following steps:
 
 1. **ABI-encode** the function call into plaintext calldata
 2. **Build Seismic metadata** -- encryption nonce, recent block hash, expiry block

--- a/docs/gitbook/clients/typescript/viem/signed-reads.md
+++ b/docs/gitbook/clients/typescript/viem/signed-reads.md
@@ -12,19 +12,25 @@ On standard Ethereum, `eth_call` can spoof any `from` address -- there is no sig
 Contracts can use `msg.sender` in view functions to gate access to shielded data. A common example: a token contract with a `balanceOf()` that takes no arguments and uses `msg.sender` internally to look up the caller's balance. Without a signed read, the contract sees the zero address and returns that address's balance -- which is almost certainly zero.
 
 ```typescript
-// Signed read -- msg.sender = your address
+// Smart read -- balanceOf(saddress) has shielded param → signed read automatically
 const myBalance = await contract.read.balanceOf(["0x1234..."]);
 
-// Transparent read -- msg.sender = zero address
-const totalSupply = await contract.tread.totalSupply();
+// Smart read -- totalSupply() has no shielded params → transparent read automatically
+const totalSupply = await contract.read.totalSupply();
+
+// Force signed read -- always encrypted, even for non-shielded functions
+const supply = await contract.sread.totalSupply();
 ```
 
-seismic-viem provides two approaches:
+seismic-viem provides several approaches:
 
-- **`signedReadContract()`** -- standalone function, same API shape as viem's `readContract`
-- **`contract.read.functionName()`** -- via a `ShieldedContract` from [getShieldedContract](contract-instance.md)
+- **`contract.read.functionName()`** -- smart routing via [getShieldedContract](contract-instance.md). Auto-detects shielded parameters and uses signed read only when needed.
+- **`contract.sread.functionName()`** -- force signed read via [getShieldedContract](contract-instance.md). Always uses signed read regardless of parameter types.
+- **`signedReadContract()`** -- standalone function, same API shape as viem's `readContract`. Always uses signed read.
+- **`walletClient.readContract()`** -- smart routing via the wallet client. Same auto-detection as `contract.read`.
+- **`walletClient.sreadContract()`** -- force signed read via the wallet client. Always uses signed read.
 
-Both encrypt the calldata, sign it, and decrypt the response automatically.
+The signed read paths all encrypt the calldata, sign it, and decrypt the response automatically.
 
 ---
 
@@ -84,7 +90,7 @@ const result = await signedCall(client, {
 
 ## How It Works
 
-When you call `signedReadContract` (or `contract.read.functionName`), the SDK performs the following steps:
+When you call `signedReadContract` (or `contract.sread.functionName`), the SDK performs the following steps:
 
 1. **ABI-encode** the function call into plaintext calldata
 2. **Build Seismic metadata** with `signedRead: true`
@@ -101,23 +107,27 @@ Both the calldata you send and the result you receive are encrypted. An observer
 
 ## Signed Read vs Transparent Read
 
-| Aspect       | `.read` (Signed)                           | `.tread` (Transparent)    |
-| ------------ | ------------------------------------------ | ------------------------- |
-| Calldata     | Encrypted                                  | Plaintext                 |
-| `msg.sender` | Signer's address                           | Zero address              |
-| Use case     | Shielded data gated by `msg.sender`        | Public view functions     |
-| Performance  | Slightly slower (sign + encrypt + decrypt) | Standard `eth_call` speed |
+| Aspect       | `.read` (Smart)                            | `.sread` (Force Signed)                    | `.tread` (Transparent)    |
+| ------------ | ------------------------------------------ | ------------------------------------------ | ------------------------- |
+| Calldata     | Auto-detected by ABI                       | Always encrypted                           | Always plaintext          |
+| `msg.sender` | Signer if shielded, zero if not            | Always signer's address                    | Always zero address       |
+| Use case     | Default -- handles most cases              | Force encryption for sensitive returns     | Public view functions     |
+| Performance  | Optimal -- encrypts only when needed       | Slightly slower (sign + encrypt + decrypt) | Standard `eth_call` speed |
 
 ```typescript
-// Signed read -- proves identity, encrypted calldata
+// Smart read -- auto-detects: balanceOf(saddress) → signed, totalSupply() → transparent
 const myBalance = await contract.read.balanceOf(["0x1234..."]);
+const totalSupply = await contract.read.totalSupply();
 
-// Transparent read -- no identity, plaintext calldata
-const totalSupply = await contract.tread.totalSupply();
+// Force signed read -- always encrypted
+const supply = await contract.sread.totalSupply();
+
+// Force transparent read -- always plaintext
+const supply2 = await contract.tread.totalSupply();
 ```
 
 {% hint style="info" %}
-Signed reads are critical for any contract that checks `msg.sender` in view functions to gate shielded data access. If you are unsure whether a view function depends on `msg.sender`, use `.read` -- it is always safe, just slightly slower than `.tread`.
+The smart `.read` namespace handles most cases correctly by inspecting the ABI. Use `.sread` when you need the response encrypted even though the function has no shielded input parameters. Use `.tread` only for public data where you don't need authentication.
 {% endhint %}
 
 ## See Also


### PR DESCRIPTION
## Summary

Updates the seismic-viem gitbook documentation to reflect the new smart routing API introduced in #142.

- **contract-instance.md** — 5 namespaces → 7. Documents `.read`/`.write` (smart), `.sread`/`.swrite` (force shielded), `.tread`/`.twrite` (force transparent), `.dwrite`. Updated namespace table, ABI examples use shielded types.
- **shielded-wallet-client.md** — Actions table adds `sreadContract`/`swriteContract`, updates `readContract`/`writeContract` descriptions to "smart".
- **shielded-writes.md** — Lists all write approaches (smart, force shielded, standalone).
- **signed-reads.md** — Lists all read approaches, 3-column comparison table (smart/force/transparent).
- **README.md** — Updated architecture diagram, feature list, quick example.

## Test plan

- [x] Verify docs render correctly on GitBook