### PR TITLE
fix(docs): use lowercase addresses in src20-factory api.md examples

### DIFF
--- a/docs/gitbook/getting-started/src20-factory/api.md
+++ b/docs/gitbook/getting-started/src20-factory/api.md
@@ -35,24 +35,28 @@ GET http://localhost:3001/api/tokens
   "count": 2,
   "tokens": [
     {
-      "address": "0xabc...",
+      "address": "0xabc123...",
       "name": "My Private Token",
       "symbol": "MPT",
       "decimals": 18,
-      "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "owner": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
       "total_supply": "1000000000000000000000000"
     },
     {
-      "address": "0xdef...",
+      "address": "0xdef456...",
       "name": "Another Token",
       "symbol": "AT",
       "decimals": 6,
-      "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "owner": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
       "total_supply": "500000000000"
     }
   ]
 }
 ```
+
+{% hint style="info" %}
+Addresses are returned as lowercase hex, not EIP-55 checksummed.
+{% endhint %}
 
 Note that `total_supply` is always in base units (not scaled by decimals).
 
@@ -75,7 +79,7 @@ GET http://localhost:3001/api/token/0xabc...
   "name": "My Private Token",
   "symbol": "MPT",
   "decimals": 18,
-  "owner": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+  "owner": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "total_supply": "1000000000000000000000000"
 }
 ```


### PR DESCRIPTION
## Summary

The Rust API (`packages/api`) serializes addresses using Alloy's `format!("{:?}", addr)`, which outputs lowercase hex — not EIP-55 checksummed. The response examples in `api.md` showed checksummed addresses, which don't match what the server actually returns.

## Changes

- `docs/gitbook/getting-started/src20-factory/api.md` — updated both response examples to use lowercase addresses and added a hint callout

## Verification

Built and ran the API server locally, curled both endpoints, confirmed address format:
```
"address": "0x7259e777cf18495d82c3c25df55907393975dd56"  ← lowercase
"owner":   "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"  ← lowercase
```