### PR TITLE
ci: bail on first test failure in bun test

### DIFF
--- a/clients/ts/bunfig.toml
+++ b/clients/ts/bunfig.toml
@@ -6,3 +6,6 @@ semicolons = false
 [install]
 # This ensures Bun installs packages in a way compatible with workspaces
 hoistingLimits = "workspaces"
+
+[test]
+bail = 1


### PR DESCRIPTION
## Summary
- Adds `bail = 1` to `[test]` section in `clients/ts/bunfig.toml`
- `bun test` now exits on the first test failure instead of running all remaining tests

## Motivation
In PR #142's final test-sreth run, the first test failed at 19:30:27 but bun kept running the remaining 44 tests until 19:32:21 — wasting ~114 seconds on tests that were all going to fail due to cascading nonce issues. With `bail = 1`, CI stops at the first failure and reports it immediately.