### PR TITLE
ci: merge lint, typecheck, build into single check job

### DIFF
--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -16,32 +16,18 @@ defaults:
     working-directory: clients/ts
 
 jobs:
-  lint:
+  check:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
       - run: mise run lint::check
-
-  typecheck:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v2
       - run: mise run typecheck
-
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: jdx/mise-action@v2
       - run: mise run build
 
   test-sanvil:
-    needs: [lint, typecheck, build]
+    needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -50,7 +36,7 @@ jobs:
       - run: mise run test::sanvil
 
   test-sreth:
-    needs: [lint, typecheck, build]
+    needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Combines the separate `lint`, `typecheck`, and `build` jobs into a single `check` job in `client-ts.yml`

## Motivation
Today if `lint` fails, `typecheck` and `build` still run to completion on their own runners. Combining them into one job means a `lint` failure kills the step and skips the rest immediately. The wall clock difference is negligible (~83s combined vs ~37s parallel) since each step is only ~25-30s.