### PR TITLE
ci: merge contracts test and fmt-check into single job

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -12,16 +12,7 @@ defaults:
     working-directory: contracts
 
 jobs:
-  contracts-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - uses: jdx/mise-action@v2
-      - run: mise run test
-
-  contracts-fmt-check:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,3 +20,4 @@ jobs:
           submodules: recursive
       - uses: jdx/mise-action@v2
       - run: mise run fmt-check
+      - run: mise run test


### PR DESCRIPTION
## Summary
- Combines `contracts-test` and `contracts-fmt-check` into a single `check` job in `contracts.yml`
- `fmt-check` runs first (fast fail) followed by `test`

## Motivation
Both jobs do identical setup (checkout with submodules + mise install). Combining them saves one runner spin-up and one full mise install cycle.