### PR TITLE
chore(clients): remove hardcoded gas, use signed estimateGas for transparent txs

### DIFF
--- a/clients/py/src/seismic_web3/contract/shielded.py
+++ b/clients/py/src/seismic_web3/contract/shielded.py
@@ -23,9 +23,11 @@ from seismic_web3.contract.abi import (
 )
 from seismic_web3.transaction.send import (
     async_debug_send_shielded_transaction,
+    async_estimate_transparent_gas,
     async_send_shielded_transaction,
     async_signed_call,
     debug_send_shielded_transaction,
+    estimate_transparent_gas,
     send_shielded_transaction,
     signed_call,
 )
@@ -192,16 +194,26 @@ class _TransparentWriteNamespace:
         w3: Web3,
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
+        private_key: PrivateKey | None = None,
     ) -> None:
         self._w3 = w3
         self._address = address
         self._abi = abi
+        self._private_key = private_key
 
     def __getattr__(self, fn_name: str) -> Callable[..., HexBytes]:
         """Return a callable that sends a standard transaction for ``fn_name``."""
 
         def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
+            if "gas" not in tx_params and self._private_key is not None:
+                tx_params["gas"] = estimate_transparent_gas(
+                    self._w3,
+                    to=self._address,
+                    data=data.to_0x_hex(),
+                    value=value,
+                    private_key=self._private_key,
+                )
             tx: dict[str, Any] = {
                 "to": self._address,
                 "data": data.to_0x_hex(),
@@ -286,13 +298,21 @@ class _SmartWriteNamespace:
                     eip712=self._eip712,
                 )
             else:
+                estimated_gas = gas
+                if estimated_gas is None:
+                    estimated_gas = estimate_transparent_gas(
+                        self._w3,
+                        to=self._address,
+                        data=data.to_0x_hex(),
+                        value=value,
+                        private_key=self._private_key,
+                    )
                 tx: dict[str, Any] = {
                     "to": self._address,
                     "data": data.to_0x_hex(),
                     "value": value,
+                    "gas": estimated_gas,
                 }
-                if gas is not None:
-                    tx["gas"] = gas
                 if gas_price is not None:
                     tx["gasPrice"] = gas_price
                 return self._w3.eth.send_transaction(tx)
@@ -499,16 +519,26 @@ class _AsyncTransparentWriteNamespace:
         w3: AsyncWeb3,
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
+        private_key: PrivateKey | None = None,
     ) -> None:
         self._w3 = w3
         self._address = address
         self._abi = abi
+        self._private_key = private_key
 
     def __getattr__(self, fn_name: str) -> Callable[..., Any]:
         """Return an async callable that sends a standard transaction."""
 
         async def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
+            if "gas" not in tx_params and self._private_key is not None:
+                tx_params["gas"] = await async_estimate_transparent_gas(
+                    self._w3,
+                    to=self._address,
+                    data=data.to_0x_hex(),
+                    value=value,
+                    private_key=self._private_key,
+                )
             tx: dict[str, Any] = {
                 "to": self._address,
                 "data": data.to_0x_hex(),
@@ -593,13 +623,21 @@ class _AsyncSmartWriteNamespace:
                     eip712=self._eip712,
                 )
             else:
+                estimated_gas = gas
+                if estimated_gas is None:
+                    estimated_gas = await async_estimate_transparent_gas(
+                        self._w3,
+                        to=self._address,
+                        data=data.to_0x_hex(),
+                        value=value,
+                        private_key=self._private_key,
+                    )
                 tx: dict[str, Any] = {
                     "to": self._address,
                     "data": data.to_0x_hex(),
                     "value": value,
+                    "gas": estimated_gas,
                 }
-                if gas is not None:
-                    tx["gas"] = gas
                 if gas_price is not None:
                     tx["gasPrice"] = gas_price
                 return await self._w3.eth.send_transaction(tx)
@@ -736,7 +774,12 @@ class ShieldedContract:
             abi,
             eip712=eip712,
         )
-        self.twrite = _TransparentWriteNamespace(w3, address, abi)
+        self.twrite = _TransparentWriteNamespace(
+            w3,
+            address,
+            abi,
+            private_key=private_key,
+        )
         self.tread = _TransparentReadNamespace(w3, address, abi)
         self.dwrite = _ShieldedDebugWriteNamespace(
             w3,
@@ -823,7 +866,12 @@ class AsyncShieldedContract:
             abi,
             eip712=eip712,
         )
-        self.twrite = _AsyncTransparentWriteNamespace(w3, address, abi)
+        self.twrite = _AsyncTransparentWriteNamespace(
+            w3,
+            address,
+            abi,
+            private_key=private_key,
+        )
         self.tread = _AsyncTransparentReadNamespace(w3, address, abi)
         self.dwrite = _AsyncShieldedDebugWriteNamespace(
             w3,

--- a/clients/py/src/seismic_web3/module.py
+++ b/clients/py/src/seismic_web3/module.py
@@ -30,9 +30,11 @@ from seismic_web3.contract.shielded import AsyncShieldedContract, ShieldedContra
 from seismic_web3.rpc import async_get_tee_public_key, get_tee_public_key
 from seismic_web3.transaction.send import (
     async_debug_send_shielded_transaction,
+    async_estimate_transparent_gas,
     async_send_shielded_transaction,
     async_signed_call,
     debug_send_shielded_transaction,
+    estimate_transparent_gas,
     send_shielded_transaction,
     signed_call,
 )
@@ -45,13 +47,6 @@ if TYPE_CHECKING:
     from seismic_web3._types import CompressedPublicKey, PrivateKey
     from seismic_web3.client import EncryptionState
     from seismic_web3.transaction_types import DebugWriteResult, SeismicSecurityParams
-
-#: Hardcoded gas limit for deposit transactions.  Unsigned
-#: ``eth_estimateGas`` zeroes ``value`` (to prevent InsufficientFunds
-#: from the zero address), which causes payable-minimum-check reverts.
-#: Providing an explicit gas skips the estimate entirely.
-#: TODO: remove once signed eth_estimateGas works for transparent txs.
-_DEPOSIT_GAS = 500_000
 
 
 # ---------------------------------------------------------------------------
@@ -468,16 +463,15 @@ class SeismicNamespace(SeismicPublicNamespace):
                 deposit_data_root,
             ],
         )
-        # Explicit gas avoids unsigned eth_estimateGas, which zeroes
-        # value and causes "deposit value too low" reverts.
-        # TODO: remove once signed eth_estimateGas works
+        gas = estimate_transparent_gas(
+            self._w3,
+            to=address,
+            data=data.to_0x_hex(),
+            value=value,
+            private_key=self._private_key,
+        )
         return self._w3.eth.send_transaction(
-            {
-                "to": address,
-                "data": data.to_0x_hex(),
-                "value": value,
-                "gas": _DEPOSIT_GAS,
-            },
+            {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},
         )
 
 
@@ -717,14 +711,13 @@ class AsyncSeismicNamespace(AsyncSeismicPublicNamespace):
                 deposit_data_root,
             ],
         )
-        # Explicit gas avoids unsigned eth_estimateGas, which zeroes
-        # value and causes "deposit value too low" reverts.
-        # TODO: remove once signed eth_estimateGas works
+        gas = await async_estimate_transparent_gas(
+            self._w3,
+            to=address,
+            data=data.to_0x_hex(),
+            value=value,
+            private_key=self._private_key,
+        )
         return await self._w3.eth.send_transaction(
-            {
-                "to": address,
-                "data": data.to_0x_hex(),
-                "value": value,
-                "gas": _DEPOSIT_GAS,
-            },
+            {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},
         )

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -205,7 +205,7 @@ async def async_estimate_shielded_gas(
 def estimate_transparent_gas(
     w3: Web3,
     *,
-    to: ChecksumAddress,
+    to: str,
     data: str,
     value: int,
     private_key: PrivateKey,
@@ -239,7 +239,7 @@ def estimate_transparent_gas(
 async def async_estimate_transparent_gas(
     w3: AsyncWeb3,
     *,
-    to: ChecksumAddress,
+    to: str,
     data: str,
     value: int,
     private_key: PrivateKey,

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from eth_account import Account as EthAccount
 from eth_keys.main import KeyAPI as eth_keys
 from hexbytes import HexBytes
 from web3.types import RPCEndpoint
@@ -192,6 +193,77 @@ async def async_estimate_shielded_gas(
     response = await w3.provider.make_request(
         RPCEndpoint("eth_estimateGas"),
         [signed.to_0x_hex()],
+    )
+    return int(_check_rpc_response(response), 16)
+
+
+# ---------------------------------------------------------------------------
+# Transparent signed gas estimation
+# ---------------------------------------------------------------------------
+
+
+def estimate_transparent_gas(
+    w3: Web3,
+    *,
+    to: ChecksumAddress,
+    data: str,
+    value: int,
+    private_key: PrivateKey,
+) -> int:
+    """Estimate gas for a transparent tx by signing it first (sync).
+
+    Signs a temporary standard transaction using the block gas limit as
+    a placeholder and sends the signed bytes to ``eth_estimateGas``.
+    This prevents the node from zeroing ``msg.value`` during simulation.
+    """
+    acct = EthAccount.from_key(private_key)
+    block_gas_limit = w3.eth.get_block("latest")["gasLimit"]
+    tx = {
+        "to": to,
+        "data": data,
+        "value": value,
+        "gas": block_gas_limit,
+        "gasPrice": w3.eth.gas_price,
+        "nonce": w3.eth.get_transaction_count(acct.address),
+        "chainId": w3.eth.chain_id,
+    }
+    signed = acct.sign_transaction(tx)
+
+    response = w3.provider.make_request(
+        RPCEndpoint("eth_estimateGas"),
+        [signed.raw_transaction.to_0x_hex()],
+    )
+    return int(_check_rpc_response(response), 16)
+
+
+async def async_estimate_transparent_gas(
+    w3: AsyncWeb3,
+    *,
+    to: ChecksumAddress,
+    data: str,
+    value: int,
+    private_key: PrivateKey,
+) -> int:
+    """Estimate gas for a transparent tx by signing it first (async).
+
+    Async variant of :func:`estimate_transparent_gas`.
+    """
+    acct = EthAccount.from_key(private_key)
+    block_gas_limit = (await w3.eth.get_block("latest"))["gasLimit"]
+    tx = {
+        "to": to,
+        "data": data,
+        "value": value,
+        "gas": block_gas_limit,
+        "gasPrice": await w3.eth.gas_price,
+        "nonce": await w3.eth.get_transaction_count(acct.address),
+        "chainId": await w3.eth.chain_id,
+    }
+    signed = acct.sign_transaction(tx)
+
+    response = await w3.provider.make_request(
+        RPCEndpoint("eth_estimateGas"),
+        [signed.raw_transaction.to_0x_hex()],
     )
     return int(_check_rpc_response(response), 16)
 

--- a/clients/py/tests/integration/test_deposit_contract.py
+++ b/clients/py/tests/integration/test_deposit_contract.py
@@ -83,7 +83,6 @@ def _make_deposit(
         CONSENSUS_SIGNATURE,
         deposit_data_root,
         value=amount_ether * 10**18,
-        gas=500_000,
     )
     receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
     assert receipt["status"] == 1, "Deposit transaction failed"

--- a/clients/py/tests/test_module.py
+++ b/clients/py/tests/test_module.py
@@ -1,6 +1,6 @@
 """Tests for seismic_web3.module — SeismicNamespace and AsyncSeismicNamespace."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from hexbytes import HexBytes
@@ -85,7 +85,8 @@ class TestDepositActions:
         assert callable(ns.get_deposit_root)
         assert callable(ns.get_deposit_count)
 
-    def test_deposit_calls_send_transaction(self):
+    @patch("seismic_web3.module.estimate_transparent_gas", return_value=100_000)
+    def test_deposit_calls_send_transaction(self, mock_estimate):
         w3 = MagicMock()
         w3.eth.send_transaction.return_value = HexBytes(b"\xaa" * 32)
         encryption = get_encryption(_NETWORK_PK, _CLIENT_SK)
@@ -105,6 +106,7 @@ class TestDepositActions:
         w3.eth.send_transaction.assert_called_once()
         call_args = w3.eth.send_transaction.call_args[0][0]
         assert call_args["value"] == 32 * 10**18
+        assert call_args["gas"] == 100_000
         assert "data" in call_args
 
     def test_deposit_rejects_wrong_byte_lengths(self):

--- a/clients/ts/packages/seismic-viem/src/actions/depositContract.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/depositContract.ts
@@ -103,7 +103,5 @@ export const depositContractWalletActions = <
         args.depositDataRoot,
       ],
       value: args.value,
-      // TODO: remove once signed eth_estimateGas works
-      gas: 500_000n,
     } as any),
 })


### PR DESCRIPTION
## Summary
- Remove hardcoded `gas: 500_000` workaround from deposit contract calls in both Python and TypeScript clients
- Add `estimate_transparent_gas` / `async_estimate_transparent_gas` to Python client — signs a temporary standard tx and sends to `eth_estimateGas` so the node preserves `msg.value` during simulation
- Apply signed gas estimation to all transparent write paths (`twrite`, smart write, namespace `deposit()`)
- TS deposit already flows through `sendTransparentTransaction` which does signed estimation, so just removing the hardcoded gas suffices

Closes #168

## Test plan
- [x] Python integration tests: 108 passed, 3 skipped
- [x] Python unit tests: 288 passed
- [x] TS lint: clean
- [ ] `bun run viem:test` against sanvil