### PR TITLE
refactor(ts-client): centralize smart contract routing

### DIFF
--- a/clients/ts/packages/seismic-viem/src/actions/wallet.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/wallet.ts
@@ -12,7 +12,6 @@ import type {
   WriteContractParameters,
   WriteContractReturnType,
 } from 'viem'
-import { readContract } from 'viem/actions'
 
 import { SeismicSecurityParams } from '@sviem/chain.ts'
 import { ShieldedWalletClient } from '@sviem/client.ts'

--- a/clients/ts/packages/seismic-viem/src/actions/wallet.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/wallet.ts
@@ -1,7 +1,6 @@
 import type {
   Abi,
   Account,
-  Address,
   Chain,
   ContractFunctionArgs,
   ContractFunctionName,
@@ -13,19 +12,20 @@ import type {
   WriteContractParameters,
   WriteContractReturnType,
 } from 'viem'
-import { readContract, writeContract } from 'viem/actions'
+import { readContract } from 'viem/actions'
 
 import { SeismicSecurityParams } from '@sviem/chain.ts'
 import { ShieldedWalletClient } from '@sviem/client.ts'
-import { hasShieldedParams } from '@sviem/contract/abi.ts'
 import {
   signedReadContract,
+  smartReadContract,
   transparentReadContract,
 } from '@sviem/contract/read.ts'
 import {
   ShieldedWriteContractDebugResult,
   shieldedWriteContract,
   shieldedWriteContractDebug,
+  smartWriteContract,
   transparentWriteContract,
 } from '@sviem/contract/write.ts'
 import { sendShieldedTransaction } from '@sviem/tx/sendShielded.ts'
@@ -253,25 +253,7 @@ export const shieldedWalletActions = <
         client as unknown as Parameters<typeof sendTransparentTransaction>[0],
         args as unknown as Parameters<typeof sendTransparentTransaction>[1]
       ),
-    writeContract: (args) => {
-      const writeArgs = args as unknown as {
-        abi: Abi
-        address: Address
-        functionName: string
-        args?: readonly unknown[]
-      }
-      if (hasShieldedParams(writeArgs.abi, writeArgs.functionName)) {
-        return shieldedWriteContract(
-          client as unknown as Parameters<typeof shieldedWriteContract>[0],
-          args as unknown as Parameters<typeof shieldedWriteContract>[1]
-        )
-      }
-      // No shielded params → abi is valid for viem as-is
-      return writeContract(
-        client as unknown as Parameters<typeof writeContract>[0],
-        args as unknown as Parameters<typeof writeContract>[1]
-      )
-    },
+    writeContract: (args) => smartWriteContract(client, args),
     swriteContract: (args) =>
       shieldedWriteContract(
         client as unknown as Parameters<typeof shieldedWriteContract>[0],
@@ -291,26 +273,8 @@ export const shieldedWalletActions = <
         ShieldedWriteContractDebugResult<TChain | undefined, TAccount>
       >
     },
-    readContract: (args, securityParams) => {
-      const readArgs = args as unknown as {
-        abi: Abi
-        address: Address
-        functionName: string
-        args?: readonly unknown[]
-      }
-      if (hasShieldedParams(readArgs.abi as Abi, readArgs.functionName)) {
-        return signedReadContract(
-          client as unknown as Parameters<typeof signedReadContract>[0],
-          args as unknown as Parameters<typeof signedReadContract>[1],
-          securityParams
-        )
-      }
-      // No shielded params → abi is valid for viem as-is
-      return readContract(
-        client as unknown as Parameters<typeof readContract>[0],
-        args as unknown as Parameters<typeof readContract>[1]
-      )
-    },
+    readContract: (args, securityParams) =>
+      smartReadContract(client, client, args, securityParams),
     sreadContract: (args, securityParams) =>
       signedReadContract(
         client as unknown as Parameters<typeof signedReadContract>[0],

--- a/clients/ts/packages/seismic-viem/src/contract/calldata.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/calldata.ts
@@ -8,11 +8,7 @@ import type {
   Hex,
   WriteContractParameters,
 } from 'viem'
-import {
-  encodeAbiParameters,
-  getAbiItem,
-  toFunctionSelector,
-} from 'viem'
+import { encodeAbiParameters, getAbiItem, toFunctionSelector } from 'viem'
 import { formatAbiItem } from 'viem/utils'
 
 import { remapSeismicAbiInputs } from '@sviem/contract/abi.ts'

--- a/clients/ts/packages/seismic-viem/src/contract/calldata.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/calldata.ts
@@ -1,0 +1,60 @@
+import type {
+  Abi,
+  AbiFunction,
+  Account,
+  Chain,
+  ContractFunctionArgs,
+  ContractFunctionName,
+  Hex,
+  WriteContractParameters,
+} from 'viem'
+import {
+  encodeAbiParameters,
+  getAbiItem,
+  toFunctionSelector,
+} from 'viem'
+import { formatAbiItem } from 'viem/utils'
+
+import { remapSeismicAbiInputs } from '@sviem/contract/abi.ts'
+
+/**
+ * Builds the plaintext calldata for a Seismic contract write before any
+ * shielding/encryption is applied.
+ *
+ * The selector is derived from the original Seismic ABI item so the method id
+ * stays aligned with the contract's declared function signature. The arguments
+ * are then encoded using a remapped ABI where shielded parameter types are
+ * converted into standard ABI-compatible types. This produces the raw calldata
+ * shape shared by both:
+ *
+ * - transparent writes, which send it as-is
+ * - shielded writes, which encrypt it before submission
+ */
+export const getPlaintextCalldata = <
+  TChain extends Chain | undefined,
+  TAccount extends Account,
+  const TAbi extends Abi | readonly unknown[],
+  TFunctionName extends ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
+  TArgs extends ContractFunctionArgs<
+    TAbi,
+    'nonpayable' | 'payable',
+    TFunctionName
+  >,
+  TChainOverride extends Chain | undefined = undefined,
+>(
+  parameters: WriteContractParameters<
+    TAbi,
+    TFunctionName,
+    TArgs,
+    TChain,
+    TAccount,
+    TChainOverride
+  >
+): Hex => {
+  const { abi, functionName, args = [] } = parameters as WriteContractParameters
+  const seismicAbi = getAbiItem({ abi, name: functionName }) as AbiFunction
+  const selector = toFunctionSelector(formatAbiItem(seismicAbi))
+  const ethAbi = remapSeismicAbiInputs(seismicAbi)
+  const encodedParams = encodeAbiParameters(ethAbi.inputs, args).slice(2)
+  return `${selector}${encodedParams}` as Hex
+}

--- a/clients/ts/packages/seismic-viem/src/contract/contract.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/contract.ts
@@ -19,7 +19,6 @@ import type {
   WriteContractReturnType,
 } from 'viem'
 import { getContract } from 'viem'
-import { readContract } from 'viem/actions'
 
 import type { ShieldedWalletClient } from '@sviem/client.ts'
 import {
@@ -594,19 +593,17 @@ export function getShieldedContract<
           ]
         ) => {
           const { args, options } = getFunctionParameters(parameters)
-          return smartRead(
-            {
-              abi,
-              address,
-              functionName,
-              args,
-              ...(options as Record<string, unknown>),
-            } as unknown as ReadContractParameters<
-              TAbi,
-              ContractFunctionName<TAbi, 'pure' | 'view'>,
-              ContractFunctionArgs<TAbi, 'pure' | 'view'>
-            >
-          )
+          return smartRead({
+            abi,
+            address,
+            functionName,
+            args,
+            ...(options as Record<string, unknown>),
+          } as unknown as ReadContractParameters<
+            TAbi,
+            ContractFunctionName<TAbi, 'pure' | 'view'>,
+            ContractFunctionArgs<TAbi, 'pure' | 'view'>
+          >)
         }
       },
     }
@@ -626,21 +623,19 @@ export function getShieldedContract<
           ]
         ) => {
           const { args, options } = getFunctionParameters(parameters)
-          return smartWrite(
-            {
-              abi,
-              address,
-              functionName,
-              args,
-              ...(options as Record<string, unknown>),
-            } as unknown as WriteContractParameters<
-              TAbi,
-              ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
-              ContractFunctionArgs<TAbi, 'nonpayable' | 'payable'>,
-              TChain,
-              TAccount
-            >
-          )
+          return smartWrite({
+            abi,
+            address,
+            functionName,
+            args,
+            ...(options as Record<string, unknown>),
+          } as unknown as WriteContractParameters<
+            TAbi,
+            ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
+            ContractFunctionArgs<TAbi, 'nonpayable' | 'payable'>,
+            TChain,
+            TAccount
+          >)
         }
       },
     }

--- a/clients/ts/packages/seismic-viem/src/contract/contract.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/contract.ts
@@ -12,25 +12,27 @@ import type {
   IsNarrowable,
   IsNever,
   ReadContractParameters,
+  ReadContractReturnType,
   Transport,
   UnionOmit,
   WriteContractParameters,
   WriteContractReturnType,
 } from 'viem'
 import { getContract } from 'viem'
-import { readContract, writeContract } from 'viem/actions'
+import { readContract } from 'viem/actions'
 
 import type { ShieldedWalletClient } from '@sviem/client.ts'
-import { hasShieldedParams } from '@sviem/contract/abi.ts'
 import {
   SignedReadContractParameters,
   signedReadContract,
+  smartReadContract,
   transparentReadContract,
 } from '@sviem/contract/read.ts'
 import {
   ShieldedWriteContractDebugResult,
   shieldedWriteContract,
   shieldedWriteContractDebug,
+  smartWriteContract,
   transparentWriteContract,
 } from '@sviem/contract/write.ts'
 import type { KeyedClient } from '@sviem/viem-internal/client.ts'
@@ -180,7 +182,7 @@ export type ShieldedContract<
  * - `swrite`: force shielded write — always uses encrypted seismic transaction regardless of params
  * - `tread`: force transparent read — always uses unsigned read (from the zero address)
  * - `twrite`: force transparent write — always uses non-encrypted calldata
- * - `dwrite`: debug write — get plaintext and encrypted transaction without broadcasting
+ * - `dwrite`: debug write — get plaintext and encrypted transaction details
  *
  * @param {GetContractParameters} params - The configuration object.
  *   - `abi` ({@link Abi}) - The contract's ABI.
@@ -251,6 +253,17 @@ export function getShieldedContract<
     if ('wallet' in client)
       return client.wallet as ShieldedWalletClient<TTransport, TChain, TAccount>
     return client as ShieldedWalletClient<TTransport, TChain, TAccount>
+  })()
+
+  const readClient: Client | undefined = (() => {
+    if (!client) return undefined
+    if ('public' in client) {
+      return client.public as Client | undefined
+    }
+    if ('wallet' in client) {
+      return client.wallet as Client | undefined
+    }
+    return client as Client
   })()
 
   const transparentWriteAction = new Proxy(
@@ -345,6 +358,37 @@ export function getShieldedContract<
     )
   }
 
+  function smartWrite<
+    functionName extends ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
+    args extends ContractFunctionArgs<
+      TAbi,
+      'payable' | 'nonpayable',
+      functionName
+    > = ContractFunctionArgs<TAbi, 'payable' | 'nonpayable', functionName>,
+  >({
+    functionName,
+    args,
+    ...options
+  }: WriteContractParameters<TAbi, functionName, args, TChain, TAccount>) {
+    if (walletClient === undefined) {
+      throw new Error('Must provide wallet client to call Contract.write')
+    }
+
+    return smartWriteContract(walletClient, {
+      abi,
+      address,
+      functionName,
+      args,
+      ...(options as Record<string, unknown>),
+    } as unknown as WriteContractParameters<
+      TAbi,
+      functionName,
+      args,
+      TChain,
+      TAccount
+    >)
+  }
+
   const shieldedWriteAction = new Proxy(
     {},
     {
@@ -421,6 +465,28 @@ export function getShieldedContract<
       throw new Error('Must provide wallet client to call signed read')
     }
     return signedReadContract(walletClient, params)
+  }
+
+  function smartRead<
+    TFunctionName extends ContractFunctionName<TAbi, 'pure' | 'view'>,
+    TArgs extends ContractFunctionArgs<
+      TAbi,
+      'pure' | 'view',
+      TFunctionName
+    > = ContractFunctionArgs<TAbi, 'pure' | 'view', TFunctionName>,
+  >(
+    params: ReadContractParameters<TAbi, TFunctionName, TArgs>
+  ): Promise<ReadContractReturnType> {
+    if (readClient === undefined) {
+      throw new Error('Must provide a client to call Contract.read')
+    }
+    return smartReadContract(
+      walletClient,
+      readClient,
+      params,
+      undefined,
+      walletClient?.account
+    )
   }
 
   const transparentReadAction = new Proxy(
@@ -527,47 +593,20 @@ export function getShieldedContract<
             >,
           ]
         ) => {
-          const isShielded = hasShieldedParams(abi as Abi, functionName)
-          if (isShielded) {
-            if (!walletClient?.account) {
-              throw new Error(
-                'Wallet must have an account to perform signed reads'
-              )
-            }
-            const params = getFunctionParameters(parameters)
-            const { args } = params
-            const {
-              options: { account: _account, ...options },
-            } = params as {
-              options: { account: Account | undefined } & Record<
-                string,
-                unknown
-              >
-            }
-            return signedRead({
-              abi,
-              address,
-              functionName,
-              args,
-              account: walletClient.account,
-              ...options,
-            } as unknown as SignedReadContractParameters<
-              TAbi,
-              ContractFunctionName<TAbi, 'pure' | 'view'>,
-              ContractFunctionArgs<TAbi, 'pure' | 'view'>
-            >)
-          } else {
-            const { args, options } = getFunctionParameters(parameters)
-            // No shielded params → abi is valid for viem as-is
-            // @ts-expect-error: walletClient satisfies Client for readContract
-            return readContract(walletClient, {
+          const { args, options } = getFunctionParameters(parameters)
+          return smartRead(
+            {
               abi,
               address,
               functionName,
               args,
               ...(options as Record<string, unknown>),
-            })
-          }
+            } as unknown as ReadContractParameters<
+              TAbi,
+              ContractFunctionName<TAbi, 'pure' | 'view'>,
+              ContractFunctionArgs<TAbi, 'pure' | 'view'>
+            >
+          )
         }
       },
     }
@@ -586,10 +625,9 @@ export function getShieldedContract<
             >,
           ]
         ) => {
-          const isShielded = hasShieldedParams(abi as Abi, functionName)
-          if (isShielded) {
-            const { args, options } = getFunctionParameters(parameters)
-            return shieldedWrite({
+          const { args, options } = getFunctionParameters(parameters)
+          return smartWrite(
+            {
               abi,
               address,
               functionName,
@@ -601,26 +639,8 @@ export function getShieldedContract<
               ContractFunctionArgs<TAbi, 'nonpayable' | 'payable'>,
               TChain,
               TAccount
-            >)
-          } else {
-            if (walletClient === undefined) {
-              throw new Error(
-                'Must provide wallet client to call Contract.write'
-              )
-            }
-            // No shielded params → abi is valid for viem as-is
-            const { args, options } = getFunctionParameters(parameters)
-            return writeContract(
-              walletClient as unknown as Parameters<typeof writeContract>[0],
-              {
-                abi,
-                address,
-                functionName,
-                args,
-                ...(options as Record<string, unknown>),
-              } as unknown as Parameters<typeof writeContract>[1]
-            )
-          }
+            >
+          )
         }
       },
     }
@@ -643,7 +663,7 @@ export function getShieldedContract<
       | 'twrite'
       | 'dwrite']?: unknown
   } = viemContract
-  // Transparent writes use the standard writeContract
+  // Force transparent writes through the transparent contract helper.
   contract.twrite = transparentWriteAction
   // Transparent reads use signed reads,
   // but signing is only activated if they supply an account parameter

--- a/clients/ts/packages/seismic-viem/src/contract/read.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/read.ts
@@ -3,6 +3,7 @@ import type {
   AbiFunction,
   Account,
   CallParameters,
+  Client,
   Chain,
   ContractFunctionArgs,
   ContractFunctionName,
@@ -18,11 +19,12 @@ import {
   getAbiItem,
   toFunctionSelector,
 } from 'viem'
+import { readContract as viemReadContract } from 'viem/actions'
 import { formatAbiItem } from 'viem/utils'
 
 import { SeismicSecurityParams } from '@sviem/chain.ts'
 import { ShieldedWalletClient } from '@sviem/client.ts'
-import { remapSeismicAbiInputs } from '@sviem/contract/abi.ts'
+import { hasShieldedParams, remapSeismicAbiInputs } from '@sviem/contract/abi.ts'
 import type { SignedCallParameters } from '@sviem/tx/signedCall.ts'
 import { signedCall } from '@sviem/tx/signedCall.ts'
 
@@ -32,6 +34,57 @@ export type SignedReadContractParameters<
   TArgs extends ContractFunctionArgs<TAbi, 'pure' | 'view', TFunctionName>,
 > = ReadContractParameters<TAbi, TFunctionName, TArgs> & {
   nonce?: number
+}
+
+/**
+ * Shared smart-read routing used by both the wallet actions and the
+ * ABI/address-bound contract wrapper.
+ *
+ * This helper inspects the target ABI/function and chooses the read path:
+ *
+ * - if the function has shielded params, it routes to `signedReadContract(...)`
+ * - otherwise it routes to viem's `readContract(...)`
+ *
+ * `walletClient` is only required for the signed-read path. `readClient` is
+ * the client used for the plain viem read path.
+ */
+export async function smartReadContract<
+  TChain extends Chain | undefined,
+  TAccount extends Account,
+  const TAbi extends Abi | readonly unknown[],
+  TFunctionName extends ContractFunctionName<TAbi, 'pure' | 'view'>,
+  TArgs extends ContractFunctionArgs<TAbi, 'pure' | 'view', TFunctionName>,
+>(
+  walletClient: ShieldedWalletClient<Transport, TChain, TAccount> | undefined,
+  readClient: Client,
+  parameters: ReadContractParameters<TAbi, TFunctionName, TArgs>,
+  securityParams?: SeismicSecurityParams,
+  forcedAccount?: Account
+): Promise<ReadContractReturnType> {
+  const readArgs = parameters as unknown as {
+    abi: Abi
+    functionName: string
+  }
+  if (hasShieldedParams(readArgs.abi, readArgs.functionName)) {
+    const account = forcedAccount ?? walletClient?.account
+    if (!walletClient || !account) {
+      throw new Error('Wallet must have an account to perform signed reads')
+    }
+    return signedReadContract(
+      walletClient as unknown as Parameters<typeof signedReadContract>[0],
+      {
+        ...(parameters as Record<string, unknown>),
+        account,
+      } as unknown as Parameters<typeof signedReadContract>[1],
+      securityParams
+    )
+  }
+
+  // No shielded params -> the ABI is valid for viem as-is.
+  return viemReadContract(
+    readClient as unknown as Parameters<typeof viemReadContract>[0],
+    parameters as unknown as Parameters<typeof viemReadContract>[1]
+  )
 }
 
 /**

--- a/clients/ts/packages/seismic-viem/src/contract/read.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/read.ts
@@ -3,8 +3,8 @@ import type {
   AbiFunction,
   Account,
   CallParameters,
-  Client,
   Chain,
+  Client,
   ContractFunctionArgs,
   ContractFunctionName,
   Hex,
@@ -24,7 +24,10 @@ import { formatAbiItem } from 'viem/utils'
 
 import { SeismicSecurityParams } from '@sviem/chain.ts'
 import { ShieldedWalletClient } from '@sviem/client.ts'
-import { hasShieldedParams, remapSeismicAbiInputs } from '@sviem/contract/abi.ts'
+import {
+  hasShieldedParams,
+  remapSeismicAbiInputs,
+} from '@sviem/contract/abi.ts'
 import type { SignedCallParameters } from '@sviem/tx/signedCall.ts'
 import { signedCall } from '@sviem/tx/signedCall.ts'
 

--- a/clients/ts/packages/seismic-viem/src/contract/write.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/write.ts
@@ -1,6 +1,5 @@
 import type {
   Abi,
-  AbiFunction,
   Account,
   Address,
   Chain,
@@ -13,23 +12,38 @@ import type {
   WriteContractParameters,
   WriteContractReturnType,
 } from 'viem'
-import {
-  encodeAbiParameters,
-  getAbiItem,
-  numberToHex,
-  toFunctionSelector,
-} from 'viem'
-import { formatAbiItem } from 'viem/utils'
+import { numberToHex } from 'viem'
+import { writeContract } from 'viem/actions'
 
 import { SEISMIC_TX_TYPE, SeismicSecurityParams } from '@sviem/chain.ts'
 import type { ShieldedWalletClient } from '@sviem/client.ts'
-import { remapSeismicAbiInputs } from '@sviem/contract/abi.ts'
+import { hasShieldedParams } from '@sviem/contract/abi.ts'
+import { getPlaintextCalldata } from '@sviem/contract/calldata.ts'
 import { randomEncryptionNonce } from '@sviem/crypto/nonce.ts'
 import { buildTxSeismicMetadata } from '@sviem/metadata.ts'
 import { sendShieldedTransaction } from '@sviem/tx/sendShielded.ts'
 import type { SendSeismicTransactionParameters } from '@sviem/tx/types.ts'
 
-export const getPlaintextCalldata = <
+export { getPlaintextCalldata } from '@sviem/contract/calldata.ts'
+
+/**
+ * Shared smart-write routing used by both the wallet actions and the
+ * ABI/address-bound contract wrapper.
+ *
+ * This helper inspects the target ABI/function and chooses the write path:
+ *
+ * - if the function has shielded params, it routes to
+ *   `shieldedWriteContract(...)`
+ * - otherwise it routes to viem's `writeContract(...)`
+ *
+ * It does not currently route non-shielded writes through
+ * `transparentWriteContract(...)`. That helper exists for the explicit
+ * force-transparent API (`twriteContract` / `contract.twrite.*`), where Seismic
+ * remaps ABI inputs and sends plaintext calldata through the transparent send
+ * path directly.
+ */
+export async function smartWriteContract<
+  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account,
   const TAbi extends Abi | readonly unknown[],
@@ -39,31 +53,40 @@ export const getPlaintextCalldata = <
     'nonpayable' | 'payable',
     TFunctionName
   >,
-  chainOverride extends Chain | undefined = undefined,
+  TChainOverride extends Chain | undefined = undefined,
 >(
+  client: ShieldedWalletClient<TTransport, TChain, TAccount>,
   parameters: WriteContractParameters<
     TAbi,
     TFunctionName,
     TArgs,
     TChain,
     TAccount,
-    chainOverride
+    TChainOverride
   >
-): Hex => {
-  const { abi, functionName, args = [] } = parameters as WriteContractParameters
-  const seismicAbi = getAbiItem({ abi, name: functionName }) as AbiFunction
-  const selector = toFunctionSelector(formatAbiItem(seismicAbi))
-  const ethAbi = remapSeismicAbiInputs(seismicAbi)
-  const encodedParams = encodeAbiParameters(ethAbi.inputs, args).slice(2)
-  const plaintextCalldata = `${selector}${encodedParams}` as Hex
-  return plaintextCalldata
+): Promise<WriteContractReturnType> {
+  const writeArgs = parameters as unknown as {
+    abi: Abi
+    functionName: string
+  }
+  if (hasShieldedParams(writeArgs.abi, writeArgs.functionName)) {
+    return shieldedWriteContract(
+      client as unknown as Parameters<typeof shieldedWriteContract>[0],
+      parameters as unknown as Parameters<typeof shieldedWriteContract>[1]
+    )
+  }
+
+  // No shielded params -> the ABI is valid for viem as-is.
+  return writeContract(
+    client as unknown as Parameters<typeof writeContract>[0],
+    parameters as unknown as Parameters<typeof writeContract>[1]
+  )
 }
 
 /**
  * Sends a transparent (non-encrypted) write to a contract whose ABI may
- * contain shielded types.  The function selector is derived from the
- * original Seismic ABI while parameters are encoded with remapped
- * standard types, then sent as a plain `eth_sendTransaction`.
+ * contain shielded types. The selector is derived from the Seismic ABI while
+ * parameters are encoded with remapped standard types.
  */
 export async function transparentWriteContract<
   TChain extends Chain | undefined,
@@ -102,7 +125,7 @@ export async function transparentWriteContract<
   } as unknown as Parameters<typeof client.sendTransaction>[0])
 }
 
-async function getShieldedWriteContractRequest<
+export async function shieldedWriteContract<
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account,
@@ -123,78 +146,10 @@ async function getShieldedWriteContractRequest<
     TChain,
     TAccount,
     TChainOverride
-  >,
-  plaintextCalldata: Hex
-): Promise<SendSeismicTransactionParameters<TChain, TAccount>> {
-  const { address, gas, gasPrice, value, nonce } = parameters
-  return {
-    account: client.account,
-    chain: undefined,
-    to: address,
-    data: plaintextCalldata,
-    nonce,
-    value,
-    gas,
-    gasPrice,
-  }
-}
-
-/**
- * Executes a shielded write function on a contract, where the calldata is encrypted. The API for this is the same as viem's {@link https://viem.sh/docs/contract/writeContract writeContract}
- *
- *
- * @param {ShieldedWalletClient} client - The client to use.
- * @param {WriteContractParameters} parameters - The configuration object for the write operation.
- *   - `address` ({@link Hex}) - The address of the contract.
- *   - `abi` ({@link Abi}) - The contract's ABI.
- *   - `functionName` (string) - The name of the contract function to call.
- *   - `args` (array) - The arguments to pass to the contract function.
- *   - `gas` (bigint, optional) - Optional gas limit for the transaction.
- *   - `gasPrice` (bigint, optional) - Optional gas price for the transaction.
- *   - `value` (bigint, optional) - Optional value (native token amount) to send with the transaction.
- *
- * @returns {Promise<WriteContractReturnType>} A promise that resolves to a transaction hash.
- *
- * @example
- * import { custom, parseAbi } from 'viem'
- * import { createShieldedWalletContract, shieldedWriteContract, seismicTestnet } from 'seismic-viem'
- *
- * const client = createShieldedWalletClient({
- *   chain: seismicTestnet,
- *   transport: custom(window.ethereum),
- * })
- * const hash = await shieldedWriteContract(client, {
- *   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
- *   abi: parseAbi(['function mint(uint32 tokenId) nonpayable']),
- *   functionName: 'mint',
- *   args: [69420],
- * })
- */
-export async function shieldedWriteContract<
-  TTransport extends Transport,
-  TChain extends Chain | undefined,
-  TAccount extends Account,
-  const TAbi extends Abi | readonly unknown[],
-  TFunctionName extends ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
-  TArgs extends ContractFunctionArgs<
-    TAbi,
-    'nonpayable' | 'payable',
-    TFunctionName
-  >,
-  chainOverride extends Chain | undefined = undefined,
->(
-  client: ShieldedWalletClient<TTransport, TChain, TAccount>,
-  parameters: WriteContractParameters<
-    TAbi,
-    TFunctionName,
-    TArgs,
-    TChain,
-    TAccount,
-    chainOverride
   >
 ): Promise<WriteContractReturnType> {
   const plaintextCalldata = getPlaintextCalldata(parameters)
-  const request = await getShieldedWriteContractRequest(
+  const request = buildShieldedWriteRequest(
     client,
     parameters,
     plaintextCalldata
@@ -222,19 +177,28 @@ export type ShieldedWriteContractDebugResult<
 }
 
 /**
- * Creates a transaction for a shielded write. Returns both plaintext and shielded transaction versions. Useful for debugging.
+ * Sends a shielded write and returns both plaintext and shielded transaction
+ * views for inspection.
  *
- * @param {ShieldedWalletClient} client - The client to use.
- * @param {WriteContractParameters} parameters - The configuration object for the write operation.
- *   - `address` ({@link Hex}) - The address of the contract.
- *   - `abi` ({@link Abi}) - The contract's ABI.
- *   - `functionName` (string) - The name of the contract function to call.
- *   - `args` (array) - The arguments to pass to the contract function.
- *   - `gas` (bigint, optional) - Optional gas limit for the transaction.
- *   - `gasPrice` (bigint, optional) - Optional gas price for the transaction.
- *   - `value` (bigint, optional) - Optional value (native token amount) to send with the transaction.
+ * This is primarily useful for debugging Seismic write behavior because the
+ * caller can see:
  *
- * @returns {ShieldedWriteContractDebugResult} Object containing both the plaintext and shielded transaction parameters.
+ * - the plaintext calldata transaction shape
+ * - the shielded transaction payload that was derived from it
+ * - the resulting transaction hash
+ *
+ * Note: despite the debug-oriented name, this function currently does
+ * broadcast the shielded transaction and returns a real `txHash`.
+ *
+ * @param client - The wallet client used to prepare, encrypt, and send the write.
+ * @param parameters - The contract write parameters, matching viem's
+ * `writeContract` shape.
+ * @param checkContractDeployed - When true, verifies that code exists at the
+ * target address before sending.
+ * @param securityParams - Optional Seismic metadata controls such as
+ * `blocksWindow` and `encryptionNonce`.
+ * @returns Both plaintext and shielded transaction representations, plus the
+ * submitted transaction hash.
  */
 export async function shieldedWriteContractDebug<
   TTransport extends Transport,
@@ -247,7 +211,7 @@ export async function shieldedWriteContractDebug<
     'nonpayable' | 'payable',
     TFunctionName
   >,
-  chainOverride extends Chain | undefined = undefined,
+  TChainOverride extends Chain | undefined = undefined,
 >(
   client: ShieldedWalletClient<TTransport, TChain, TAccount>,
   parameters: WriteContractParameters<
@@ -256,7 +220,7 @@ export async function shieldedWriteContractDebug<
     TArgs,
     TChain,
     TAccount,
-    chainOverride
+    TChainOverride
   >,
   checkContractDeployed?: boolean,
   {
@@ -271,7 +235,7 @@ export async function shieldedWriteContractDebug<
     }
   }
   const plaintextCalldata = getPlaintextCalldata(parameters)
-  const request = await getShieldedWriteContractRequest(
+  const request = buildShieldedWriteRequest(
     client,
     parameters,
     plaintextCalldata
@@ -306,5 +270,50 @@ export async function shieldedWriteContractDebug<
       ...metadata.seismicElements,
     },
     txHash,
+  }
+}
+
+/**
+ * Builds the Seismic transaction request consumed by the shielded send path.
+ *
+ * At this stage the calldata is still plaintext. This helper only maps the
+ * contract-write parameters into the request fields needed by
+ * `sendShieldedTransaction(...)`, preserving user-supplied tx options like
+ * `gas`, `gasPrice`, `value`, and `nonce`.
+ */
+function buildShieldedWriteRequest<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account,
+  const TAbi extends Abi | readonly unknown[],
+  TFunctionName extends ContractFunctionName<TAbi, 'nonpayable' | 'payable'>,
+  TArgs extends ContractFunctionArgs<
+    TAbi,
+    'nonpayable' | 'payable',
+    TFunctionName
+  >,
+  TChainOverride extends Chain | undefined = undefined,
+>(
+  client: ShieldedWalletClient<TTransport, TChain, TAccount>,
+  parameters: WriteContractParameters<
+    TAbi,
+    TFunctionName,
+    TArgs,
+    TChain,
+    TAccount,
+    TChainOverride
+  >,
+  plaintextCalldata: Hex
+): SendSeismicTransactionParameters<TChain, TAccount> {
+  const { address, gas, gasPrice, value, nonce } = parameters
+  return {
+    account: client.account,
+    chain: undefined,
+    to: address,
+    data: plaintextCalldata,
+    nonce,
+    value,
+    gas,
+    gasPrice,
   }
 }

--- a/clients/ts/packages/seismic-viem/src/contract/write.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/write.ts
@@ -24,8 +24,6 @@ import { buildTxSeismicMetadata } from '@sviem/metadata.ts'
 import { sendShieldedTransaction } from '@sviem/tx/sendShielded.ts'
 import type { SendSeismicTransactionParameters } from '@sviem/tx/types.ts'
 
-export { getPlaintextCalldata } from '@sviem/contract/calldata.ts'
-
 /**
  * Shared smart-write routing used by both the wallet actions and the
  * ABI/address-bound contract wrapper.

--- a/clients/ts/packages/seismic-viem/src/index.ts
+++ b/clients/ts/packages/seismic-viem/src/index.ts
@@ -35,9 +35,12 @@ export type { ShieldedWriteContractDebugResult } from '@sviem/contract/write.ts'
 export {
   shieldedWriteContract,
   shieldedWriteContractDebug,
-  getPlaintextCalldata,
   transparentWriteContract,
 } from '@sviem/contract/write.ts'
+// TODO(samlaf): Revisit whether getPlaintextCalldata should remain part of the public
+// package surface. It is currently used by tests, but likely belongs as an
+// internal helper rather than a root re-export.
+export { getPlaintextCalldata } from '@sviem/contract/calldata.ts'
 export {
   hasShieldedParams,
   remapSeismicAbiInputs,


### PR DESCRIPTION
Smart read/write routing was duplicated across the wallet actions and the ABI-bound contract wrapper. Both surfaces were making their own decisions about when to use shielded vs plain contract behavior, which made the flow harder to trace and created room for the two paths to drift over time.

Move that routing into the shared contract helpers instead. Smart writes now flow through contract/write.ts, smart reads through contract/read.ts, and both wallet and contract APIs delegate to those shared helpers. This keeps the behavior aligned while preserving the existing public surface.