### PR TITLE
fix(ts-client): enforce tread semantics consistently

### DIFF
--- a/clients/ts/docs/pages/viem/actions/wallet.mdx
+++ b/clients/ts/docs/pages/viem/actions/wallet.mdx
@@ -4,38 +4,73 @@ description: Actions for the shielded wallet client
 
 # Shielded Wallet Actions
 
-In addition to all standard viem WalletClient methods, the ShieldedWalletClient provides several privacy-preserving features:
+In addition to standard viem wallet actions, the shielded wallet client exposes Seismic-specific contract helpers.
 
-## signedReadContract
+## Read Helpers
 
 ```ts
-const result = await walletClient.signedReadContract({
+const smartResult = await walletClient.readContract({
   address: '0x1234...',
   abi: contractAbi,
-  functionName: 'balanceOf',
-  args: ['0xabcd...'],
+  functionName: 'isOdd',
+})
+
+const signedResult = await walletClient.sreadContract({
+  address: '0x1234...',
+  abi: contractAbi,
+  functionName: 'isOdd',
+})
+
+const transparentResult = await walletClient.treadContract({
+  address: '0x1234...',
+  abi: contractAbi,
+  functionName: 'isOdd',
 })
 ```
 
-Performs a signed read operation from a contract.
+- `readContract`: smart routing, signed if the target function has shielded params, transparent otherwise
+- `sreadContract`: always signed
+- `treadContract`: always transparent. Seismic zeroes out `from` on transparent `eth_call`, so it rejects `account` here to prevent silent bugs; use `sreadContract` for sender-aware reads
 
-## shieldedWriteContract
+## Write Helpers
 
 ```ts
-const hash = await walletClient.shieldedWriteContract({
+const smartHash = await walletClient.writeContract({
   address: '0x1234...',
   abi: contractAbi,
-  functionName: 'transfer',
-  args: ['0xabcd...', 100n],
+  functionName: 'setNumber',
+  args: [7n],
+})
+
+const shieldedHash = await walletClient.swriteContract({
+  address: '0x1234...',
+  abi: contractAbi,
+  functionName: 'increment',
+})
+
+const transparentHash = await walletClient.twriteContract({
+  address: '0x1234...',
+  abi: contractAbi,
+  functionName: 'increment',
+})
+
+const debugResult = await walletClient.dwriteContract({
+  address: '0x1234...',
+  abi: contractAbi,
+  functionName: 'setNumber',
+  args: [7n],
 })
 ```
 
-Executes a contract write with encrypted calldata.
+- `writeContract`: smart routing, shielded if the target function has shielded params, transparent otherwise
+- `swriteContract`: always shielded
+- `twriteContract`: always transparent
+- `dwriteContract`: sends a real shielded transaction and returns `txHash`, `plaintextTx`, and `shieldedTx`
 
 ## getEncryption
 
 ```ts
-const { aesKey, ecdhPubKey } = walletClient.getEncryption()
+const { aesKey, encryptionPublicKey } = walletClient.getEncryption()
 ```
 
 Retrieves the encryption keys currently in use by the client.

--- a/clients/ts/docs/pages/viem/clients/wallet.mdx
+++ b/clients/ts/docs/pages/viem/clients/wallet.mdx
@@ -30,7 +30,9 @@ const walletClient = await createShieldedWalletClient({
 // Perform wallet operations
 const result = await walletClient.writeContract({
   address: '0x1234...',
-  data: '0xdeadbeef...',
+  abi: contractAbi,
+  functionName: 'setNumber',
+  args: [7n],
 })
 
 // Access shielded-specific actions
@@ -43,6 +45,17 @@ console.info('AES Key:', aesKey)
 `Promise<ShieldedWalletClient>` - A promise that resolves to a shielded wallet client instance.
 
 The ShieldedWalletClient extends viem's WalletClient with additional methods for privacy-preserving operations.
+
+Important contract helpers:
+
+- `readContract`: smart routing, signed if the target function has shielded params, transparent otherwise
+- `sreadContract`: always signed
+- `treadContract`: always transparent. Seismic zeroes out `from` on transparent `eth_call`, so it rejects `account` here to prevent silent bugs; use `sreadContract` for sender-aware reads
+- `writeContract`: smart routing, shielded if the target function has shielded params, transparent otherwise
+- `swriteContract`: always shielded
+- `twriteContract`: always transparent
+- `dwriteContract`: sends a real shielded transaction and returns `txHash`, `plaintextTx`, and `shieldedTx`
+- `deployContract`: still uses viem's direct deploy path, so treat its gas-estimation behavior separately from `sendTransaction`
 
 ## Parameters
 

--- a/clients/ts/docs/pages/viem/contract/instance.mdx
+++ b/clients/ts/docs/pages/viem/contract/instance.mdx
@@ -39,10 +39,13 @@ Depending on the client you provide, different methods will be available on the 
 
 ### Available Methods
 
-- **`write`**: Write to a contract with encrypted calldata
-- **`read`**: Read from a contract using a signed read
-- **`tread`**: Transparently read from a contract using an unsigned read (from the zero address)
-- **`twrite`**: Transparently write to a contract using non-encrypted calldata
+- **`write`**: Smart write, shielded if the target function has shielded params, transparent otherwise
+- **`read`**: Smart read, signed if the target function has shielded params, transparent otherwise
+- **`swrite`**: Force shielded write
+- **`sread`**: Force signed read
+- **`twrite`**: Force transparent write
+- **`tread`**: Force transparent read
+- **`dwrite`**: Send a real shielded transaction and return the plaintext/shielded tx views plus `txHash`
 
 ### Calling Methods
 
@@ -50,7 +53,7 @@ Contract instance methods follow this general format:
 
 ```ts
 // function calls
-contract.(read|write|tread|twrite).(functionName)(args, options)
+contract.(read|write|sread|swrite|tread|twrite|dwrite).(functionName)(args, options)
 ```
 
 If the contract function doesn't accept arguments, you can set the `args` parameter to an empty array `[]`
@@ -91,6 +94,8 @@ const contract = getShieldedContract({
 
 The ShieldedWalletClient for performing contract actions with privacy features.
 
+For read-only usage, you can also pass a keyed client object with only `public`.
+
 ```ts
 const contract = getShieldedContract({
   address: '0x1234...',
@@ -101,11 +106,14 @@ const contract = getShieldedContract({
 
 ## Remarks
 
-- The `read` property will always call a signed read
-- The `tread` property will toggle between public reads and signed reads, depending on whether an `account` is provided
-- The `write` property will encrypt calldata of the transaction
-- The `twrite` property will make a normal write with transparent calldata
-- The client must be a `ShieldedWalletClient`
+- The `read` property auto-detects shielded params and routes to signed read or transparent read
+- The `write` property auto-detects shielded params and routes to shielded write or transparent write
+- The `sread` property always performs a signed read
+- The `swrite` property always sends a shielded transaction
+- The `tread` property always performs a transparent read. Seismic zeroes out `from` on transparent `eth_call`, so `tread` rejects `account` here to prevent silent bugs; use `sread` for sender-aware reads
+- The `twrite` property always sends transparent calldata
+- The `dwrite` property sends a real shielded transaction and returns inspection data for that submitted tx
+- The client must be a `ShieldedWalletClient` for write, signed-read, and debug-write surfaces
 
 ## Throws
 

--- a/clients/ts/packages/seismic-viem-tests/src/index.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/index.ts
@@ -6,6 +6,9 @@ export { testSeismicTx } from '@sviem-tests/tests/contract/contract.ts'
 export { testDepositContract } from '@sviem-tests/tests/contract/depositContract.ts'
 export {
   testContractTreadIsntSeismicTx,
+  testContractTreadRejectsAccountOption,
+  testContractTreadWithPublicOnlyClient,
+  testShieldedWalletClientTreadRejectsAccountOption,
   testShieldedWalletClientTreadIsntSeismicTx,
   testViemReadContractIsntSeismicTx,
 } from '@sviem-tests/tests/transparentContract/tread-contract.ts'

--- a/clients/ts/packages/seismic-viem-tests/src/tests/contract/contract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/contract/contract.ts
@@ -152,11 +152,8 @@ export const testSeismicTx = async ({
   )
   expectSeismicTx(receiptDw2.type as `0x${string}` | null)
 
-  console.log(`[3] Using non-explicit signed read...`)
-  // Use non-explicit signed-read
-  const isOdd3 = await seismicContract.tread.isOdd({
-    account: walletClient.account.address,
-  })
+  console.log('[3] Using explicit force-signed read...')
+  const isOdd3 = await seismicContract.sread.isOdd()
   // number has been set back to 11
   expect(isOdd3).toBe(true)
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/tread-contract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/tread-contract.ts
@@ -89,3 +89,81 @@ export const testShieldedWalletClientTreadIsntSeismicTx = async ({
   })
   expect(isOdd).toBe(false)
 }
+
+export const testContractTreadRejectsAccountOption = async ({
+  chain,
+  url,
+  account,
+}: ContractTestArgs) => {
+  const { deployedContractAddress, walletClient } = await treadSetup({
+    chain,
+    url,
+    account,
+  })
+
+  const seismicContract = getShieldedContract({
+    abi: transparentCounterABI,
+    address: deployedContractAddress,
+    client: walletClient,
+  })
+
+  let error: Error | undefined
+  try {
+    await seismicContract.tread.isOdd({
+      account: walletClient.account.address,
+    })
+  } catch (err) {
+    error = err as Error
+  }
+
+  expect(error).toBeDefined()
+  expect(error?.message).toContain('zeroes out `from`')
+}
+
+export const testShieldedWalletClientTreadRejectsAccountOption = async ({
+  chain,
+  url,
+  account,
+}: ContractTestArgs) => {
+  const { deployedContractAddress, walletClient } = await treadSetup({
+    chain,
+    url,
+    account,
+  })
+
+  let error: Error | undefined
+  try {
+    await walletClient.treadContract({
+      address: deployedContractAddress,
+      abi: transparentCounterABI,
+      functionName: 'isOdd',
+      account: walletClient.account.address,
+    })
+  } catch (err) {
+    error = err as Error
+  }
+
+  expect(error).toBeDefined()
+  expect(error?.message).toContain('zeroes out `from`')
+}
+
+export const testContractTreadWithPublicOnlyClient = async ({
+  chain,
+  url,
+  account,
+}: ContractTestArgs) => {
+  const { deployedContractAddress, publicClient } = await treadSetup({
+    chain,
+    url,
+    account,
+  })
+
+  const seismicContract = getShieldedContract({
+    abi: transparentCounterABI,
+    address: deployedContractAddress,
+    client: { public: publicClient },
+  })
+
+  const isOdd = await seismicContract.tread.isOdd()
+  expect(isOdd).toBe(false)
+}

--- a/clients/ts/packages/seismic-viem/src/actions/wallet.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/wallet.ts
@@ -280,11 +280,18 @@ export const shieldedWalletActions = <
         args as unknown as Parameters<typeof signedReadContract>[1],
         securityParams
       ),
-    treadContract: (args) =>
-      transparentReadContract(
+    treadContract: (args) => {
+      const readArgs = args as Record<string, unknown>
+      if (readArgs.account !== undefined) {
+        throw new Error(
+          'walletClient.treadContract is always transparent. Seismic zeroes out `from` on transparent `eth_call`, so `account` would be ignored on the node and cause silent bugs. Remove `account` or use `walletClient.sreadContract`.'
+        )
+      }
+      return transparentReadContract(
         client as unknown as Parameters<typeof transparentReadContract>[0],
         args as unknown as Parameters<typeof transparentReadContract>[1]
-      ),
+      )
+    },
     signedCall: (args, securityParams) =>
       signedCall(
         client as unknown as Parameters<typeof signedCall>[0],

--- a/clients/ts/packages/seismic-viem/src/client.ts
+++ b/clients/ts/packages/seismic-viem/src/client.ts
@@ -92,12 +92,16 @@ export type ShieldedPublicClient<
  *   - `readContract`: smart read — auto-detects shielded params; uses signed read if shielded, transparent read otherwise
  *   - `sreadContract`: force shielded read — always uses signed read
  *   - `treadContract`: force transparent read — always uses unsigned read (from the zero address)
+ *     and rejects `account`. Seismic zeroes out `from` on transparent `eth_call`,
+ *     so this prevents silent bugs; use `sreadContract` for sender-aware reads.
  *   - `writeContract`: smart write — auto-detects shielded params; uses shielded write if shielded, transparent write otherwise
  *     Transparent writes inherit the `sendTransaction` behavior above, so `local` accounts also
  *     use signed `eth_estimateGas` there.
  *   - `swriteContract`: force shielded write — always encrypts calldata via seismic transaction
  *   - `twriteContract`: force transparent write — executes via standard ethereum transaction and
  *     also inherits signed `eth_estimateGas` for `local` accounts
+ *   - `dwriteContract`: send + inspect write — sends a real shielded tx and returns the submitted
+ *     `txHash` together with plaintext and shielded tx views for debugging
  *   - `deposit`: deposit into the deposit contract. This currently uses the transparent
  *     `writeContract` path, so it inherits the same estimateGas behavior.
  *   - `deployContract`: currently still uses viem's direct deploy path; treat its gas-estimation

--- a/clients/ts/packages/seismic-viem/src/contract/contract.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/contract.ts
@@ -153,8 +153,8 @@ type TransparentWriteContractReturnType<
  * The same as viem's {@link https://viem.sh/docs/contract/getContract.html#with-wallet-client GetContractReturnType}, with a few differences:
  * - `read` and `write` are "smart" — they auto-detect shielded params and route accordingly
  * - `sread` and `swrite` always use signed reads & seismic transactions (force shielded)
- * - `tread` and `twrite` behave like viem's standard read & write (force transparent)
- * - `dwrite` returns both plaintext and encrypted tx for debugging
+ * - `tread` and `twrite` always use the transparent path
+ * - `dwrite` sends a real shielded tx and returns both plaintext and shielded tx views for inspection
  */
 export type ShieldedContract<
   TTransport extends Transport = Transport,
@@ -181,12 +181,12 @@ export type ShieldedContract<
  * - `swrite`: force shielded write — always uses encrypted seismic transaction regardless of params
  * - `tread`: force transparent read — always uses unsigned read (from the zero address)
  * - `twrite`: force transparent write — always uses non-encrypted calldata
- * - `dwrite`: debug write — get plaintext and encrypted transaction details
+ * - `dwrite`: send + inspect write — sends a real shielded tx and returns the plaintext/shielded tx details
  *
  * @param {GetContractParameters} params - The configuration object.
  *   - `abi` ({@link Abi}) - The contract's ABI.
  *   - `address` ({@link Address}) - The contract's address.
- *   - `client` ({@link ShieldedWalletClient}) - The client instance to use for interacting with the contract.
+ *   - `client` ({@link ShieldedWalletClient} | keyed client object) - The client instance to use for interacting with the contract.
  *
  * @throws {Error} If the wallet client is not provided for shielded write or signed read operations.
  * @throws {Error} If the wallet client does not have an account configured for signed reads.
@@ -217,10 +217,10 @@ export type ShieldedContract<
  * - The `write` property auto-detects shielded params and routes to shielded write or transparent write
  * - The `sread` property always calls a signed read
  * - The `swrite` property always encrypts calldata via seismic transaction
- * - The `tread` property toggles between public reads and signed reads, depending on whether an `account` is provided
+ * - The `tread` property always performs a transparent read. Seismic zeroes out `from` on transparent `eth_call`, so `tread` rejects `account` here to prevent silent bugs; use `sread` for sender-aware reads
  * - The `twrite` property makes a normal write with transparent calldata
- * - The `dwrite` property returns both plaintext and encrypted tx for debugging
- * - The client must be a {@link ShieldedWalletClient}
+ * - The `dwrite` property sends a real shielded tx and returns inspection data for it
+ * - The client must include a wallet client for write, signed-read, and debug-write surfaces
  */
 export function getShieldedContract<
   TTransport extends Transport,
@@ -503,21 +503,16 @@ export function getShieldedContract<
         ) => {
           const { args, options } = getFunctionParameters(parameters)
           const opts = options as Record<string, unknown>
-          if (opts?.account) {
-            return signedRead({
-              abi,
-              address,
-              functionName,
-              args,
-              ...opts,
-            } as unknown as SignedReadContractParameters<
-              TAbi,
-              ContractFunctionName<TAbi, 'pure' | 'view'>,
-              ContractFunctionArgs<TAbi, 'pure' | 'view'>
-            >)
+          if (opts?.account !== undefined) {
+            throw new Error(
+              'Contract.tread is always transparent. Seismic zeroes out `from` on transparent `eth_call`, so `account` would be ignored on the node and cause silent bugs. Remove `account` or use `contract.sread`.'
+            )
+          }
+          if (readClient === undefined) {
+            throw new Error('Must provide a client to call Contract.tread')
           }
           return transparentReadContract(
-            walletClient as unknown as Parameters<
+            readClient as unknown as Parameters<
               typeof transparentReadContract
             >[0],
             {

--- a/clients/ts/tests/seismic-viem/src/viem.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem.test.ts
@@ -51,7 +51,10 @@ import {
 } from '@sviem-tests/tests/trace.ts'
 import {
   testContractTreadIsntSeismicTx,
+  testContractTreadRejectsAccountOption,
+  testContractTreadWithPublicOnlyClient,
   testShieldedWalletClientTreadIsntSeismicTx,
+  testShieldedWalletClientTreadRejectsAccountOption,
   testViemReadContractIsntSeismicTx,
 } from '@sviem-tests/tests/transparentContract/tread-contract.ts'
 import {
@@ -206,6 +209,37 @@ describe('tread should not use seismic tx', async () => {
     'viem readContract should not use seismic tx',
     async () =>
       await testViemReadContractIsntSeismicTx({ chain, url, account }),
+    {
+      timeout: TIMEOUT_MS,
+    }
+  )
+
+  test(
+    'ShieldedContract.tread rejects account because it is always transparent',
+    async () =>
+      await testContractTreadRejectsAccountOption({ chain, url, account }),
+    {
+      timeout: TIMEOUT_MS,
+    }
+  )
+
+  test(
+    'ShieldedContract.tread works with a public-only keyed client',
+    async () =>
+      await testContractTreadWithPublicOnlyClient({ chain, url, account }),
+    {
+      timeout: TIMEOUT_MS,
+    }
+  )
+
+  test(
+    'ShieldedWalletClient.treadContract rejects account because it is always transparent',
+    async () =>
+      await testShieldedWalletClientTreadRejectsAccountOption({
+        chain,
+        url,
+        account,
+      }),
     {
       timeout: TIMEOUT_MS,
     }


### PR DESCRIPTION
Make contract.tread and walletClient.treadContract behave consistently as strict transparent-read APIs.

Historically, tread appears to have carried an older compatibility shim: if a caller supplied account, the contract surface would quietly upgrade to a signed read instead of staying transparent. That may have made sense before the current read/sread/tread split was explicit, but it no longer matches the API semantics and it hides bugs on Seismic, where transparent eth_call zeroes out from on the node.

This change removes that fallback, makes both tread surfaces reject account explicitly, routes contract.tread through the read client so public-only keyed clients work, updates docs/JSDoc to explain the node behavior, clarifies dwrite as send + inspect, and adds regressions for the new tread behavior.