### PR TITLE
refactor(ts-client): scope securityParams to explicit Seismic paths

### DIFF
--- a/clients/ts/docs/pages/viem/actions/wallet.mdx
+++ b/clients/ts/docs/pages/viem/actions/wallet.mdx
@@ -32,6 +32,8 @@ const transparentResult = await walletClient.treadContract({
 - `sreadContract`: always signed
 - `treadContract`: always transparent. Seismic zeroes out `from` on transparent `eth_call`, so it rejects `account` here to prevent silent bugs; use `sreadContract` for sender-aware reads
 
+`securityParams` are advanced metadata overrides for Seismic signed/shielded paths. Most callers should omit them; they are mainly useful for deterministic tests/debugging, explicit expiry control, and low-level interop. These apply to `sreadContract`, `swriteContract`, `dwriteContract`, `signedCall`, and `sendShieldedTransaction`, not to smart or transparent helpers.
+
 ## Write Helpers
 
 ```ts

--- a/clients/ts/docs/pages/viem/clients/wallet.mdx
+++ b/clients/ts/docs/pages/viem/clients/wallet.mdx
@@ -57,6 +57,8 @@ Important contract helpers:
 - `dwriteContract`: sends a real shielded transaction and returns `txHash`, `plaintextTx`, and `shieldedTx`
 - `deployContract`: still uses viem's direct deploy path, so treat its gas-estimation behavior separately from `sendTransaction`
 
+`securityParams` are advanced metadata overrides for Seismic signed/shielded paths. Most callers should omit them; they are mainly useful for deterministic tests/debugging, explicit expiry control, and low-level interop. These apply to `sreadContract`, `swriteContract`, `dwriteContract`, `signedCall`, and `sendShieldedTransaction`, not to smart or transparent helpers.
+
 ## Parameters
 
 ### parameters

--- a/clients/ts/docs/pages/viem/contract/shielded-write.mdx
+++ b/clients/ts/docs/pages/viem/contract/shielded-write.mdx
@@ -54,6 +54,8 @@ const hash = await shieldedWriteContract(client, {
   abi: parseAbi(['function mint(uint32 tokenId) nonpayable']),
   functionName: 'mint',
   args: [69420],
+}, {
+  blocksWindow: 50n,
 })
 ```
 
@@ -139,3 +141,9 @@ Gas price for the transaction.
 - **Type:** `bigint`
 
 Value (native token amount) to send with the transaction.
+
+### securityParams (optional)
+
+- **Type:** `SeismicSecurityParams`
+
+Advanced Seismic metadata overrides. Most callers should omit these; they are mainly useful for deterministic tests/debugging, explicit expiry control, and low-level interop.

--- a/clients/ts/docs/pages/viem/contract/signed-read.mdx
+++ b/clients/ts/docs/pages/viem/contract/signed-read.mdx
@@ -36,6 +36,8 @@ const result = await signedReadContract(client, {
   functionName: 'balanceOf',
   address: '0x5678...',
   args: [],
+}, {
+  blocksWindow: 50n,
 })
 console.log('Shielded balance:', result)
 ```
@@ -100,6 +102,12 @@ The arguments for the function.
 - **Type:** `Address`
 
 The contract's address on the blockchain.
+
+### securityParams (optional)
+
+- **Type:** `SeismicSecurityParams`
+
+Advanced Seismic metadata overrides. Most callers should omit these; they are mainly useful for deterministic tests/debugging, explicit expiry control, and low-level interop.
 
 ## Throws
 

--- a/clients/ts/packages/seismic-viem-tests/src/index.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/index.ts
@@ -4,6 +4,7 @@ export { connectToNode } from '@sviem-tests/connect.ts'
 export { testSeismicTxEncoding } from '@sviem-tests/tests/encoding.ts'
 export { testSeismicTx } from '@sviem-tests/tests/contract/contract.ts'
 export { testDepositContract } from '@sviem-tests/tests/contract/depositContract.ts'
+export { testDwriteContractUsesSecurityParams } from '@sviem-tests/tests/securityParams.ts'
 export {
   testContractTreadIsntSeismicTx,
   testContractTreadRejectsAccountOption,

--- a/clients/ts/packages/seismic-viem-tests/src/tests/securityParams.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/securityParams.ts
@@ -1,0 +1,62 @@
+import { expect } from 'bun:test'
+import {
+  createShieldedPublicClient,
+  createShieldedWalletClient,
+} from 'seismic-viem'
+import { http } from 'viem'
+
+import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
+import { seismicCounterBytecode } from '@sviem-tests/tests/contract/bytecode.ts'
+import type { ContractTestArgs } from '@sviem-tests/tests/contract/contract.ts'
+
+export const testDwriteContractUsesSecurityParams = async ({
+  chain,
+  url,
+  account,
+}: ContractTestArgs) => {
+  const publicClient = createShieldedPublicClient({
+    chain,
+    transport: http(url),
+  })
+  const walletClient = await createShieldedWalletClient({
+    chain,
+    transport: http(url),
+    account,
+  })
+  const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
+
+  const deployTx = await walletClient.deployContract({
+    abi: seismicCounterAbi,
+    bytecode,
+    chain: walletClient.chain,
+  })
+  const deployReceipt = await publicClient.waitForTransactionReceipt({
+    hash: deployTx,
+  })
+  const address = deployReceipt.contractAddress!
+
+  const latestBlock = await publicClient.getBlock({ blockTag: 'latest' })
+  const encryptionNonce = '0xaaaaaaaaaaaaaaaaaaaaaaaa'
+  const expiresAtBlock = latestBlock.number + 10n
+
+  const { txHash, shieldedTx } = await walletClient.dwriteContract(
+    {
+      address,
+      abi: seismicCounterAbi,
+      functionName: 'setNumber',
+      args: [11n],
+    },
+    {
+      encryptionNonce,
+      recentBlockHash: latestBlock.hash,
+      expiresAtBlock,
+    }
+  )
+
+  expect(shieldedTx.encryptionNonce).toBe(encryptionNonce)
+  expect(shieldedTx.recentBlockHash).toBe(latestBlock.hash)
+  expect(shieldedTx.expiresAtBlock).toBe(expiresAtBlock)
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash })
+  expect(receipt.status).toBe('success')
+}

--- a/clients/ts/packages/seismic-viem/src/actions/wallet.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/wallet.ts
@@ -46,14 +46,21 @@ import type {
  * @template TChain - The type of the blockchain chain (extends `Chain` or `undefined`).
  * @template TAccount - The type of the account (extends `Account` or `undefined`).
  *
- * @property writeContract - Executes a write operation on a shielded contract.
- * Takes parameters specific to the contract and returns the transaction result.
+ * @property writeContract - Smart write helper. Routes to a shielded write when
+ * the target function has shielded params, and to a transparent write otherwise.
  *
- * @property readContract - Reads data from a shielded contract using signed read methods.
- * Returns the contract's data as defined by the provided arguments.
+ * @property readContract - Smart read helper. Routes to a signed read when the
+ * target function has shielded params, and to a transparent read otherwise.
  *
  * @property signedCall - Executes a signed call on the blockchain, allowing for
  * advanced interactions with shielded contracts or transactions.
+ *
+ * Explicit signed/shielded helpers such as `sreadContract`,
+ * `swriteContract`, `dwriteContract`, `signedCall`, and
+ * `sendShieldedTransaction` accept optional `securityParams` advanced metadata
+ * overrides. Most callers should omit these; they are mainly useful for
+ * deterministic tests/debugging, explicit expiry control, and low-level
+ * interoperability.
  *
  * @property sendShieldedTransaction - Sends a shielded transaction using encrypted payloads
  * and advanced features such as blobs and authorization lists.
@@ -95,8 +102,7 @@ export type ShieldedWalletActions<
       TChain,
       TAccount,
       TChainOverride
-    >,
-    securityParams?: SeismicSecurityParams
+    >
   ) => Promise<WriteContractReturnType>
   swriteContract: <
     TAbi extends Abi | readonly unknown[],
@@ -162,8 +168,7 @@ export type ShieldedWalletActions<
     TFunctionName extends ContractFunctionName<TAbi, 'pure' | 'view'>,
     TArgs extends ContractFunctionArgs<TAbi, 'pure' | 'view', TFunctionName>,
   >(
-    args: ReadContractParameters<TAbi, TFunctionName, TArgs>,
-    securityParams?: SeismicSecurityParams
+    args: ReadContractParameters<TAbi, TFunctionName, TArgs>
   ) => Promise<ReadContractReturnType>
   sreadContract: <
     TAbi extends Abi | readonly unknown[],
@@ -178,8 +183,7 @@ export type ShieldedWalletActions<
     TFunctionName extends ContractFunctionName<TAbi, 'pure' | 'view'>,
     TArgs extends ContractFunctionArgs<TAbi, 'pure' | 'view', TFunctionName>,
   >(
-    args: ReadContractParameters<TAbi, TFunctionName, TArgs>,
-    securityParams?: SeismicSecurityParams
+    args: ReadContractParameters<TAbi, TFunctionName, TArgs>
   ) => Promise<ReadContractReturnType>
   signedCall: SignedCall<TChain>
   sendShieldedTransaction: <
@@ -253,27 +257,29 @@ export const shieldedWalletActions = <
         args as unknown as Parameters<typeof sendTransparentTransaction>[1]
       ),
     writeContract: (args) => smartWriteContract(client, args),
-    swriteContract: (args) =>
+    swriteContract: (args, securityParams) =>
       shieldedWriteContract(
         client as unknown as Parameters<typeof shieldedWriteContract>[0],
-        args as unknown as Parameters<typeof shieldedWriteContract>[1]
+        args as unknown as Parameters<typeof shieldedWriteContract>[1],
+        securityParams
       ),
     twriteContract: (args) =>
       transparentWriteContract(
         client as unknown as Parameters<typeof transparentWriteContract>[0],
         args as unknown as Parameters<typeof transparentWriteContract>[1]
       ),
-    dwriteContract: (args) => {
+    dwriteContract: (args, securityParams) => {
       const debugResult = shieldedWriteContractDebug(
         client as unknown as Parameters<typeof shieldedWriteContractDebug>[0],
-        args as unknown as Parameters<typeof shieldedWriteContractDebug>[1]
+        args as unknown as Parameters<typeof shieldedWriteContractDebug>[1],
+        undefined,
+        securityParams
       )
       return debugResult as unknown as Promise<
         ShieldedWriteContractDebugResult<TChain | undefined, TAccount>
       >
     },
-    readContract: (args, securityParams) =>
-      smartReadContract(client, client, args, securityParams),
+    readContract: (args) => smartReadContract(client, client, args),
     sreadContract: (args, securityParams) =>
       signedReadContract(
         client as unknown as Parameters<typeof signedReadContract>[0],

--- a/clients/ts/packages/seismic-viem/src/chain.ts
+++ b/clients/ts/packages/seismic-viem/src/chain.ts
@@ -68,6 +68,20 @@ export type SeismicElements = {
   signedRead: boolean
 } & SeismicBlockParams
 
+/**
+ * Advanced overrides for Seismic metadata generation.
+ *
+ * Most callers should omit these and let the client derive safe defaults from
+ * chain state. These are primarily useful for:
+ *
+ * - deterministic tests and debugging
+ * - reproducing an exact encrypted or signed request shape
+ * - explicit expiry-window control
+ * - low-level interoperability with other Seismic tooling
+ *
+ * These options are only meaningful on Seismic signed or shielded paths. They
+ * do not apply to transparent reads or writes.
+ */
 export type SeismicSecurityParams = {
   blocksWindow?: bigint
   encryptionNonce?: Hex

--- a/clients/ts/packages/seismic-viem/src/client.ts
+++ b/clients/ts/packages/seismic-viem/src/client.ts
@@ -90,18 +90,22 @@ export type ShieldedPublicClient<
  *     performed via a signed `eth_estimateGas` request; for `json-rpc` accounts, this currently
  *     falls back to viem's standard behavior.
  *   - `readContract`: smart read — auto-detects shielded params; uses signed read if shielded, transparent read otherwise
- *   - `sreadContract`: force shielded read — always uses signed read
+ *   - `sreadContract`: force shielded read — always uses signed read. This accepts optional
+ *     `securityParams` advanced metadata overrides for deterministic tests/debugging,
+ *     expiry control, and low-level Seismic interop.
  *   - `treadContract`: force transparent read — always uses unsigned read (from the zero address)
  *     and rejects `account`. Seismic zeroes out `from` on transparent `eth_call`,
  *     so this prevents silent bugs; use `sreadContract` for sender-aware reads.
  *   - `writeContract`: smart write — auto-detects shielded params; uses shielded write if shielded, transparent write otherwise
  *     Transparent writes inherit the `sendTransaction` behavior above, so `local` accounts also
  *     use signed `eth_estimateGas` there.
- *   - `swriteContract`: force shielded write — always encrypts calldata via seismic transaction
+ *   - `swriteContract`: force shielded write — always encrypts calldata via seismic transaction.
+ *     This accepts optional `securityParams` advanced metadata overrides.
  *   - `twriteContract`: force transparent write — executes via standard ethereum transaction and
  *     also inherits signed `eth_estimateGas` for `local` accounts
  *   - `dwriteContract`: send + inspect write — sends a real shielded tx and returns the submitted
- *     `txHash` together with plaintext and shielded tx views for debugging
+ *     `txHash` together with plaintext and shielded tx views for debugging. This also accepts
+ *     optional `securityParams` advanced metadata overrides.
  *   - `deposit`: deposit into the deposit contract. This currently uses the transparent
  *     `writeContract` path, so it inherits the same estimateGas behavior.
  *   - `deployContract`: currently still uses viem's direct deploy path; treat its gas-estimation

--- a/clients/ts/packages/seismic-viem/src/contract/read.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/read.ts
@@ -112,6 +112,9 @@ export async function smartReadContract<
  *   - `args` (array) - The arguments for the function.
  *   - `address` ({@link Hex}) - The contract's address on the blockchain.
  *   - Additional options for customizing the call request.
+ * @param securityParams - Optional advanced Seismic metadata overrides. Most
+ * callers should omit these; they are mainly useful for deterministic
+ * tests/debugging, explicit expiry control, and low-level interop.
  *
  * @returns {Promise<ReadContractReturnType>} A promise that resolves to the response from the contract.
  *

--- a/clients/ts/packages/seismic-viem/src/contract/write.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/write.ts
@@ -144,7 +144,8 @@ export async function shieldedWriteContract<
     TChain,
     TAccount,
     TChainOverride
-  >
+  >,
+  securityParams?: SeismicSecurityParams
 ): Promise<WriteContractReturnType> {
   const plaintextCalldata = getPlaintextCalldata(parameters)
   const request = buildShieldedWriteRequest(
@@ -152,7 +153,7 @@ export async function shieldedWriteContract<
     parameters,
     plaintextCalldata
   )
-  return sendShieldedTransaction(client, request)
+  return sendShieldedTransaction(client, request, securityParams)
 }
 
 type PlaintextTransactionParameters = {
@@ -193,8 +194,9 @@ export type ShieldedWriteContractDebugResult<
  * `writeContract` shape.
  * @param checkContractDeployed - When true, verifies that code exists at the
  * target address before sending.
- * @param securityParams - Optional Seismic metadata controls such as
- * `blocksWindow` and `encryptionNonce`.
+ * @param securityParams - Optional advanced Seismic metadata overrides. Most
+ * callers should omit these; they are mainly useful for deterministic
+ * tests/debugging, explicit expiry control, and low-level interop.
  * @returns Both plaintext and shielded transaction representations, plus the
  * submitted transaction hash.
  */
@@ -221,11 +223,14 @@ export async function shieldedWriteContractDebug<
     TChainOverride
   >,
   checkContractDeployed?: boolean,
-  {
+  securityParams: SeismicSecurityParams = {}
+): Promise<ShieldedWriteContractDebugResult<TChain, TAccount>> {
+  const {
     blocksWindow = 100n,
     encryptionNonce: userEncNonce,
-  }: SeismicSecurityParams = {}
-): Promise<ShieldedWriteContractDebugResult<TChain, TAccount>> {
+    recentBlockHash,
+    expiresAtBlock,
+  } = securityParams
   if (checkContractDeployed) {
     const code = await client.getCode({ address: parameters.address })
     if (code === undefined) {
@@ -246,11 +251,14 @@ export async function shieldedWriteContractDebug<
     value: request.value,
     encryptionNonce,
     blocksWindow,
+    recentBlockHash,
+    expiresAtBlock,
     signedRead: false,
   })
   const txHash = await sendShieldedTransaction(client, request, {
-    blocksWindow,
     encryptionNonce,
+    recentBlockHash: metadata.seismicElements.recentBlockHash,
+    expiresAtBlock: metadata.seismicElements.expiresAtBlock,
   })
   return {
     plaintextTx: {

--- a/clients/ts/packages/seismic-viem/src/index.ts
+++ b/clients/ts/packages/seismic-viem/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  SeismicSecurityParams,
   SeismicTxExtras,
   SeismicTransactionRequest,
   TransactionSerializableSeismic,

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -50,6 +50,9 @@ import type {
  * @param client - The client instance used to execute the transaction, including chain, account,
  * and transport configurations.
  * @param parameters - The transaction parameters, including gas, value, blobs, and other details.
+ * @param securityParams - Optional advanced Seismic metadata overrides. Most
+ * callers should omit these; they are mainly useful for deterministic
+ * tests/debugging, explicit expiry control, and low-level interop.
  *
  * @returns A promise that resolves to the result of the shielded transaction submission.
  *
@@ -88,7 +91,12 @@ export async function sendShieldedTransaction<
     TChainOverride,
     TRequest
   >,
-  { blocksWindow = 100n, encryptionNonce }: SeismicSecurityParams = {}
+  {
+    blocksWindow = 100n,
+    encryptionNonce,
+    recentBlockHash,
+    expiresAtBlock,
+  }: SeismicSecurityParams = {}
 ): Promise<SendSeismicTransactionReturnType> {
   const {
     account: account_ = client.account,
@@ -144,6 +152,8 @@ export async function sendShieldedTransaction<
         blocksWindow,
         signedRead: false,
         encryptionNonce,
+        recentBlockHash,
+        expiresAtBlock,
       })
       const encryptedCalldata = await client.encrypt(
         plaintextCalldata,

--- a/clients/ts/packages/seismic-viem/src/tx/signedCall.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/signedCall.ts
@@ -119,6 +119,9 @@ export type SignedCallParameters<chain extends Chain | undefined> = UnionOmit<
  * - The blockchain account to use for signing.
  * - The contract address, method, and parameters.
  * - Additional transaction-related options (e.g., gas, value).
+ * @param securityParams - Optional advanced Seismic metadata overrides. Most
+ * callers should omit these; they are mainly useful for deterministic
+ * tests/debugging, explicit expiry control, and low-level interop.
  *
  * @returns {Promise<CallReturnType>} A promise that resolves to the result of the signed call,
  * including any data returned by the contract or transaction.
@@ -171,6 +174,9 @@ const prepareAccount = (
  *
  * @param client - {@link ShieldedPublicClient}
  * @param args - {@link SignedCallParameters}
+ * @param securityParams - Optional advanced Seismic metadata overrides. Most
+ * callers should omit these; they are mainly useful for deterministic
+ * tests/debugging, explicit expiry control, and low-level interop.
  *
  * @returns A promise that resolves to the result of the call, including any returned data.
  *
@@ -200,7 +206,12 @@ export async function signedCall<
 >(
   client: ShieldedWalletClient<TTransport, TChain, TAccount>,
   args: SignedCallParameters<TChain>,
-  { blocksWindow = 100n, encryptionNonce }: SeismicSecurityParams = {}
+  {
+    blocksWindow = 100n,
+    encryptionNonce,
+    recentBlockHash,
+    expiresAtBlock,
+  }: SeismicSecurityParams = {}
 ): Promise<CallReturnType> {
   const {
     account: account_ = client.account,
@@ -262,6 +273,8 @@ export async function signedCall<
       to: to!,
       blocksWindow,
       encryptionNonce,
+      recentBlockHash,
+      expiresAtBlock,
       signedRead: true,
     })
     const encryptedCalldata = await client.encrypt(plaintextCalldata, metadata)

--- a/clients/ts/tests/seismic-viem/src/viem.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem.test.ts
@@ -13,6 +13,7 @@ import {
   testWriteWithExplicitGasSkipsEstimation,
   testWriteWithoutExplicitGasSucceeds,
 } from '@sviem-tests/tests/estimateGas.ts'
+import { testDwriteContractUsesSecurityParams } from '@sviem-tests/tests/securityParams.ts'
 import {
   testAesGcm,
   testEcdh,
@@ -120,6 +121,16 @@ describe('Seismic Contract', async () => {
       // @ts-ignore
       await testSeismicTx({ chain, url, account: jsonRpcAccount })
     },
+    {
+      timeout: CONTRACT_TIMEOUT_MS,
+    }
+  )
+})
+
+describe('Security params', async () => {
+  test(
+    'dwriteContract forwards explicit Seismic metadata overrides',
+    async () => await testDwriteContractUsesSecurityParams({ chain, url, account }),
     {
       timeout: CONTRACT_TIMEOUT_MS,
     }

--- a/clients/ts/tests/seismic-viem/src/viem.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem.test.ts
@@ -13,7 +13,6 @@ import {
   testWriteWithExplicitGasSkipsEstimation,
   testWriteWithoutExplicitGasSucceeds,
 } from '@sviem-tests/tests/estimateGas.ts'
-import { testDwriteContractUsesSecurityParams } from '@sviem-tests/tests/securityParams.ts'
 import {
   testAesGcm,
   testEcdh,
@@ -23,6 +22,7 @@ import {
   testRngWithPers,
   testSecp256k1,
 } from '@sviem-tests/tests/precompiles.ts'
+import { testDwriteContractUsesSecurityParams } from '@sviem-tests/tests/securityParams.ts'
 import {
   testHasShieldedParamsDetectsShielded,
   testHasShieldedParamsDetectsTransparent,
@@ -130,7 +130,8 @@ describe('Seismic Contract', async () => {
 describe('Security params', async () => {
   test(
     'dwriteContract forwards explicit Seismic metadata overrides',
-    async () => await testDwriteContractUsesSecurityParams({ chain, url, account }),
+    async () =>
+      await testDwriteContractUsesSecurityParams({ chain, url, account }),
     {
       timeout: CONTRACT_TIMEOUT_MS,
     }


### PR DESCRIPTION
Treat securityParams as advanced Seismic metadata overrides, not general-purpose options on smart contract helpers.

Changes:
- keep securityParams on explicit Seismic APIs only: sreadContract, swriteContract, dwriteContract, signedCall, and sendShieldedTransaction
- remove securityParams from smart/transparent helpers where they become route-dependent no-ops: readContract, writeContract, and treadContract
- export SeismicSecurityParams from the package root and document its intended use cases
- fully wire recentBlockHash and expiresAtBlock through the signed/shielded runtime paths instead of dropping them
- update docs/JSDoc to describe securityParams as advanced controls for deterministic tests/debugging, expiry control, and low-level interop
- add a regression test showing dwriteContract forwards explicit Seismic metadata overrides

Rationale:
securityParams only have meaning on signed/shielded Seismic paths. Exposing them on smart helpers was misleading because they were conditional no-ops depending on ABI routing. This change makes the API honest and ensures the supported metadata overrides work end-to-end.