### PR TITLE
docs(seismic-viem): correct dwrite and tread behavior

### DIFF
--- a/docs/gitbook/clients/typescript/viem/contract-instance.md
+++ b/docs/gitbook/clients/typescript/viem/contract-instance.md
@@ -13,11 +13,11 @@ import { getShieldedContract } from "seismic-viem";
 
 ## Constructor
 
-| Parameter | Type                   | Required | Description                                           |
-| --------- | ---------------------- | -------- | ----------------------------------------------------- |
-| `abi`     | `Abi`                  | Yes      | Contract ABI (use `as const` for full type inference) |
-| `address` | `Address`              | Yes      | Deployed contract address                             |
-| `client`  | `ShieldedWalletClient` | Yes      | Wallet client with encryption capabilities            |
+| Parameter | Type                                | Required | Description                                           |
+| --------- | ----------------------------------- | -------- | ----------------------------------------------------- |
+| `abi`     | `Abi`                               | Yes      | Contract ABI (use `as const` for full type inference) |
+| `address` | `Address`                           | Yes      | Deployed contract address                             |
+| `client`  | `ShieldedWalletClient` \| keyed client | Yes   | Wallet client for full capabilities, or a keyed client (e.g., `{ public: publicClient }`) for read-only use. `.write`, `.swrite`, `.sread`, and `.dwrite` require a wallet client. |
 
 ```typescript
 import { getShieldedContract } from "seismic-viem";
@@ -76,9 +76,9 @@ The returned `ShieldedContract` exposes seven namespaces. Each namespace provide
 | `.write`  | Smart Write       | Auto-detected   | Signer's address | Inspects ABI -- shielded if shielded params, else transparent |
 | `.sread`  | Force Signed Read | Encrypted       | Signer's address | Always authenticated read -- proves identity        |
 | `.swrite` | Force Shielded    | Encrypted       | Signer's address | Always encrypted transaction                        |
-| `.tread`  | Transparent Read  | Plaintext       | Zero address     | Always standard read                                |
+| `.tread`  | Transparent Read  | Plaintext       | Zero address     | Always standard read -- rejects `account`           |
 | `.twrite` | Transparent Write | Plaintext       | Signer's address | Always standard write                               |
-| `.dwrite` | Debug Write       | Encrypted       | Signer's address | Returns plaintext + encrypted tx + hash             |
+| `.dwrite` | Send + Inspect    | Encrypted       | Signer's address | Broadcasts shielded tx and returns plaintext + encrypted tx + hash |
 
 ---
 
@@ -145,6 +145,10 @@ const supply = await contract.tread.totalSupply();
 
 Use `.tread` for public view functions that do not depend on `msg.sender`.
 
+{% hint style="warning" %}
+`.tread` **rejects** the `account` option and will throw. Seismic zeroes out `from` on transparent `eth_call`, so an `account` passed here would be ignored on the node and cause silent bugs. Use `.sread` for sender-aware reads.
+{% endhint %}
+
 ---
 
 ### `.twrite` -- Transparent Write
@@ -159,9 +163,9 @@ Use `.twrite` when you intentionally want calldata to be visible on-chain (e.g.,
 
 ---
 
-### `.dwrite` -- Debug Write
+### `.dwrite` -- Send + Inspect
 
-Builds the same encrypted transaction as `.swrite`, but returns the plaintext transaction, the shielded transaction, and the transaction hash. Useful for inspecting what the SDK produces before sending.
+Sends the same encrypted transaction as `.swrite` -- the tx **is** broadcast and `txHash` is a real on-chain hash -- and additionally returns the plaintext transaction view and the shielded (encrypted) transaction view alongside the hash. Useful for inspecting exactly what the SDK encrypted and submitted.
 
 ```typescript
 const { plaintextTx, shieldedTx, txHash } = await contract.dwrite.transfer([
@@ -173,6 +177,10 @@ console.log("Plaintext calldata:", plaintextTx.data);
 console.log("Encrypted calldata:", shieldedTx.data);
 console.log("Transaction hash:", txHash);
 ```
+
+{% hint style="info" %}
+Despite the "debug" flavor of the name, `.dwrite` broadcasts a real shielded transaction. If you just want to see what would be sent without submitting, build the calldata yourself via `getPlaintextCalldata`.
+{% endhint %}
 
 ## TypeScript ABI Typing
 

--- a/docs/gitbook/clients/typescript/viem/contract-instance.md
+++ b/docs/gitbook/clients/typescript/viem/contract-instance.md
@@ -17,7 +17,7 @@ import { getShieldedContract } from "seismic-viem";
 | --------- | ----------------------------------- | -------- | ----------------------------------------------------- |
 | `abi`     | `Abi`                               | Yes      | Contract ABI (use `as const` for full type inference) |
 | `address` | `Address`                           | Yes      | Deployed contract address                             |
-| `client`  | `ShieldedWalletClient` \| keyed client | Yes   | Wallet client for full capabilities, or a keyed client (e.g., `{ public: publicClient }`) for read-only use. `.write`, `.swrite`, `.sread`, and `.dwrite` require a wallet client. |
+| `client`  | `ShieldedWalletClient` \| keyed client | Yes   | Wallet client for full capabilities, or a keyed client (e.g., `{ public: publicClient }`) for read-only use. All writes (`.write`, `.swrite`, `.twrite`, `.dwrite`) and signed reads (`.sread`, plus `.read` when the target function has shielded params) require a wallet client. A keyed read-only client only supports `.tread` and `.read` on functions without shielded params. |
 
 ```typescript
 import { getShieldedContract } from "seismic-viem";

--- a/docs/gitbook/clients/typescript/viem/shielded-wallet-client.md
+++ b/docs/gitbook/clients/typescript/viem/shielded-wallet-client.md
@@ -95,10 +95,10 @@ When you call `createShieldedWalletClient()`, the following steps happen:
 | `writeContract(params)`           | Smart write -- inspects ABI for shielded params; encrypts if shielded, sends transparent otherwise                 |
 | `swriteContract(params)`          | Force shielded write -- always encrypts calldata with the AES key before sending                                   |
 | `twriteContract(params)`          | Transparent write -- always sends with plaintext calldata (unencrypted)                                            |
-| `dwriteContract(params)`          | Debug write -- returns the plaintext tx, encrypted tx, and tx hash without broadcasting                            |
+| `dwriteContract(params)`          | Send + inspect write -- broadcasts a real shielded tx and returns the plaintext tx, shielded tx, and `txHash`       |
 | `readContract(params)`            | Smart read -- inspects ABI for shielded params; uses signed read if shielded, transparent read otherwise            |
 | `sreadContract(params)`           | Force signed read -- always authenticated `eth_call` that proves the caller's identity                             |
-| `treadContract(params)`           | Transparent read -- always standard unsigned call                                                                  |
+| `treadContract(params)`           | Transparent read -- always standard unsigned call. Rejects `account` (Seismic zeroes out `from` on transparent `eth_call`); use `sreadContract` for sender-aware reads |
 | `signedCall(params)`              | Low-level signed `eth_call`                                                                                        |
 | `sendShieldedTransaction(params)` | Low-level shielded transaction send                                                                                |
 
@@ -210,10 +210,11 @@ const walletClient2 = await createShieldedWalletClient({
 });
 ```
 
-### Debug Write
+### Send + Inspect Write
 
 ```typescript
-// Debug write: inspect the transaction without broadcasting
+// dwriteContract broadcasts a real shielded tx AND returns the plaintext
+// and shielded tx views for inspection. txHash is a real on-chain hash.
 const debugResult = await walletClient.dwriteContract({
   address: "0xContractAddress",
   abi: contractAbi,

--- a/docs/gitbook/clients/typescript/viem/shielded-writes.md
+++ b/docs/gitbook/clients/typescript/viem/shielded-writes.md
@@ -55,9 +55,13 @@ const hash = await shieldedWriteContract(client, {
 
 ---
 
-## Debug: `shieldedWriteContractDebug`
+## Send + Inspect: `shieldedWriteContractDebug`
 
-Returns the plaintext transaction, the shielded (encrypted) transaction, and the transaction hash. Useful for inspecting what the SDK encrypts and broadcasts.
+Broadcasts a shielded transaction (like `shieldedWriteContract`) and additionally returns the plaintext transaction view and the shielded (encrypted) transaction view alongside the resulting transaction hash. Useful for inspecting exactly what the SDK encrypted and submitted.
+
+{% hint style="info" %}
+Despite the "debug" flavor of the name, `shieldedWriteContractDebug` does send the transaction -- the returned `txHash` is a real on-chain hash, not a dry run.
+{% endhint %}
 
 ```typescript
 import { shieldedWriteContractDebug } from "seismic-viem";

--- a/docs/gitbook/clients/typescript/viem/signed-reads.md
+++ b/docs/gitbook/clients/typescript/viem/signed-reads.md
@@ -130,6 +130,10 @@ const supply2 = await contract.tread.totalSupply();
 The smart `.read` namespace handles most cases correctly by inspecting the ABI. Use `.sread` when you need the response encrypted even though the function has no shielded input parameters. Use `.tread` only for public data where you don't need authentication.
 {% endhint %}
 
+{% hint style="warning" %}
+`.tread` and `walletClient.treadContract` reject the `account` option and will throw. On Seismic, transparent `eth_call` zeroes out `from` on the node, so any `account` you pass would silently be ignored. For any sender-aware read, use `.sread` / `sreadContract`.
+{% endhint %}
+
 ## See Also
 
 - [Contract Instance](contract-instance.md) -- `getShieldedContract` with `.read` and `.tread` namespaces


### PR DESCRIPTION
## Summary

Follow-up to #143 (docs for smart routing), which was written before #171 / #175 landed and missed a few code-behavior updates.

Mismatches against the current \`main\` code, now corrected:

- **\`.dwrite\` / \`dwriteContract\` / \`shieldedWriteContractDebug\`** — docs said these returned tx views *without broadcasting*. They actually broadcast a real shielded transaction and return a real \`txHash\`. JSDoc in #171 explicitly calls this out. Reworded as "Send + Inspect" and added hints warning that the tx is submitted.
- **\`.tread\` / \`treadContract\`** — #175 made these strictly transparent and they **throw** if \`account\` is passed (Seismic zeroes out \`from\` on transparent \`eth_call\`, so an \`account\` would silently be ignored). Added warnings that point to \`.sread\` / \`sreadContract\` for sender-aware reads.
- **\`getShieldedContract\` \`client\` param** — now accepts a keyed client (e.g. \`{ public: publicClient }\`) for read-only use. Constructor table updated; clarified that all writes (\`.write\`, \`.swrite\`, \`.twrite\`, \`.dwrite\`) and signed reads (\`.sread\`, plus \`.read\` for shielded-param functions) still require a wallet client — a keyed read-only client only supports \`.tread\` and \`.read\` on non-shielded-param functions.

## Files

- \`docs/gitbook/clients/typescript/viem/contract-instance.md\`
- \`docs/gitbook/clients/typescript/viem/shielded-wallet-client.md\`
- \`docs/gitbook/clients/typescript/viem/shielded-writes.md\`
- \`docs/gitbook/clients/typescript/viem/signed-reads.md\`

## Test plan

- [x] Render on GitBook and verify the hint callouts display
- [ ] Sanity-check that the updated \`.dwrite\` / \`.tread\` descriptions match the JSDoc in \`clients/ts/packages/seismic-viem/src/contract/contract.ts\` and \`.../write.ts\`