### PR TITLE
refactor(ts-client): centralize blocksWindow defaults

### DIFF
--- a/clients/ts/packages/seismic-encrypt/src/index.ts
+++ b/clients/ts/packages/seismic-encrypt/src/index.ts
@@ -19,6 +19,7 @@ import { hkdf } from '@noble/hashes/hkdf'
 import { sha256 } from '@noble/hashes/sha256'
 
 export const SEISMIC_TX_TYPE = 0x4a
+const DEFAULT_SEISMIC_BLOCKS_WINDOW = 100n
 
 // ── Helpers (inlined from seismic-viem to keep this package standalone) ──
 
@@ -191,7 +192,10 @@ export type EncryptSeismicTxParams = {
   rpcUrl: string
   /** Optional: your own encryption private key (ephemeral one generated if omitted) */
   encryptionPrivateKey?: Hex
-  /** Optional: how many blocks until this tx expires (default 100) */
+  /**
+   * Optional: how many blocks until this tx expires.
+   * Defaults to `DEFAULT_SEISMIC_BLOCKS_WINDOW`.
+   */
   blocksWindow?: bigint
 }
 
@@ -248,7 +252,7 @@ export const encryptSeismicTx = async ({
   sender,
   rpcUrl,
   encryptionPrivateKey,
-  blocksWindow = 100n,
+  blocksWindow = DEFAULT_SEISMIC_BLOCKS_WINDOW,
 }: EncryptSeismicTxParams): Promise<EncryptSeismicTxResult> => {
   const client = createPublicClient({ transport: http(rpcUrl) })
 

--- a/clients/ts/packages/seismic-viem/src/chain.ts
+++ b/clients/ts/packages/seismic-viem/src/chain.ts
@@ -83,9 +83,31 @@ export type SeismicElements = {
  * do not apply to transparent reads or writes.
  */
 export type SeismicSecurityParams = {
+  /**
+   * Expiry window used when deriving `expiresAtBlock` from a recent block.
+   * Defaults to the standard 100-block window.
+   * Ignored when `expiresAtBlock` is provided explicitly.
+   */
   blocksWindow?: bigint
+  /**
+   * Override the AEAD encryption nonce used for the Seismic payload.
+   * Mainly useful for deterministic tests or reproducing an exact request.
+   * When omitted, a random nonce is generated.
+   */
   encryptionNonce?: Hex
+  /**
+   * Override the recent block hash used for freshness and replay protection.
+   * If provided without `expiresAtBlock`, expiry is derived from this block plus
+   * `blocksWindow`.
+   * When omitted, the latest block hash is used.
+   */
   recentBlockHash?: Hex
+  /**
+   * Override the block height after which the signed or shielded request is no
+   * longer valid.
+   * When omitted, expiry is derived from the chosen recent block plus
+   * `blocksWindow`.
+   */
   expiresAtBlock?: bigint
 }
 

--- a/clients/ts/packages/seismic-viem/src/contract/write.ts
+++ b/clients/ts/packages/seismic-viem/src/contract/write.ts
@@ -226,7 +226,7 @@ export async function shieldedWriteContractDebug<
   securityParams: SeismicSecurityParams = {}
 ): Promise<ShieldedWriteContractDebugResult<TChain, TAccount>> {
   const {
-    blocksWindow = 100n,
+    blocksWindow,
     encryptionNonce: userEncNonce,
     recentBlockHash,
     expiresAtBlock,

--- a/clients/ts/packages/seismic-viem/src/metadata.ts
+++ b/clients/ts/packages/seismic-viem/src/metadata.ts
@@ -17,6 +17,8 @@ import { ShieldedWalletClient } from '@sviem/client.ts'
 import { randomEncryptionNonce } from '@sviem/crypto/nonce.ts'
 import { TYPED_DATA_MESSAGE_VERSION } from '@sviem/signSeismicTypedData.ts'
 
+const DEFAULT_SEISMIC_BLOCKS_WINDOW = 100n
+
 export type LegacyFields = {
   chainId: number
   nonce: number
@@ -86,7 +88,7 @@ export const buildTxSeismicMetadata = async <
     to,
     value = 0n,
     encryptionNonce,
-    blocksWindow = 100n,
+    blocksWindow = DEFAULT_SEISMIC_BLOCKS_WINDOW,
     recentBlockHash,
     expiresAtBlock,
     typedDataTx,

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -92,7 +92,7 @@ export async function sendShieldedTransaction<
     TRequest
   >,
   {
-    blocksWindow = 100n,
+    blocksWindow,
     encryptionNonce,
     recentBlockHash,
     expiresAtBlock,

--- a/clients/ts/packages/seismic-viem/src/tx/signedCall.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/signedCall.ts
@@ -207,7 +207,7 @@ export async function signedCall<
   client: ShieldedWalletClient<TTransport, TChain, TAccount>,
   args: SignedCallParameters<TChain>,
   {
-    blocksWindow = 100n,
+    blocksWindow,
     encryptionNonce,
     recentBlockHash,
     expiresAtBlock,


### PR DESCRIPTION
Make metadata construction the single source of truth for the default blocks window in seismic-viem instead of re-defaulting it in multiple wrapper layers.

Changes:
- keep the default blocks window internal to metadata derivation
- remove duplicate wrapper-level  defaults from signedCall, sendShieldedTransaction, and debug-write paths
- keep seismic-encrypt on a single internal named default instead of a repeated literal
- add field-level SeismicSecurityParams docs clarifying default behavior for blocksWindow, encryptionNonce, recentBlockHash, and expiresAtBlock