### PR TITLE
chore: rename gcp-N.seismictest.net to testnet-N.seismictest.net

### DIFF
--- a/clients/py/pyproject.toml
+++ b/clients/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seismic-web3"
-version = "0.2.1"
+version = "0.1.3"
 description = "Seismic Python SDK — web3.py extensions for the Seismic network"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/py/src/seismic_web3/__init__.py
+++ b/clients/py/src/seismic_web3/__init__.py
@@ -37,7 +37,7 @@ Public API
     :func:`build_seismic_typed_data`
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # -- Types -------------------------------------------------------------------
 from seismic_web3._types import (

--- a/clients/py/src/seismic_web3/chains.py
+++ b/clients/py/src/seismic_web3/chains.py
@@ -223,7 +223,7 @@ def make_seismic_testnet(
             "Provide either n or host, not both.",
         )
     if host is None:
-        host = f"gcp-{n}.seismictest.net"
+        host = f"testnet-{n}.seismictest.net"
     return ChainConfig(
         chain_id=SEISMIC_TESTNET_CHAIN_ID,
         rpc_url=f"https://{host}/rpc",

--- a/clients/py/tests/test_chains.py
+++ b/clients/py/tests/test_chains.py
@@ -45,10 +45,10 @@ class TestSeismicTestnet:
         assert SEISMIC_TESTNET.chain_id == 5124
 
     def test_rpc_url(self):
-        assert SEISMIC_TESTNET.rpc_url == "https://gcp-1.seismictest.net/rpc"
+        assert SEISMIC_TESTNET.rpc_url == "https://testnet-1.seismictest.net/rpc"
 
     def test_ws_url(self):
-        assert SEISMIC_TESTNET.ws_url == "wss://gcp-1.seismictest.net/ws"
+        assert SEISMIC_TESTNET.ws_url == "wss://testnet-1.seismictest.net/ws"
 
     def test_name(self):
         assert "Testnet" in SEISMIC_TESTNET.name
@@ -58,8 +58,8 @@ class TestMakeSeismicTestnet:
     def test_instance_2(self):
         cfg = make_seismic_testnet(2)
         assert cfg.chain_id == 5124
-        assert "gcp-2" in cfg.rpc_url
-        assert "gcp-2" in (cfg.ws_url or "")
+        assert "testnet-2" in cfg.rpc_url
+        assert "testnet-2" in (cfg.ws_url or "")
 
     def test_default_is_1(self):
         cfg = make_seismic_testnet()

--- a/clients/py/tests/test_placeholder.py
+++ b/clients/py/tests/test_placeholder.py
@@ -2,4 +2,4 @@ import seismic_web3
 
 
 def test_import():
-    assert seismic_web3.__version__ == "0.1.2"
+    assert seismic_web3.__version__ == "0.1.3"

--- a/clients/py/uv.lock
+++ b/clients/py/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "seismic-web3"
-version = "0.2.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "coincurve" },

--- a/clients/ts/packages/seismic-encrypt/README.md
+++ b/clients/ts/packages/seismic-encrypt/README.md
@@ -15,7 +15,7 @@ import { encryptSeismicTx } from 'seismic-encrypt'
 import { createPublicClient, encodeFunctionData, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 
-const RPC_URL = 'https://gcp-1.seismictest.net/rpc'
+const RPC_URL = 'https://testnet-1.seismictest.net/rpc'
 
 const account = privateKeyToAccount('0xYourPrivateKey')
 const client = createPublicClient({ transport: http(RPC_URL) })
@@ -117,7 +117,7 @@ const { seismicTx, serialize } = await encryptSeismicTx({
     chainId: 5124,
   },
   sender: account.address,
-  rpcUrl: 'https://gcp-1.seismictest.net/rpc',
+  rpcUrl: 'https://testnet-1.seismictest.net/rpc',
 })
 ```
 

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React components for Seismic.",
   "type": "module",
   "main": "./dist/_cjs/index.js",

--- a/clients/ts/packages/seismic-react/src/rainbowkit/chain.ts
+++ b/clients/ts/packages/seismic-react/src/rainbowkit/chain.ts
@@ -23,8 +23,8 @@ const toRainbowKitChain = (chain: ViemChain): RainbowKitChain => {
 }
 
 /** Seismic's testnet at:
- * - https: https://gcp-1.seismictest.net/rpc
- * - wss: wss://gcp-1.seismictest.net/ws
+ * - https: https://testnet-1.seismictest.net/rpc
+ * - wss: wss://testnet-1.seismictest.net/ws
  * - explorer: https://seismic-testnet.socialscan.io
  */
 export const seismicTestnet = toRainbowKitChain(seismicTestnetViem)
@@ -46,7 +46,7 @@ export const localSeismicDevnet = toRainbowKitChain(
  * Creates a Seismic chain configuration.
  *
  * @param {CreateSeismicDevnetParams} params - The parameters for creating a Seismic chain.
- *   - `nodeHost` (string) - The hostname for the node (e.g. `gcp-1.seismictest.net`).
+ *   - `nodeHost` (string) - The hostname for the node (e.g. `testnet-1.seismictest.net`).
  *   - `explorerUrl` (string, optional) - Block explorer URL.
  *
  * @throws {Error} Throws if `nodeHost` is not provided.
@@ -61,7 +61,7 @@ export const localSeismicDevnet = toRainbowKitChain(
  *
  * @example
  * ```typescript
- * const chain = createSeismicDevnet({ nodeHost: 'gcp-1.seismictest.net' });
+ * const chain = createSeismicDevnet({ nodeHost: 'testnet-1.seismictest.net' });
  * ```
  */
 export const createSeismicDevnet = (

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-viem",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Typescript interface for Seismic",
   "type": "module",
   "main": "./dist/_cjs/index.js",

--- a/clients/ts/packages/seismic-viem/src/chain.ts
+++ b/clients/ts/packages/seismic-viem/src/chain.ts
@@ -78,6 +78,12 @@ export const createSeismicAzTestnet = (n: number) =>
 
 export const createSeismicGcpTestnet = (n: number) =>
   createSeismicDevnet({
+    nodeHost: `gcp-${n}.seismictest.net`,
+    explorerUrl: 'https://seismic-testnet.socialscan.io',
+  })
+
+export const createSeismicTestnet = (n: number) =>
+  createSeismicDevnet({
     nodeHost: `testnet-${n}.seismictest.net`,
     explorerUrl: 'https://seismic-testnet.socialscan.io',
   })
@@ -91,8 +97,8 @@ export const createSeismicGcpTestnet = (n: number) =>
 export const seismicTestnetGcp1 = createSeismicGcpTestnet(1)
 export const seismicTestnetGcp2 = createSeismicGcpTestnet(2)
 
-export const seismicTestnet1 = seismicTestnetGcp1
-export const seismicTestnet2 = seismicTestnetGcp2
+export const seismicTestnet1 = createSeismicTestnet(1)
+export const seismicTestnet2 = createSeismicTestnet(2)
 
 export const seismicTestnet = seismicTestnet1
 

--- a/clients/ts/packages/seismic-viem/src/chain.ts
+++ b/clients/ts/packages/seismic-viem/src/chain.ts
@@ -19,7 +19,7 @@ export type CreateSeismicTestnetParams = {
  * Creates a Seismic chain configuration.
  *
  * @param {CreateSeismicDevnetParams} params - The parameters for creating a Seismic chain.
- *   - `nodeHost` (string) - The hostname for the node (e.g. `gcp-1.seismictest.net`).
+ *   - `nodeHost` (string) - The hostname for the node (e.g. `testnet-1.seismictest.net`).
  *   - `explorerUrl` (string, optional) - Block explorer URL.
  *
  * @throws {Error} Throws if `nodeHost` is not provided.
@@ -34,7 +34,7 @@ export type CreateSeismicTestnetParams = {
  *
  * @example
  * ```typescript
- * const chain = createSeismicDevnet({ nodeHost: 'gcp-1.seismictest.net' });
+ * const chain = createSeismicDevnet({ nodeHost: 'testnet-1.seismictest.net' });
  * ```
  */
 export const createSeismicDevnet = /*#__PURE__*/ ({
@@ -42,7 +42,9 @@ export const createSeismicDevnet = /*#__PURE__*/ ({
   explorerUrl,
 }: CreateSeismicDevnetParams): Chain => {
   if (!nodeHost) {
-    throw new Error('Must set `nodeHost` argument, e.g. gcp-1.seismictest.net')
+    throw new Error(
+      'Must set `nodeHost` argument, e.g. testnet-1.seismictest.net'
+    )
   }
 
   return defineChain({
@@ -76,7 +78,7 @@ export const createSeismicAzTestnet = (n: number) =>
 
 export const createSeismicGcpTestnet = (n: number) =>
   createSeismicDevnet({
-    nodeHost: `gcp-${n}.seismictest.net`,
+    nodeHost: `testnet-${n}.seismictest.net`,
     explorerUrl: 'https://seismic-testnet.socialscan.io',
   })
 

--- a/clients/ts/packages/seismic-viem/src/index.ts
+++ b/clients/ts/packages/seismic-viem/src/index.ts
@@ -23,6 +23,7 @@ export {
   createSeismicDevnet,
   createSeismicAzTestnet,
   createSeismicGcpTestnet,
+  createSeismicTestnet,
 } from '@sviem/chain.ts'
 export {
   SEISMIC_TX_TYPE,

--- a/docs/gitbook/claude-code/templates/seismic-alloy.md
+++ b/docs/gitbook/claude-code/templates/seismic-alloy.md
@@ -67,7 +67,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```
@@ -77,7 +77,7 @@ let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```rust
 use seismic_alloy::prelude::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 ```
 
@@ -158,8 +158,8 @@ You do not need to manually encrypt calldata or set Seismic-specific transaction
 
 | Network        | Chain ID | RPC URL                             | Network type     |
 | -------------- | -------- | ----------------------------------- | ---------------- |
-| Testnet         | 5124     | `https://gcp-1.seismictest.net/rpc` | `SeismicReth`    |
-| Testnet (WS)    | 5124     | `wss://gcp-1.seismictest.net/ws`    | `SeismicReth`    |
+| Testnet         | 5124     | `https://testnet-1.seismictest.net/rpc` | `SeismicReth`    |
+| Testnet (WS)    | 5124     | `wss://testnet-1.seismictest.net/ws`    | `SeismicReth`    |
 | Local (sanvil) | 31337    | `http://127.0.0.1:8545`             | `SeismicFoundry` |
 
 Faucet: https://faucet.seismictest.net/

--- a/docs/gitbook/claude-code/templates/seismic-python.md
+++ b/docs/gitbook/claude-code/templates/seismic-python.md
@@ -152,8 +152,8 @@ The wallet client automatically handles encryption. On creation, it fetches the 
 
 | Network        | Chain ID | Chain config      | RPC URL                             |
 | -------------- | -------- | ----------------- | ----------------------------------- |
-| Testnet         | 5124     | `SEISMIC_TESTNET` | `https://gcp-1.seismictest.net/rpc` |
-| Testnet (WS)    | 5124     | `SEISMIC_TESTNET` | `wss://gcp-1.seismictest.net/ws`    |
+| Testnet         | 5124     | `SEISMIC_TESTNET` | `https://testnet-1.seismictest.net/rpc` |
+| Testnet (WS)    | 5124     | `SEISMIC_TESTNET` | `wss://testnet-1.seismictest.net/ws`    |
 | Local (sanvil) | 31337    | `SANVIL`          | `http://127.0.0.1:8545`             |
 
 Faucet: https://faucet.seismictest.net/

--- a/docs/gitbook/claude-code/templates/seismic-react.md
+++ b/docs/gitbook/claude-code/templates/seismic-react.md
@@ -184,8 +184,8 @@ function App() {
 
 | Network        | Chain ID | RPC URL                             |
 | -------------- | -------- | ----------------------------------- |
-| Testnet         | 5124     | `https://gcp-1.seismictest.net/rpc` |
-| Testnet (WS)    | 5124     | `wss://gcp-1.seismictest.net/ws`    |
+| Testnet         | 5124     | `https://testnet-1.seismictest.net/rpc` |
+| Testnet (WS)    | 5124     | `wss://testnet-1.seismictest.net/ws`    |
 | Local (sanvil) | 31337    | `http://127.0.0.1:8545`             |
 
 Faucet: https://faucet.seismictest.net/

--- a/docs/gitbook/claude-code/templates/seismic-solidity.md
+++ b/docs/gitbook/claude-code/templates/seismic-solidity.md
@@ -119,12 +119,12 @@ sforge test --match-test testTransfer  # Run specific test
 ```bash
 # Deploy to testnet
 sforge create src/MyContract.sol:MyContract \
-    --rpc-url https://gcp-1.seismictest.net/rpc \
+    --rpc-url https://testnet-1.seismictest.net/rpc \
     --private-key $PRIVATE_KEY
 
 # Deploy with script
 sforge script script/Deploy.s.sol \
-    --rpc-url https://gcp-1.seismictest.net/rpc \
+    --rpc-url https://testnet-1.seismictest.net/rpc \
     --private-key $PRIVATE_KEY \
     --broadcast
 ```
@@ -147,8 +147,8 @@ sanvil  # Starts local Seismic node on http://127.0.0.1:8545
 
 | Network        | Chain ID | RPC URL                             |
 | -------------- | -------- | ----------------------------------- |
-| Testnet         | 5124     | `https://gcp-1.seismictest.net/rpc` |
-| Testnet (WS)    | 5124     | `wss://gcp-1.seismictest.net/ws`    |
+| Testnet         | 5124     | `https://testnet-1.seismictest.net/rpc` |
+| Testnet (WS)    | 5124     | `wss://testnet-1.seismictest.net/ws`    |
 | Local (sanvil) | 31337    | `http://127.0.0.1:8545`             |
 
 Faucet: https://faucet.seismictest.net/

--- a/docs/gitbook/claude-code/templates/seismic-viem.md
+++ b/docs/gitbook/claude-code/templates/seismic-viem.md
@@ -57,7 +57,7 @@ import { http } from "viem";
 
 const walletClient = await createShieldedWalletClient({
   chain: seismicTestnet,
-  transport: http("https://gcp-1.seismictest.net/rpc"),
+  transport: http("https://testnet-1.seismictest.net/rpc"),
   privateKey: "0xYOUR_PRIVATE_KEY",
 });
 ```
@@ -70,7 +70,7 @@ import { http } from "viem";
 
 const publicClient = await createShieldedPublicClient({
   chain: seismicTestnet,
-  transport: http("https://gcp-1.seismictest.net/rpc"),
+  transport: http("https://testnet-1.seismictest.net/rpc"),
 });
 ```
 
@@ -110,7 +110,7 @@ import { createPublicClient, http } from "viem";
 // Use a standard viem public client for receipt watching
 const publicClient = createPublicClient({
   chain: seismicTestnet,
-  transport: http("https://gcp-1.seismictest.net/rpc"),
+  transport: http("https://testnet-1.seismictest.net/rpc"),
 });
 
 const receipt = await publicClient.waitForTransactionReceipt({ hash });
@@ -128,8 +128,8 @@ const receipt = await publicClient.waitForTransactionReceipt({ hash });
 
 | Network        | Chain ID | RPC URL                             | Chain export    |
 | -------------- | -------- | ----------------------------------- | --------------- |
-| Testnet         | 5124     | `https://gcp-1.seismictest.net/rpc` | `seismicTestnet` |
-| Testnet (WS)    | 5124     | `wss://gcp-1.seismictest.net/ws`    | `seismicTestnet` |
+| Testnet         | 5124     | `https://testnet-1.seismictest.net/rpc` | `seismicTestnet` |
+| Testnet (WS)    | 5124     | `wss://testnet-1.seismictest.net/ws`    | `seismicTestnet` |
 | Local (sanvil) | 31337    | `http://127.0.0.1:8545`             | —               |
 
 Faucet: https://faucet.seismictest.net/

--- a/docs/gitbook/claude-code/workflow-skills.md
+++ b/docs/gitbook/claude-code/workflow-skills.md
@@ -47,7 +47,7 @@ Deploy a Seismic smart contract using sforge.
 
 4. **Choose network** — Ask which network to deploy to:
    - **Local (sanvil):** `http://127.0.0.1:8545` — start sanvil first with `sanvil`
-   - **Testnet:** `https://gcp-1.seismictest.net/rpc` — needs funded wallet from https://faucet.seismictest.net/
+   - **Testnet:** `https://testnet-1.seismictest.net/rpc` — needs funded wallet from https://faucet.seismictest.net/
 
 5. **Deploy** — Run the deployment:
 

--- a/docs/gitbook/clients/alloy/README.md
+++ b/docs/gitbook/clients/alloy/README.md
@@ -22,7 +22,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Unsigned provider -- read-only (no private key needed)
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 
 let block = provider.get_block_number().await?;

--- a/docs/gitbook/clients/alloy/chains/README.md
+++ b/docs/gitbook/clients/alloy/chains/README.md
@@ -19,7 +19,7 @@ let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
 
 // Testnet
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_signed_provider(wallet, url).await?;
 
 // Local (Sanvil)
@@ -31,7 +31,7 @@ let provider = sfoundry_signed_provider(wallet, url).await?;
 
 | Chain                                 | Chain ID | RPC URL                           | Network Type     | Description                                |
 | ------------------------------------- | -------- | --------------------------------- | ---------------- | ------------------------------------------ |
-| [Seismic Testnet](seismic-testnet.md) | `5124`   | `https://gcp-1.seismictest.net/rpc` | `SeismicReth`    | Public testnet for development and testing |
+| [Seismic Testnet](seismic-testnet.md) | `5124`   | `https://testnet-1.seismictest.net/rpc` | `SeismicReth`    | Public testnet for development and testing |
 | [Sanvil (local)](sanvil.md)           | `31337`  | `http://127.0.0.1:8545`           | `SeismicFoundry` | Local development node                     |
 
 ## Choosing a Chain
@@ -55,7 +55,7 @@ The Alloy provider automatically fetches the chain ID from the connected node vi
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 
 // Chain ID is fetched from the node

--- a/docs/gitbook/clients/alloy/chains/seismic-testnet.md
+++ b/docs/gitbook/clients/alloy/chains/seismic-testnet.md
@@ -12,7 +12,7 @@ The Seismic public testnet is the primary network for development and testing. I
 | Property          | Value                              |
 | ----------------- | ---------------------------------- |
 | Chain ID          | `5124`                             |
-| RPC URL           | `https://gcp-1.seismictest.net/rpc`  |
+| RPC URL           | `https://testnet-1.seismictest.net/rpc`  |
 | Network Type      | `SeismicReth`                      |
 | Transaction Types | Legacy, EIP-1559, Seismic (`0x4A`) |
 
@@ -30,7 +30,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = sreth_signed_provider(wallet, url).await?;
 
@@ -52,7 +52,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let block_number = provider.get_block_number().await?;
@@ -72,7 +72,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```
@@ -90,7 +90,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = sreth_signed_provider(wallet, url).await?;
 
@@ -116,7 +116,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     match provider.get_chain_id().await {
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let wallet = SeismicWallet::from(signer);
 
     let rpc_url = env::var("SEISMIC_RPC_URL")
-        .unwrap_or_else(|_| "https://gcp-1.seismictest.net/rpc".to_string());
+        .unwrap_or_else(|_| "https://testnet-1.seismictest.net/rpc".to_string());
     let url = rpc_url.parse()?;
 
     let provider = sreth_signed_provider(wallet, url).await?;

--- a/docs/gitbook/clients/alloy/contract-interaction/shielded-calls.md
+++ b/docs/gitbook/clients/alloy/contract-interaction/shielded-calls.md
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up provider
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let contract_address: Address = "0x1234...".parse()?;
@@ -176,7 +176,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up signed provider (required for signed reads)
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let contract_address: Address = "0x1234...".parse()?;

--- a/docs/gitbook/clients/alloy/contract-interaction/transparent-calls.md
+++ b/docs/gitbook/clients/alloy/contract-interaction/transparent-calls.md
@@ -127,7 +127,7 @@ Transparent reads do not require a private key, so you can use `SeismicUnsignedP
 use seismic_prelude::foundry::*;
 
 // No private key needed
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 
 // Transparent read works with unsigned provider
@@ -164,7 +164,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up signed provider
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     // 1. Deploy contract (transparent -- Create txs cannot be seismic)

--- a/docs/gitbook/clients/alloy/examples/README.md
+++ b/docs/gitbook/clients/alloy/examples/README.md
@@ -65,7 +65,7 @@ rustup update stable
 
 # Set environment variables
 export PRIVATE_KEY="0x..."
-export RPC_URL="https://gcp-1.seismictest.net/rpc"
+export RPC_URL="https://testnet-1.seismictest.net/rpc"
 ```
 
 And your `Cargo.toml` includes:

--- a/docs/gitbook/clients/alloy/examples/basic-setup.md
+++ b/docs/gitbook/clients/alloy/examples/basic-setup.md
@@ -15,7 +15,7 @@ rustup update stable
 
 # Set environment variables
 export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-export RPC_URL="https://gcp-1.seismictest.net/rpc"
+export RPC_URL="https://testnet-1.seismictest.net/rpc"
 ```
 
 `Cargo.toml`:

--- a/docs/gitbook/clients/alloy/examples/contract-deployment.md
+++ b/docs/gitbook/clients/alloy/examples/contract-deployment.md
@@ -15,8 +15,8 @@ This example demonstrates the full contract lifecycle: compile a contract (with 
 
 # Set environment variables
 export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-export RPC_URL="https://gcp-1.seismictest.net/rpc"
-export WS_URL="wss://gcp-1.seismictest.net/ws"
+export RPC_URL="https://testnet-1.seismictest.net/rpc"
+export WS_URL="wss://testnet-1.seismictest.net/ws"
 ```
 
 `Cargo.toml`:

--- a/docs/gitbook/clients/alloy/examples/shielded-write-complete.md
+++ b/docs/gitbook/clients/alloy/examples/shielded-write-complete.md
@@ -12,7 +12,7 @@ This example demonstrates the full lifecycle of a shielded write: deploy a contr
 ```bash
 # Set environment variables
 export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-export RPC_URL="https://gcp-1.seismictest.net/rpc"
+export RPC_URL="https://testnet-1.seismictest.net/rpc"
 ```
 
 `Cargo.toml`:

--- a/docs/gitbook/clients/alloy/examples/signed-read-pattern.md
+++ b/docs/gitbook/clients/alloy/examples/signed-read-pattern.md
@@ -11,7 +11,7 @@ This example demonstrates the authenticated read pattern: create a signed provid
 
 ```bash
 export PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-export RPC_URL="https://gcp-1.seismictest.net/rpc"
+export RPC_URL="https://testnet-1.seismictest.net/rpc"
 ```
 
 `Cargo.toml`:

--- a/docs/gitbook/clients/alloy/fillers/README.md
+++ b/docs/gitbook/clients/alloy/fillers/README.md
@@ -66,7 +66,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // Fillers are set up automatically
 let provider = sreth_signed_provider(wallet, url).await?;

--- a/docs/gitbook/clients/alloy/fillers/seismic-elements-filler.md
+++ b/docs/gitbook/clients/alloy/fillers/seismic-elements-filler.md
@@ -166,7 +166,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // SeismicElementsFiller is configured automatically
 let provider = sreth_signed_provider(wallet, url).await?;

--- a/docs/gitbook/clients/alloy/fillers/seismic-gas-filler.md
+++ b/docs/gitbook/clients/alloy/fillers/seismic-gas-filler.md
@@ -82,7 +82,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // SeismicGasFiller is set up automatically with the same URL
 let provider = sreth_signed_provider(wallet, url).await?;
@@ -95,7 +95,7 @@ If building a custom provider stack:
 ```rust
 use seismic_prelude::foundry::*;
 
-let rpc_url: reqwest::Url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let rpc_url: reqwest::Url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let gas_filler = SeismicGasFiller::with_url(rpc_url);
 ```
 

--- a/docs/gitbook/clients/alloy/guides/shielded-write.md
+++ b/docs/gitbook/clients/alloy/guides/shielded-write.md
@@ -32,7 +32,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url: reqwest::Url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url: reqwest::Url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```

--- a/docs/gitbook/clients/alloy/guides/signed-reads.md
+++ b/docs/gitbook/clients/alloy/guides/signed-reads.md
@@ -50,7 +50,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url: reqwest::Url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url: reqwest::Url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```

--- a/docs/gitbook/clients/alloy/installation.md
+++ b/docs/gitbook/clients/alloy/installation.md
@@ -135,7 +135,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 

--- a/docs/gitbook/clients/alloy/network/README.md
+++ b/docs/gitbook/clients/alloy/network/README.md
@@ -64,7 +64,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // Convenience constructor (selects SeismicReth automatically)
 let provider = sreth_signed_provider(wallet, url).await?;

--- a/docs/gitbook/clients/alloy/network/seismic-reth.md
+++ b/docs/gitbook/clients/alloy/network/seismic-reth.md
@@ -55,7 +55,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
@@ -76,7 +76,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = sreth_signed_provider(wallet, url).await?;
 ```
@@ -88,7 +88,7 @@ For read-only access without a private key:
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 
 let block = provider.get_block_number().await?;

--- a/docs/gitbook/clients/alloy/precompiles/README.md
+++ b/docs/gitbook/clients/alloy/precompiles/README.md
@@ -60,7 +60,7 @@ use alloy_rpc_types_eth::TransactionRequest;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // RNG precompile: request 32 random bytes

--- a/docs/gitbook/clients/alloy/precompiles/aes-gcm-decrypt.md
+++ b/docs/gitbook/clients/alloy/precompiles/aes-gcm-decrypt.md
@@ -53,7 +53,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let encrypt_address: Address =
@@ -110,7 +110,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let encrypt_address: Address =
@@ -175,7 +175,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let decrypt_address: Address =
@@ -217,7 +217,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // Bob derives the same shared secret that Alice used to encrypt

--- a/docs/gitbook/clients/alloy/precompiles/aes-gcm-encrypt.md
+++ b/docs/gitbook/clients/alloy/precompiles/aes-gcm-encrypt.md
@@ -60,7 +60,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let encrypt_address: Address =
@@ -103,7 +103,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let encrypt_address: Address =
@@ -148,7 +148,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let encrypt_address: Address =
@@ -205,7 +205,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // Step 1: Derive shared key via ECDH

--- a/docs/gitbook/clients/alloy/precompiles/ecdh.md
+++ b/docs/gitbook/clients/alloy/precompiles/ecdh.md
@@ -55,7 +55,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let ecdh_address: Address =
@@ -98,7 +98,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let ecdh_address: Address =
@@ -156,7 +156,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // Step 1: Derive shared key via ECDH

--- a/docs/gitbook/clients/alloy/precompiles/hkdf.md
+++ b/docs/gitbook/clients/alloy/precompiles/hkdf.md
@@ -53,7 +53,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let hkdf_address: Address =
@@ -88,7 +88,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let hkdf_address: Address =
@@ -131,7 +131,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // Step 1: Derive AES key via HKDF
@@ -185,7 +185,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     // Step 1: Perform ECDH
@@ -239,7 +239,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let hkdf_address: Address =

--- a/docs/gitbook/clients/alloy/precompiles/rng.md
+++ b/docs/gitbook/clients/alloy/precompiles/rng.md
@@ -51,7 +51,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let rng_address: Address =
@@ -86,7 +86,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let rng_address: Address =
@@ -125,7 +125,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let rng_address: Address =
@@ -161,7 +161,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let rng_address: Address =

--- a/docs/gitbook/clients/alloy/precompiles/secp256k1-sign.md
+++ b/docs/gitbook/clients/alloy/precompiles/secp256k1-sign.md
@@ -60,7 +60,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let sign_address: Address =
@@ -105,7 +105,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let sign_address: Address =
@@ -153,7 +153,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let sign_address: Address =
@@ -202,7 +202,7 @@ use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let sign_address: Address =

--- a/docs/gitbook/clients/alloy/provider/README.md
+++ b/docs/gitbook/clients/alloy/provider/README.md
@@ -37,7 +37,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // Full-featured provider
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
@@ -48,13 +48,13 @@ let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 // Read-only provider (HTTP)
 let provider = sreth_unsigned_provider(url);
 
 // Read-only provider (WebSocket)
-let ws_url = "wss://gcp-1.seismictest.net/ws".parse()?;
+let ws_url = "wss://testnet-1.seismictest.net/ws".parse()?;
 let provider = SeismicUnsignedProvider::<SeismicReth>::new_ws(ws_url).await?;
 ```
 

--- a/docs/gitbook/clients/alloy/provider/encryption.md
+++ b/docs/gitbook/clients/alloy/provider/encryption.md
@@ -269,7 +269,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let tee_pubkey = provider.get_tee_pubkey().await?;
@@ -290,7 +290,7 @@ use alloy_primitives::address;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     // Provider automatically:
     // 1. Generates ephemeral keypair

--- a/docs/gitbook/clients/alloy/provider/seismic-signed-provider.md
+++ b/docs/gitbook/clients/alloy/provider/seismic-signed-provider.md
@@ -67,7 +67,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 ```
@@ -144,7 +144,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::from(signer);
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
 let provider = sreth_signed_provider(wallet, url).await?;
 ```
@@ -305,7 +305,7 @@ use alloy_primitives::{address, U256};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = sreth_signed_provider(wallet, url).await?;
 
@@ -338,7 +338,7 @@ use alloy_primitives::address;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     let provider = sreth_signed_provider(wallet, url).await?;
 
@@ -386,7 +386,7 @@ use alloy_signer_local::PrivateKeySigner;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url: reqwest::Url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url: reqwest::Url = "https://testnet-1.seismictest.net/rpc".parse()?;
 
     // Fetch TEE pubkey once
     let unsigned = sreth_unsigned_provider(url.clone());

--- a/docs/gitbook/clients/alloy/provider/seismic-unsigned-provider.md
+++ b/docs/gitbook/clients/alloy/provider/seismic-unsigned-provider.md
@@ -58,7 +58,7 @@ pub fn new_http(url: reqwest::Url) -> Self
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = SeismicUnsignedProvider::<SeismicReth>::new_http(url);
 
 let block_number = provider.get_block_number().await?;
@@ -81,7 +81,7 @@ pub async fn new_ws(url: reqwest::Url) -> TransportResult<Self>
 
 | Parameter | Type           | Required | Description                                                              |
 | --------- | -------------- | -------- | ------------------------------------------------------------------------ |
-| `url`     | `reqwest::Url` | Yes      | WebSocket URL of the Seismic node (e.g., `wss://gcp-1.seismictest.net/ws`) |
+| `url`     | `reqwest::Url` | Yes      | WebSocket URL of the Seismic node (e.g., `wss://testnet-1.seismictest.net/ws`) |
 
 #### Returns
 
@@ -94,7 +94,7 @@ pub async fn new_ws(url: reqwest::Url) -> TransportResult<Self>
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "wss://gcp-1.seismictest.net/ws".parse()?;
+let url = "wss://testnet-1.seismictest.net/ws".parse()?;
 let provider = SeismicUnsignedProvider::<SeismicReth>::new_ws(url).await?;
 
 let block_number = provider.get_block_number().await?;
@@ -120,7 +120,7 @@ For Seismic devnet, testnet, or mainnet.
 ```rust
 use seismic_prelude::foundry::*;
 
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = sreth_unsigned_provider(url);
 ```
 
@@ -254,7 +254,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let block_number = provider.get_block_number().await?;
@@ -275,7 +275,7 @@ use alloy_primitives::address;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let addr = address!("0x1234567890abcdef1234567890abcdef12345678");
@@ -293,7 +293,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let tee_pubkey = provider.get_tee_pubkey().await?;
@@ -313,7 +313,7 @@ use seismic_prelude::foundry::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "wss://gcp-1.seismictest.net/ws".parse()?;
+    let url = "wss://testnet-1.seismictest.net/ws".parse()?;
     let provider = SeismicUnsignedProvider::<SeismicReth>::new_ws(url).await?;
 
     let block_number = provider.get_block_number().await?;

--- a/docs/gitbook/clients/alloy/src20/README.md
+++ b/docs/gitbook/clients/alloy/src20/README.md
@@ -92,7 +92,7 @@ sol! {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token_address: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;

--- a/docs/gitbook/clients/alloy/src20/event-decryption.md
+++ b/docs/gitbook/clients/alloy/src20/event-decryption.md
@@ -59,7 +59,7 @@ sol! {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ws_url = "wss://gcp-1.seismictest.net/ws".parse()?;
+    let ws_url = "wss://testnet-1.seismictest.net/ws".parse()?;
     let provider = SeismicUnsignedProvider::<SeismicReth>::new_ws(ws_url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -113,7 +113,7 @@ sol! {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -165,7 +165,7 @@ sol! {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -248,7 +248,7 @@ sol! {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let ws_url = "wss://gcp-1.seismictest.net/ws".parse()?;
+    let ws_url = "wss://testnet-1.seismictest.net/ws".parse()?;
     let provider = SeismicUnsignedProvider::<SeismicReth>::new_ws(ws_url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;

--- a/docs/gitbook/clients/alloy/src20/token-interaction.md
+++ b/docs/gitbook/clients/alloy/src20/token-interaction.md
@@ -52,7 +52,7 @@ use alloy_rpc_types_eth::TransactionRequest;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = sreth_unsigned_provider(url);
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -117,7 +117,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -163,7 +163,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -204,7 +204,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -246,7 +246,7 @@ use alloy_signer_local::PrivateKeySigner;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;

--- a/docs/gitbook/clients/alloy/src20/transfers.md
+++ b/docs/gitbook/clients/alloy/src20/transfers.md
@@ -47,7 +47,7 @@ The simplest pattern: transfer tokens directly from your wallet to a recipient.
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Owner's provider
     let owner_signer: PrivateKeySigner = "0xOWNER_PRIVATE_KEY".parse()?;
     let owner_wallet = SeismicWallet::from(owner_signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let owner_provider =
         SeismicSignedProvider::<SeismicReth>::new(owner_wallet, url).await?;
 
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Spender's provider
     let spender_signer: PrivateKeySigner = "0xSPENDER_PRIVATE_KEY".parse()?;
     let spender_wallet = SeismicWallet::from(spender_signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let spender_provider =
         SeismicSignedProvider::<SeismicReth>::new(spender_wallet, url).await?;
 
@@ -162,7 +162,7 @@ Always verify sufficient balance before sending a transfer to avoid wasted gas:
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;
@@ -218,7 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Setup owner and spender providers
     let owner_signer: PrivateKeySigner = "0xOWNER_PRIVATE_KEY".parse()?;
     let owner_wallet = SeismicWallet::from(owner_signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let owner_provider =
         SeismicSignedProvider::<SeismicReth>::new(owner_wallet, url.clone()).await?;
 
@@ -291,7 +291,7 @@ Send tokens to multiple recipients in sequence:
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
     let wallet = SeismicWallet::from(signer);
-    let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+    let url = "https://testnet-1.seismictest.net/rpc".parse()?;
     let provider = SeismicSignedProvider::<SeismicReth>::new(wallet, url).await?;
 
     let token: Address = "0xYOUR_TOKEN_ADDRESS".parse()?;

--- a/docs/gitbook/clients/alloy/wallet/README.md
+++ b/docs/gitbook/clients/alloy/wallet/README.md
@@ -28,7 +28,7 @@ let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::<SeismicReth>::from(signer);
 
 // Use it to create a provider
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = SeismicSignedProvider::new(wallet, url).await?;
 ```
 

--- a/docs/gitbook/clients/alloy/wallet/seismic-wallet.md
+++ b/docs/gitbook/clients/alloy/wallet/seismic-wallet.md
@@ -173,7 +173,7 @@ let signer: PrivateKeySigner = "0xYOUR_PRIVATE_KEY".parse()?;
 let wallet = SeismicWallet::<SeismicReth>::from(signer);
 
 // Use with a provider
-let url = "https://gcp-1.seismictest.net/rpc".parse()?;
+let url = "https://testnet-1.seismictest.net/rpc".parse()?;
 let provider = SeismicSignedProvider::new(wallet, url).await?;
 ```
 

--- a/docs/gitbook/clients/python/chains/README.md
+++ b/docs/gitbook/clients/python/chains/README.md
@@ -31,7 +31,7 @@ w3 = SANVIL.wallet_client(pk)
 | Component | Description |
 |-----------|-------------|
 | [ChainConfig](chain-config.md) | Immutable dataclass for network configuration |
-| [SEISMIC_TESTNET](seismic-testnet.md) | Public testnet configuration (GCP-1) |
+| [SEISMIC_TESTNET](seismic-testnet.md) | Public testnet configuration (testnet-1) |
 | [SANVIL](sanvil.md) | Local development network configuration |
 | [make_seismic_testnet](make-seismic-testnet.md) | Factory for alternate testnet instances |
 
@@ -70,7 +70,7 @@ from seismic_web3 import SEISMIC_TESTNET, SANVIL
 SEISMIC_TESTNET.rpc_url   # "https://testnet-1.seismictest.net/rpc"
 SEISMIC_TESTNET.ws_url    # "wss://testnet-1.seismictest.net/ws"
 SEISMIC_TESTNET.chain_id  # 5124
-SEISMIC_TESTNET.name      # "Seismic Testnet (GCP-1)"
+SEISMIC_TESTNET.name      # "Seismic Testnet (testnet-1)"
 
 # Sanvil properties
 SANVIL.rpc_url   # "http://127.0.0.1:8545"

--- a/docs/gitbook/clients/python/chains/README.md
+++ b/docs/gitbook/clients/python/chains/README.md
@@ -67,8 +67,8 @@ public = SEISMIC_TESTNET.public_client()
 from seismic_web3 import SEISMIC_TESTNET, SANVIL
 
 # Testnet properties
-SEISMIC_TESTNET.rpc_url   # "https://gcp-1.seismictest.net/rpc"
-SEISMIC_TESTNET.ws_url    # "wss://gcp-1.seismictest.net/ws"
+SEISMIC_TESTNET.rpc_url   # "https://testnet-1.seismictest.net/rpc"
+SEISMIC_TESTNET.ws_url    # "wss://testnet-1.seismictest.net/ws"
 SEISMIC_TESTNET.chain_id  # 5124
 SEISMIC_TESTNET.name      # "Seismic Testnet (GCP-1)"
 
@@ -85,8 +85,8 @@ SANVIL.name      # "Sanvil (local)"
 from seismic_web3 import make_seismic_testnet
 
 # Connect to different GCP testnet instances
-testnet_2 = make_seismic_testnet(2)  # gcp-2.seismictest.net
-testnet_3 = make_seismic_testnet(3)  # gcp-3.seismictest.net
+testnet_2 = make_seismic_testnet(2)  # testnet-2.seismictest.net
+testnet_3 = make_seismic_testnet(3)  # testnet-3.seismictest.net
 
 w3 = testnet_2.wallet_client(pk)
 ```
@@ -98,8 +98,8 @@ from seismic_web3 import ChainConfig, PrivateKey
 
 custom = ChainConfig(
     chain_id=5124,
-    rpc_url="https://gcp-1.seismictest.net/rpc",
-    ws_url="wss://gcp-1.seismictest.net/ws",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
+    ws_url="wss://testnet-1.seismictest.net/ws",
     name="Seismic Testnet",
 )
 

--- a/docs/gitbook/clients/python/chains/chain-config.md
+++ b/docs/gitbook/clients/python/chains/chain-config.md
@@ -48,8 +48,8 @@ from seismic_web3 import ChainConfig
 
 config = ChainConfig(
     chain_id=5124,
-    rpc_url="https://gcp-1.seismictest.net/rpc",
-    ws_url="wss://gcp-1.seismictest.net/ws",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
+    ws_url="wss://testnet-1.seismictest.net/ws",
     name="Seismic Testnet",
 )
 ```
@@ -59,7 +59,7 @@ config = ChainConfig(
 ```python
 config = ChainConfig(
     chain_id=5124,
-    rpc_url="https://gcp-1.seismictest.net/rpc",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
     name="Seismic Testnet",
 )
 ```

--- a/docs/gitbook/clients/python/chains/make-seismic-testnet.md
+++ b/docs/gitbook/clients/python/chains/make-seismic-testnet.md
@@ -70,7 +70,7 @@ from seismic_web3 import make_seismic_testnet
 # No argument defaults to GCP node 1
 testnet = make_seismic_testnet()
 
-print(testnet.rpc_url)  # "https://gcp-1.seismictest.net/rpc"
+print(testnet.rpc_url)  # "https://testnet-1.seismictest.net/rpc"
 ```
 
 ## Relationship to SEISMIC_TESTNET

--- a/docs/gitbook/clients/python/chains/seismic-testnet.md
+++ b/docs/gitbook/clients/python/chains/seismic-testnet.md
@@ -22,8 +22,8 @@ Internally, this is equivalent to:
 ```python
 ChainConfig(
     chain_id=5124,
-    rpc_url="https://gcp-1.seismictest.net/rpc",
-    ws_url="wss://gcp-1.seismictest.net/ws",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
+    ws_url="wss://testnet-1.seismictest.net/ws",
     name="Seismic Testnet",
 )
 ```
@@ -33,8 +33,8 @@ ChainConfig(
 | Property | Value |
 |----------|-------|
 | `chain_id` | `5124` |
-| `rpc_url` | `"https://gcp-1.seismictest.net/rpc"` |
-| `ws_url` | `"wss://gcp-1.seismictest.net/ws"` |
+| `rpc_url` | `"https://testnet-1.seismictest.net/rpc"` |
+| `ws_url` | `"wss://testnet-1.seismictest.net/ws"` |
 | `name` | `"Seismic Testnet"` |
 
 ## Usage
@@ -45,8 +45,8 @@ ChainConfig(
 from seismic_web3 import SEISMIC_TESTNET
 
 # Access configuration
-print(SEISMIC_TESTNET.rpc_url)   # "https://gcp-1.seismictest.net/rpc"
-print(SEISMIC_TESTNET.ws_url)    # "wss://gcp-1.seismictest.net/ws"
+print(SEISMIC_TESTNET.rpc_url)   # "https://testnet-1.seismictest.net/rpc"
+print(SEISMIC_TESTNET.ws_url)    # "wss://testnet-1.seismictest.net/ws"
 print(SEISMIC_TESTNET.chain_id)  # 5124
 print(SEISMIC_TESTNET.name)      # "Seismic Testnet"
 ```
@@ -75,7 +75,7 @@ pk = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 # HTTP
 w3 = await SEISMIC_TESTNET.async_wallet_client(pk)
 
-# WebSocket (auto-selects wss://gcp-1.seismictest.net/ws)
+# WebSocket (auto-selects wss://testnet-1.seismictest.net/ws)
 w3 = await SEISMIC_TESTNET.async_wallet_client(pk, ws=True)
 ```
 

--- a/docs/gitbook/clients/python/client/create-async-public-client.md
+++ b/docs/gitbook/clients/python/client/create-async-public-client.md
@@ -44,7 +44,7 @@ def create_async_public_client(
 from seismic_web3 import create_async_public_client
 
 # Create async public client
-w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
 
 # Query TEE public key
 tee_pk = await w3.seismic.get_tee_public_key()
@@ -63,7 +63,7 @@ from seismic_web3 import create_async_public_client
 
 # WebSocket provider for persistent connection
 w3 = create_async_public_client(
-    "wss://gcp-1.seismictest.net/ws",
+    "wss://testnet-1.seismictest.net/ws",
     ws=True,
 )
 
@@ -95,7 +95,7 @@ import asyncio
 from seismic_web3 import create_async_public_client
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
 
     # Get current block
     block = await w3.eth.get_block("latest")
@@ -119,7 +119,7 @@ asyncio.run(main())
 from seismic_web3 import create_async_public_client
 
 async def query_contract():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
 
     # Create contract wrapper (read-only)
     contract = w3.seismic.contract(
@@ -139,7 +139,7 @@ from seismic_web3 import create_async_public_client
 import asyncio
 
 async def monitor_deposits():
-    w3 = create_async_public_client("wss://gcp-1.seismictest.net/ws", ws=True)
+    w3 = create_async_public_client("wss://testnet-1.seismictest.net/ws", ws=True)
 
     last_count = await w3.seismic.get_deposit_count()
     print(f"Starting deposit count: {last_count}")
@@ -162,7 +162,7 @@ from seismic_web3 import create_async_public_client
 import asyncio
 
 async def get_chain_stats():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
 
     # Run multiple queries in parallel
     block, tee_pk, deposit_root, deposit_count = await asyncio.gather(
@@ -186,7 +186,7 @@ async def get_chain_stats():
 from seismic_web3 import create_async_public_client
 
 async with create_async_public_client(
-    "wss://gcp-1.seismictest.net/ws",
+    "wss://testnet-1.seismictest.net/ws",
     ws=True,
 ) as w3:
     # WebSocket connection will be properly closed

--- a/docs/gitbook/clients/python/client/create-async-wallet-client.md
+++ b/docs/gitbook/clients/python/client/create-async-wallet-client.md
@@ -53,7 +53,7 @@ private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
 # Create async wallet client
 w3 = await create_async_wallet_client(
-    "https://gcp-1.seismictest.net/rpc",
+    "https://testnet-1.seismictest.net/rpc",
     private_key=private_key,
 )
 
@@ -73,7 +73,7 @@ private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
 # WebSocket provider for persistent connection
 w3 = await create_async_wallet_client(
-    "wss://gcp-1.seismictest.net/ws",
+    "wss://testnet-1.seismictest.net/ws",
     private_key=private_key,
     ws=True,
 )
@@ -108,7 +108,7 @@ private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
 # Use context manager to ensure cleanup
 async with create_async_wallet_client(
-    "wss://gcp-1.seismictest.net/ws",
+    "wss://testnet-1.seismictest.net/ws",
     private_key=private_key,
     ws=True,
 ) as w3:
@@ -128,7 +128,7 @@ async def main():
     private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
     w3 = await create_async_wallet_client(
-        "https://gcp-1.seismictest.net/rpc",
+        "https://testnet-1.seismictest.net/rpc",
         private_key=private_key,
     )
 
@@ -155,7 +155,7 @@ async def setup_client():
     encryption_key = PrivateKey(os.urandom(32))  # Custom encryption keypair
 
     w3 = await create_async_wallet_client(
-        "https://gcp-1.seismictest.net/rpc",
+        "https://testnet-1.seismictest.net/rpc",
         private_key=signing_key,
         encryption_sk=encryption_key,
     )

--- a/docs/gitbook/clients/python/client/create-public-client.md
+++ b/docs/gitbook/clients/python/client/create-public-client.md
@@ -23,7 +23,7 @@ def create_public_client(rpc_url: str) -> Web3
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `rpc_url` | `str` | Yes | HTTP(S) URL of the Seismic node (e.g., `"https://gcp-1.seismictest.net/rpc"`). WebSocket URLs are not supported — see note below |
+| `rpc_url` | `str` | Yes | HTTP(S) URL of the Seismic node (e.g., `"https://testnet-1.seismictest.net/rpc"`). WebSocket URLs are not supported — see note below |
 
 ## Returns
 
@@ -39,7 +39,7 @@ def create_public_client(rpc_url: str) -> Web3
 from seismic_web3 import create_public_client
 
 # Create public client
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 # Query TEE public key
 tee_pk = w3.seismic.get_tee_public_key()
@@ -68,7 +68,7 @@ w3 = SEISMIC_TESTNET.public_client()
 ```python
 from seismic_web3 import create_public_client
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 # Create contract wrapper (read-only)
 contract = w3.seismic.contract(
@@ -89,7 +89,7 @@ result = contract.tread.balanceOf("0x1234...")
 ```python
 from seismic_web3 import create_public_client
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 # All standard web3.py read operations work
 block = w3.eth.get_block("latest")
@@ -128,7 +128,7 @@ def get_chain_stats(rpc_url: str):
         "tee_public_key": tee_pk.to_0x_hex(),
     }
 
-stats = get_chain_stats("https://gcp-1.seismictest.net/rpc")
+stats = get_chain_stats("https://testnet-1.seismictest.net/rpc")
 print(stats)
 ```
 

--- a/docs/gitbook/clients/python/client/create-wallet-client.md
+++ b/docs/gitbook/clients/python/client/create-wallet-client.md
@@ -28,7 +28,7 @@ def create_wallet_client(
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `rpc_url` | `str` | Yes | HTTP(S) URL of the Seismic node (e.g., `"https://gcp-1.seismictest.net/rpc"`). WebSocket URLs are not supported — see note below |
+| `rpc_url` | `str` | Yes | HTTP(S) URL of the Seismic node (e.g., `"https://testnet-1.seismictest.net/rpc"`). WebSocket URLs are not supported — see note below |
 | `private_key` | [`PrivateKey`](../api-reference/types/private-key.md) | Yes | 32-byte secp256k1 private key for signing transactions |
 | `encryption_sk` | [`PrivateKey`](../api-reference/types/private-key.md) | No | Optional 32-byte key for ECDH. If `None`, a random ephemeral key is generated |
 
@@ -51,7 +51,7 @@ private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
 # Create wallet client
 w3 = create_wallet_client(
-    "https://gcp-1.seismictest.net/rpc",
+    "https://testnet-1.seismictest.net/rpc",
     private_key=private_key,
 )
 
@@ -86,7 +86,7 @@ signing_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 encryption_key = PrivateKey(os.urandom(32))  # Custom encryption keypair
 
 w3 = create_wallet_client(
-    "https://gcp-1.seismictest.net/rpc",
+    "https://testnet-1.seismictest.net/rpc",
     private_key=signing_key,
     encryption_sk=encryption_key,
 )
@@ -99,7 +99,7 @@ import os
 from seismic_web3 import create_wallet_client, PrivateKey
 
 private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
-w3 = create_wallet_client("https://gcp-1.seismictest.net/rpc", private_key=private_key)
+w3 = create_wallet_client("https://testnet-1.seismictest.net/rpc", private_key=private_key)
 
 # All standard web3.py operations work
 block = w3.eth.get_block("latest")

--- a/docs/gitbook/clients/python/client/encryption-state.md
+++ b/docs/gitbook/clients/python/client/encryption-state.md
@@ -158,7 +158,7 @@ import os
 from seismic_web3 import create_wallet_client, PrivateKey
 
 private_key = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
-w3 = create_wallet_client("https://gcp-1.seismictest.net/rpc", private_key=private_key)
+w3 = create_wallet_client("https://testnet-1.seismictest.net/rpc", private_key=private_key)
 
 # Access encryption state
 encryption = w3.seismic.encryption

--- a/docs/gitbook/clients/python/client/get-encryption.md
+++ b/docs/gitbook/clients/python/client/get-encryption.md
@@ -74,7 +74,7 @@ from seismic_web3 import get_encryption, get_tee_public_key, PrivateKey
 from web3 import Web3
 
 # This is what create_wallet_client() does internally
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = Web3(Web3.HTTPProvider("https://testnet-1.seismictest.net/rpc"))
 
 # Step 1: Fetch TEE public key
 network_pk = get_tee_public_key(w3)

--- a/docs/gitbook/clients/python/contract/async-public-contract.md
+++ b/docs/gitbook/clients/python/contract/async-public-contract.md
@@ -53,7 +53,7 @@ from seismic_web3 import create_async_public_client, AsyncPublicContract
 async def main():
     # Create async client without private key
     w3 = create_async_public_client(
-        provider_url="https://gcp-1.seismictest.net/rpc",
+        provider_url="https://testnet-1.seismictest.net/rpc",
     )
 
     # Create read-only contract instance

--- a/docs/gitbook/clients/python/contract/async-shielded-contract.md
+++ b/docs/gitbook/clients/python/contract/async-shielded-contract.md
@@ -107,7 +107,7 @@ from seismic_web3 import create_async_wallet_client, AsyncShieldedContract
 
 async def main():
     w3 = await create_async_wallet_client(
-        provider_url="https://gcp-1.seismictest.net/rpc",
+        provider_url="https://testnet-1.seismictest.net/rpc",
         private_key=private_key,
     )
 
@@ -250,7 +250,7 @@ async def eip712_example():
 async def client_pattern():
     # Most common pattern - let the client create the contract
     w3 = await create_async_wallet_client(
-        provider_url="https://gcp-1.seismictest.net/rpc",
+        provider_url="https://testnet-1.seismictest.net/rpc",
         private_key=private_key,
     )
 

--- a/docs/gitbook/clients/python/contract/public-contract.md
+++ b/docs/gitbook/clients/python/contract/public-contract.md
@@ -51,7 +51,7 @@ from seismic_web3 import create_public_client, PublicContract
 
 # Create client without private key
 w3 = create_public_client(
-    rpc_url="https://gcp-1.seismictest.net/rpc",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
 )
 
 # Create read-only contract instance

--- a/docs/gitbook/clients/python/contract/shielded-contract.md
+++ b/docs/gitbook/clients/python/contract/shielded-contract.md
@@ -105,7 +105,7 @@ Like `.write` but returns debug information including plaintext and encrypted vi
 from seismic_web3 import create_wallet_client, ShieldedContract
 
 w3 = create_wallet_client(
-    rpc_url="https://gcp-1.seismictest.net/rpc",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
     private_key=private_key,
 )
 
@@ -203,7 +203,7 @@ tx_hash = contract.write.setNumber(123)
 from seismic_web3 import create_wallet_client
 
 w3 = create_wallet_client(
-    rpc_url="https://gcp-1.seismictest.net/rpc",
+    rpc_url="https://testnet-1.seismictest.net/rpc",
     private_key=private_key,
 )
 

--- a/docs/gitbook/clients/python/guides/async-patterns.md
+++ b/docs/gitbook/clients/python/guides/async-patterns.md
@@ -74,7 +74,7 @@ async def seismic_client(rpc_url: str, private_key: PrivateKey):
 async def main():
     pk = PrivateKey.from_hex_str(os.environ["PRIVATE_KEY"])
 
-    async with seismic_client("https://gcp-1.seismictest.net/rpc", pk) as w3:
+    async with seismic_client("https://testnet-1.seismictest.net/rpc", pk) as w3:
         chain_id = await w3.eth.chain_id
         print(f"Chain {chain_id}")
     # Client automatically disconnected
@@ -88,7 +88,7 @@ Use `ws=True` for event streaming:
 from seismic_web3 import create_async_wallet_client
 
 w3 = await create_async_wallet_client(
-    "wss://gcp-1.seismictest.net/ws",
+    "wss://testnet-1.seismictest.net/ws",
     private_key=pk,
     ws=True,
 )

--- a/docs/gitbook/clients/python/precompiles/README.md
+++ b/docs/gitbook/clients/python/precompiles/README.md
@@ -17,7 +17,7 @@ from seismic_web3 import PrivateKey, create_public_client
 from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 # 1) Random bytes as int
 random_val = sp.rng(w3, num_bytes=32)

--- a/docs/gitbook/clients/python/precompiles/aes-gcm-decrypt.md
+++ b/docs/gitbook/clients/python/precompiles/aes-gcm-decrypt.md
@@ -57,7 +57,7 @@ import os
 from seismic_web3 import Bytes32, create_public_client
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 key = Bytes32(os.urandom(32))
 pt = b"secret"
@@ -85,7 +85,7 @@ from seismic_web3 import Bytes32
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     key = Bytes32(os.urandom(32))
     ct = sp.aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"async secret")
     pt = await sp.async_aes_gcm_decrypt(w3, aes_key=key, nonce=1, ciphertext=bytes(ct))

--- a/docs/gitbook/clients/python/precompiles/aes-gcm-encrypt.md
+++ b/docs/gitbook/clients/python/precompiles/aes-gcm-encrypt.md
@@ -57,7 +57,7 @@ import os
 from seismic_web3 import Bytes32, create_public_client
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 key = Bytes32(os.urandom(32))
 plaintext = b"secret message"
@@ -86,7 +86,7 @@ from seismic_web3 import Bytes32
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     key = Bytes32(os.urandom(32))
     ct = await sp.async_aes_gcm_encrypt(w3, aes_key=key, nonce=1, plaintext=b"async")
     print(ct.hex())

--- a/docs/gitbook/clients/python/precompiles/ecdh.md
+++ b/docs/gitbook/clients/python/precompiles/ecdh.md
@@ -55,7 +55,7 @@ from seismic_web3 import PrivateKey, create_public_client
 from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 alice_sk = PrivateKey(os.urandom(32))
 bob_sk = PrivateKey(os.urandom(32))
@@ -90,7 +90,7 @@ from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     alice_sk = PrivateKey(os.urandom(32))
     bob_sk = PrivateKey(os.urandom(32))
     bob_pk = private_key_to_compressed_public_key(bob_sk)

--- a/docs/gitbook/clients/python/precompiles/hkdf.md
+++ b/docs/gitbook/clients/python/precompiles/hkdf.md
@@ -46,7 +46,7 @@ async def async_hkdf(
 from seismic_web3 import create_public_client
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 key = sp.hkdf(w3, b"input key material")
 print(key.to_0x_hex())
@@ -68,7 +68,7 @@ from seismic_web3 import create_async_public_client
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     key = await sp.async_hkdf(w3, b"async input")
     print(key.to_0x_hex())
 ```

--- a/docs/gitbook/clients/python/precompiles/rng.md
+++ b/docs/gitbook/clients/python/precompiles/rng.md
@@ -55,7 +55,7 @@ async def async_rng(
 from seismic_web3 import create_public_client
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 value = sp.rng(w3, num_bytes=32)
 print(value)
@@ -74,7 +74,7 @@ from seismic_web3 import create_async_public_client
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     value = await sp.async_rng(w3, num_bytes=32)
     print(value)
 ```

--- a/docs/gitbook/clients/python/precompiles/secp256k1-sign.md
+++ b/docs/gitbook/clients/python/precompiles/secp256k1-sign.md
@@ -55,7 +55,7 @@ import os
 from seismic_web3 import PrivateKey, create_public_client
 from seismic_web3 import precompiles as sp
 
-w3 = create_public_client("https://gcp-1.seismictest.net/rpc")
+w3 = create_public_client("https://testnet-1.seismictest.net/rpc")
 
 sk = PrivateKey(os.urandom(32))
 sig = sp.secp256k1_sign(w3, sk=sk, message="hello")
@@ -85,7 +85,7 @@ from seismic_web3 import PrivateKey
 from seismic_web3 import precompiles as sp
 
 async def main():
-    w3 = create_async_public_client("https://gcp-1.seismictest.net/rpc")
+    w3 = create_async_public_client("https://testnet-1.seismictest.net/rpc")
     sk = PrivateKey(os.urandom(32))
     sig = await sp.async_secp256k1_sign(w3, sk=sk, message="async hello")
     print(sig.hex())

--- a/docs/gitbook/clients/python/src20/intelligence-providers/check-has-key.md
+++ b/docs/gitbook/clients/python/src20/intelligence-providers/check-has-key.md
@@ -37,7 +37,7 @@ async def async_get_key_hash(w3: AsyncWeb3, address: ChecksumAddress) -> bytes
 from web3 import Web3
 from seismic_web3.src20 import check_has_key, get_key_hash
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = Web3(Web3.HTTPProvider("https://testnet-1.seismictest.net/rpc"))
 address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 
 if check_has_key(w3, address):

--- a/docs/gitbook/clients/python/src20/intelligence-providers/watch-src20-events-with-key.md
+++ b/docs/gitbook/clients/python/src20/intelligence-providers/watch-src20-events-with-key.md
@@ -55,7 +55,7 @@ from web3 import Web3
 from seismic_web3 import Bytes32
 from seismic_web3.src20 import watch_src20_events_with_key
 
-w3 = Web3(Web3.HTTPProvider("https://gcp-1.seismictest.net/rpc"))
+w3 = Web3(Web3.HTTPProvider("https://testnet-1.seismictest.net/rpc"))
 viewing_key = Bytes32(bytes.fromhex(os.environ["VIEWING_KEY"].removeprefix("0x")))
 
 watcher = watch_src20_events_with_key(

--- a/docs/gitbook/clients/typescript/react/chains/create-seismic-devnet.md
+++ b/docs/gitbook/clients/typescript/react/chains/create-seismic-devnet.md
@@ -17,7 +17,7 @@ import { createSeismicDevnet } from "seismic-react/rainbowkit";
 
 | Parameter     | Type     | Required | Description                                          |
 | ------------- | -------- | -------- | ---------------------------------------------------- |
-| `nodeHost`    | `string` | Yes      | Hostname for the node (e.g. `gcp-1.seismictest.net`) |
+| `nodeHost`    | `string` | Yes      | Hostname for the node (e.g. `testnet-1.seismictest.net`) |
 | `explorerUrl` | `string` | No       | Block explorer URL                                   |
 
 ## Return Type

--- a/docs/gitbook/clients/typescript/react/chains/seismic-testnet.md
+++ b/docs/gitbook/clients/typescript/react/chains/seismic-testnet.md
@@ -13,8 +13,8 @@ The Seismic public testnet is the primary network for development and testing. `
 | --------------- | --------------------------------------- |
 | Chain ID        | `5124`                                  |
 | Name            | `Seismic`                               |
-| RPC (HTTPS)     | `https://gcp-1.seismictest.net/rpc`     |
-| RPC (WSS)       | `wss://gcp-1.seismictest.net/ws`        |
+| RPC (HTTPS)     | `https://testnet-1.seismictest.net/rpc`     |
+| RPC (WSS)       | `wss://testnet-1.seismictest.net/ws`        |
 | Explorer        | `https://seismic-testnet.socialscan.io` |
 | Native Currency | ETH (18 decimals)                       |
 

--- a/docs/gitbook/clients/typescript/viem/chains.md
+++ b/docs/gitbook/clients/typescript/viem/chains.md
@@ -22,7 +22,7 @@ import {
 
 | Chain           | Export               | Chain ID | RPC URL                             | Description              |
 | --------------- | -------------------- | -------- | ----------------------------------- | ------------------------ |
-| Seismic Testnet | `seismicTestnet`     | 5124     | `https://gcp-1.seismictest.net/rpc` | Public testnet           |
+| Seismic Testnet | `seismicTestnet`     | 5124     | `https://testnet-1.seismictest.net/rpc` | Public testnet           |
 | Sanvil          | `sanvil`             | 31337    | `http://127.0.0.1:8545`             | Local Seismic Anvil      |
 | Local Devnet    | `localSeismicDevnet` | 5124     | `http://127.0.0.1:8545`             | Local seismic-reth --dev |
 

--- a/docs/gitbook/getting-started/src20-factory/README.md
+++ b/docs/gitbook/getting-started/src20-factory/README.md
@@ -49,7 +49,7 @@ Example output:
 | `--symbol` | Token symbol                                                   | prompted                            |
 | `--supply` | Initial supply in whole tokens (multiplied by 10¹⁸ internally) | prompted                            |
 | `--key`    | 0x-prefixed 64-character hex private key                       | prompted (hidden input)             |
-| `--rpc`    | Custom RPC URL                                                 | `https://gcp-2.seismictest.net/rpc` |
+| `--rpc`    | Custom RPC URL                                                 | `https://testnet-2.seismictest.net/rpc` |
 
 {% hint style="info" %}
 Supply is always treated as whole tokens. Passing `--supply 1000000` mints `1,000,000 × 10¹⁸` base units, using 18 decimals.

--- a/docs/gitbook/getting-started/src20-factory/api.md
+++ b/docs/gitbook/getting-started/src20-factory/api.md
@@ -14,7 +14,7 @@ cd packages/api
 cargo run
 ```
 
-The server starts on port **3001** and connects to Seismic testnet at `https://gcp-2.seismictest.net/rpc`.
+The server starts on port **3001** and connects to Seismic testnet at `https://testnet-2.seismictest.net/rpc`.
 
 ---
 

--- a/docs/gitbook/networks/testnet.md
+++ b/docs/gitbook/networks/testnet.md
@@ -7,15 +7,15 @@ icon: flask-vial
 |              |                                                                                  |
 | ------------ | -------------------------------------------------------------------------------- |
 | Chain ID     | `5124`                                                                           |
-| RPC (HTTPS)  | `https://gcp-1.seismictest.net/rpc`                                              |
-| RPC (WSS)    | `wss://gcp-1.seismictest.net/ws`                                                 |
+| RPC (HTTPS)  | `https://testnet-1.seismictest.net/rpc`                                              |
+| RPC (WSS)    | `wss://testnet-1.seismictest.net/ws`                                                 |
 | Faucet       | [https://faucet.seismictest.net/](https://faucet.seismictest.net/)               |
 | Explorer     | [https://seismic-testnet.socialscan.io/](https://seismic-testnet.socialscan.io/) |
 
 ## Quick Test
 
 ```bash
-curl -X POST https://gcp-1.seismictest.net/rpc \
+curl -X POST https://testnet-1.seismictest.net/rpc \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
 ```
@@ -26,12 +26,12 @@ curl -X POST https://gcp-1.seismictest.net/rpc \
 import { seismicTestnet } from "seismic-viem";
 
 console.log(seismicTestnet.rpcUrls.default.http[0]);
-// "https://gcp-1.seismictest.net/rpc"
+// "https://testnet-1.seismictest.net/rpc"
 ```
 
 ```python
 from seismic_web3 import SEISMIC_TESTNET
 
 print(SEISMIC_TESTNET.rpc_url)
-# "https://gcp-1.seismictest.net/rpc"
+# "https://testnet-1.seismictest.net/rpc"
 ```

--- a/docs/gitbook/reference/migrating-from-ethereum.md
+++ b/docs/gitbook/reference/migrating-from-ethereum.md
@@ -199,7 +199,7 @@ Deploy to the Seismic network using the same flow you would use for Ethereum, ju
 
 ```bash
 sforge create src/MyContract.sol:MyContract \
-    --rpc-url https://gcp-1.seismictest.net/rpc \
+    --rpc-url https://testnet-1.seismictest.net/rpc \
     --private-key $PRIVATE_KEY
 ```
 
@@ -207,7 +207,7 @@ sforge create src/MyContract.sol:MyContract \
 
 ```bash
 sforge script script/Deploy.s.sol \
-    --rpc-url https://gcp-1.seismictest.net/rpc \
+    --rpc-url https://testnet-1.seismictest.net/rpc \
     --private-key $PRIVATE_KEY \
     --broadcast
 ```

--- a/docs/gitbook/reference/rpc-methods/eth-get-storage-at.md
+++ b/docs/gitbook/reference/rpc-methods/eth-get-storage-at.md
@@ -25,7 +25,7 @@ This is a deliberate security measure — shielded storage values are flagged wi
 ## Example Request
 
 ```bash
-curl -X POST https://gcp-1.seismictest.net/rpc \
+curl -X POST https://testnet-1.seismictest.net/rpc \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",

--- a/docs/gitbook/reference/rpc-methods/seismic-get-tee-public-key.md
+++ b/docs/gitbook/reference/rpc-methods/seismic-get-tee-public-key.md
@@ -19,7 +19,7 @@ None.
 ## Example Request
 
 ```bash
-curl -X POST https://gcp-1.seismictest.net/rpc \
+curl -X POST https://testnet-1.seismictest.net/rpc \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",

--- a/docs/gitbook/rpc-terminal/index.html
+++ b/docs/gitbook/rpc-terminal/index.html
@@ -567,8 +567,8 @@
         <div class="endpoint-row">
           <div class="endpoint-select-group">
             <select id="endpointSelect">
-              <option value="https://gcp-0.seismictest.net/rpc">Testnet</option>
-              <option value="https://gcp-1.seismictest.net/rpc">Testnet</option>
+              <option value="https://testnet-0.seismictest.net/rpc">Testnet</option>
+              <option value="https://testnet-1.seismictest.net/rpc">Testnet</option>
               <option value="custom">Custom</option>
             </select>
           </div>
@@ -1027,7 +1027,7 @@
 
         // ── Update code snippets ──
         function updateSnippets() {
-          var ep = getEndpoint() || "https://gcp-0.seismictest.net/rpc";
+          var ep = getEndpoint() || "https://testnet-0.seismictest.net/rpc";
           var tsFn = TS_TEMPLATES[method] || TS_TEMPLATES.eth_blockNumber;
 
           var tsRaw = tsFn(ep);

--- a/docs/gitbook/tutorials/src20/building-the-frontend.md
+++ b/docs/gitbook/tutorials/src20/building-the-frontend.md
@@ -39,7 +39,7 @@ import { seismicTestnet } from "seismic-viem";
 const config = createConfig({
   chains: [seismicTestnet],
   transports: {
-    [seismicTestnet.id]: http("https://gcp-1.seismictest.net/rpc"),
+    [seismicTestnet.id]: http("https://testnet-1.seismictest.net/rpc"),
   },
 });
 

--- a/docs/gitbook/tutorials/src20/signed-reads-for-balance-checking.md
+++ b/docs/gitbook/tutorials/src20/signed-reads-for-balance-checking.md
@@ -77,7 +77,7 @@ import { privateKeyToAccount } from "viem/accounts";
 // Create a shielded wallet client
 const walletClient = await createShieldedWalletClient({
   chain: seismicTestnet,
-  transport: http("https://gcp-1.seismictest.net/rpc"),
+  transport: http("https://testnet-1.seismictest.net/rpc"),
   account: privateKeyToAccount(PRIVATE_KEY),
 });
 


### PR DESCRIPTION
## Summary

- Rename all testnet RPC hostnames from `gcp-{0..3}.seismictest.net` to `testnet-{0..3}.seismictest.net` across python (`seismic-web3`), typescript (`seismic-viem`, `seismic-react`), and the gitbook docs.
- Bump `seismic-viem` and `seismic-react` to `2.0.1` and `seismic-web3` to `0.1.3` so the updated URLs ship with the next publish.

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run pytest tests/ --ignore=tests/integration` (288 passed)
- [x] `bun run lint:check` passes
- [x] `grep -r 'gcp-' .` returns no hits