### PR TITLE
chore(seismic-web3): bump to 0.2.2

### DIFF
--- a/clients/py/pyproject.toml
+++ b/clients/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seismic-web3"
-version = "0.1.3"
+version = "0.2.2"
 description = "Seismic Python SDK — web3.py extensions for the Seismic network"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/py/src/seismic_web3/__init__.py
+++ b/clients/py/src/seismic_web3/__init__.py
@@ -37,7 +37,7 @@ Public API
     :func:`build_seismic_typed_data`
 """
 
-__version__ = "0.1.3"
+__version__ = "0.2.2"
 
 # -- Types -------------------------------------------------------------------
 from seismic_web3._types import (

--- a/clients/py/tests/test_placeholder.py
+++ b/clients/py/tests/test_placeholder.py
@@ -2,4 +2,4 @@ import seismic_web3
 
 
 def test_import():
-    assert seismic_web3.__version__ == "0.1.3"
+    assert seismic_web3.__version__ == "0.2.2"

--- a/clients/py/uv.lock
+++ b/clients/py/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "seismic-web3"
-version = "0.1.3"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "coincurve" },


### PR DESCRIPTION
## Summary

- 0.2.0 and 0.2.1 of `seismic-web3` were already published to PyPI, so the 0.1.3 bump from #187 was not a valid next version. Bump to 0.2.2 instead.
- Updates `pyproject.toml`, `__init__.py`, `uv.lock`, and the version assertion in `tests/test_placeholder.py`.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` (288 passed)