### PR TITLE
chore(vscode): fix settings.json default python path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     // Get vscode to use the uv venv so imports resolve. Run `make install` in clients/py/ first.
-    "python.defaultInterpreterPath": "clients/py/.venv/bin/python",
+    // To disable auto-activation of this venv in new terminals, add
+    // `"python-envs.terminal.autoActivationType": "off"` to your user settings
+    // (the setting is machine-scoped and can't live here).
+    "python.defaultInterpreterPath": "${workspaceFolder}/clients/py/.venv/bin/python",
 }


### PR DESCRIPTION
The path was wrong when using the workspace structure, and I didn't notice it wasn't working until now.

Also added a comment mentioning how to disable vscode integrated terminals from enabling python on startup (since it does it regardless of the repo/dir we are in).