### PR TITLE
fix(seismic-react): allow React 19 peer deps

### DIFF
--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -56,8 +56,8 @@
       "version": "2.0.1",
       "peerDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
-        "react": "^18",
-        "react-dom": "^18",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
         "seismic-viem": ">=1.1.1",
         "typescript": ">=5.0.4",
         "viem": "2.x",

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -47,8 +47,8 @@
   },
   "peerDependencies": {
     "@rainbow-me/rainbowkit": "^2.0.0",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19",
     "typescript": ">=5.0.4",
     "viem": "2.x",
     "wagmi": "^2.0.0",

--- a/docs/gitbook/clients/typescript/react/installation.md
+++ b/docs/gitbook/clients/typescript/react/installation.md
@@ -178,8 +178,8 @@ If you encounter React version conflicts in a monorepo, ensure all packages reso
 ```json
 {
   "resolutions": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- widens `seismic-react` peer dependency ranges for `react` and `react-dom` to allow React 19
- updates the Bun lockfile workspace snapshot
- updates the React installation docs to show the same peer range

## Testing

- `jq empty clients/ts/packages/seismic-react/package.json`
- `git diff --check`

Closes #191.