### PR TITLE
docs(seismic-transaction): add Cryptography page, slim tx-lifecycle/signed-reads

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -250,6 +250,7 @@
 ## Reference
 
 * [The Seismic Transaction](reference/seismic-transaction/README.md)
+  * [Cryptography](reference/seismic-transaction/cryptography.md)
   * [Tx Lifecycle](reference/seismic-transaction/tx-lifecycle.md)
   * [Signed Reads](reference/seismic-transaction/signed-reads.md)
 * [Opcodes](reference/opcodes.md)

--- a/docs/gitbook/reference/seismic-transaction/README.md
+++ b/docs/gitbook/reference/seismic-transaction/README.md
@@ -6,7 +6,8 @@ icon: dollar-sign
 
 <figure><img src="../../.gitbook/assets/seismic-tx-format.png" alt=""><figcaption></figcaption></figure>
 
-Seismic extends Ethereum's transaction model with encrypted calldata and authenticated reads. This section covers the two core mechanisms:
+Seismic extends Ethereum's transaction model with encrypted calldata and authenticated reads. This section covers:
 
-* [**Tx Lifecycle**](tx-lifecycle.md) — How a Seismic transaction is constructed, encrypted, sent, decrypted, and executed. Covers key management, the `SeismicElements` metadata fields, AES encryption with AEAD, node-side decryption, and shielded storage via `CLOAD`/`CSTORE`.
-* [**Signed Reads**](signed-reads.md) — How users make authenticated `eth_call` requests that prove `msg.sender` identity. Covers the motivation (preventing from-address spoofing), how signed reads are sent and validated, and the `signed_read` field that prevents replay as write transactions.
+* [**Cryptography**](cryptography.md) — The encryption scheme (ECIES on secp256k1), key derivation, AEAD construction, and client key-management strategies
+* [**Tx Lifecycle**](tx-lifecycle.md) — How a Seismic transaction is built, signed, submitted, validated, and executed; the `SeismicElements` metadata fields; wire vs. signing format; tx-pool validation rules
+* [**Signed Reads**](signed-reads.md) — The read variant: Seismic txs sent to `eth_call`, with `msg.sender` recovered from the signature

--- a/docs/gitbook/reference/seismic-transaction/cryptography.md
+++ b/docs/gitbook/reference/seismic-transaction/cryptography.md
@@ -1,0 +1,103 @@
+---
+icon: key
+---
+
+# Cryptography
+
+This page describes the cryptographic primitives and key material underlying Seismic transactions. It targets readers who want enough detail to audit, port, or build alternative implementations — the encryption scheme, KDF, AEAD, and AAD binding are all named explicitly.
+
+## Network keys
+
+* The network is bootstrapped with a chain-wide **`root_key`** (32 random bytes) which validators keep secret
+  * Enclave can boot in either `--genesis-node` or `--peers <ip>` mode. The former generates its own root key and shares it with peers after they pass validation. The latter loops through its peer IPs until it receives the root key from one of them
+* All other network-shared keys are derived from `root_key` via HKDF-SHA256, with a purpose label for domain separation. For example, the **`tx_io`** key (the ECIES recipient for transaction encryption) is derived as `HKDF(root_key, salt=None, info="tx_io key", length=32)`
+* The key clients care about is **`tx_io`** — the secp256k1 keypair used as the ECIES recipient for transaction calldata. Clients fetch the `tx_io_pk` via the [`seismic_getTeePublicKey`](../rpc-methods/seismic-get-tee-public-key.md) RPC once and cache it for subsequent transactions.
+
+## Client keys
+
+For each transaction the client uses a secp256k1 encryption keypair to encrypt calldata to `tx_io_pk`. The client's encryption public key is sent on-chain as part of `TxSeismicMetadata`. Two strategies are supported, with different convenience/privacy trade-offs:
+
+### Strategy 1 — ephemeral key per tx (default, recommended)
+
+* Generate a fresh secp256k1 keypair for each transaction; use it once; discard `eph_sk` after submission
+* Each tx has its own AES key — a different `eph_sk` produces a different ECDH output, a different `shared_secret`, and therefore a different `K`. The AES-GCM `encryptionNonce` can be a **fixed constant** (the reference clients use all-zeros) because `(K, nonce)` pairs are unique by construction, never reused
+* **Self-decryption is unavailable once `eph_sk` is discarded** — the client can no longer reproduce `K` for that tx, and the protocol exposes no validator-side recovery mechanism. Clients that want to view their own historical calldata must persist `eph_sk` (or `K`) per tx in wallet-side storage at submission time
+* **Privacy benefit:** a discarded `eph_sk` removes the client's *own* ability to recover the plaintext from the on-chain ciphertext. Reduces blast-radius of a wallet compromise (only txs whose ephemerals are still cached are decryptable), and provides strong forward deniability — even the client themselves cannot prove what was in past calldata
+
+### Strategy 2 — long-lived client key
+
+* Use a persistent secp256k1 keypair across many transactions
+* `(client_sk, tx_io_pk)` produces the same `shared_secret` and therefore the same `K` for every tx the client sends; the `encryptionNonce` **must** be unique per tx under this `K`. Use an incrementing counter, or a freshly random 12-byte value (birthday-bound — collision-probable after ~2⁴⁸ txs)
+* **Self-decryption is offline and free:** the client recomputes `K` once from `(client_sk, tx_io_pk)` and decrypts any of their past transactions directly from on-chain data. Useful for wallets that want to display a user's tx history without round-tripping a validator
+* **Trade-off:** loss of `client_sk` exposes every transaction ever encrypted under it. Strategy 1 doesn't have this exposure by construction
+
+### Strategy 3 — deterministic derivation from the signing key
+
+Derive each per-tx encryption key deterministically from a seed bound to the user's wallet. Gives offline self-decryption without managing a separate encryption key — the only thing the user needs to back up is their normal signing seed.
+
+* `eph_sk = HKDF(seed, chain_id, tx_nonce)`; `seed` source depends on the wallet (see below)
+* **Self-decryption is offline:** any past `eph_sk` re-derives from the seed plus on-chain `(chain_id, tx_nonce)`. No per-tx storage required
+* **Trade-off:** loss of the wallet's signing material exposes every past Seismic tx (no forward deniability)
+
+Two sub-cases depending on what the wallet exposes:
+
+* **(a) Direct** — if the dApp can access `signing_sk` (mnemonic-based JS wallets, server-side signers, programmatic test setups): `seed = signing_sk`
+* **(b) Session signature** — if the wallet only exposes signing (MetaMask, Ledger, Trezor, KMS): prompt the user once at session start to `personal_sign` a fixed message (e.g., `"Seismic encryption session for {address}"`); use the resulting signature as `seed`, cached in dApp memory for the session lifetime. The same prompt always yields the same signature (deterministic ECDSA), so refresh-recovery works. The signature must not be exposed — sharing it grants offline decryption of every past tx
+
+## Encryption scheme
+
+Transaction calldata encryption is **ECIES on secp256k1** — a standard KEM-DEM hybrid public-key encryption construction, using the EC primitives Seismic already requires for signing.
+
+End-to-end pipeline (client side; decryption inverts):
+
+```
+ECDH(client_sk, network_pk) ──► shared point
+                              │
+                              ▼  SHA256 of compressed point
+                          shared_secret (32 B)
+                              │
+                              ▼  HKDF-SHA256, info = "aes-gcm key"
+                          AES-256 key (32 B)
+                              │
+                              ▼  AES-GCM, 12 B nonce, AAD = RLP(TxSeismicMetadata)
+                          ciphertext
+```
+
+**KEM (key encapsulation)**
+
+* Curve: **secp256k1**
+* ECDH on secp256k1: shared point = `client_sk × network_pk` (encryption side) / `network_sk × client_pk` (decryption side)
+* Shared-secret derivation: `SHA256` of the SEC1 **compressed-point encoding** of the shared ECDH point — i.e., `SHA256(0x02 || x)` if the y-coordinate is even, `SHA256(0x03 || x)` if odd. This is libsecp256k1's `ecdh::SharedSecret::new(pk, sk)` default behaviour and matches the Rust [`ecies`](https://github.com/ecies/rs) crate convention; Python and TypeScript reimplementations construct the parity byte explicitly as `(shared_point.y[-1] & 0x01) | 0x02`
+
+**KDF**
+
+Takes the 32-byte `shared_secret` produced by the KEM step and expands it into the actual symmetric encryption key.
+
+* Algorithm: **HKDF-SHA256**
+* `ikm` (input keying material): the `shared_secret` from above
+* `salt`: none — the `ikm` is already a SHA-256 output and therefore uniformly random, so Extract has no biased entropy to extract from. [RFC 5869 §3.1](https://datatracker.ietf.org/doc/html/rfc5869#section-3.1) explicitly permits this
+* `info`: `"aes-gcm key"` — provides domain separation; lets the same `shared_secret` derive other context-specific keys in the future with a different label
+* Output length: 32 bytes — the AES-256 key
+
+**DEM (authenticated encryption)**
+
+* **AES-256-GCM**, with a 12-byte nonce supplied by the client (the `encryptionNonce` field in `TxSeismicMetadata`)
+* **AAD = RLP-encoded `TxSeismicMetadata`** — the 11-field metadata struct (`sender`, `chain_id`, tx `nonce`, `to`, `value`, `encryption_pubkey`, `encryption_nonce`, `recentBlockHash`, `expires_at_block`, `signedRead`, `messageVersion`). Binding everything that contextualizes the tx prevents ciphertext malleability across senders, replay across chains or blocks, and substitution attacks
+
+**Decryption (any validator node)**
+
+* `tx_io_sk` (re-derived from `root_key` on demand) + client's `eph_pk` from the on-chain tx → ECDH → same shared secret → same AES key → AEAD-open with the same AAD → plaintext calldata
+
+## Curve choice
+
+* **secp256k1** rather than X25519 (the curve used by HPKE / RFC 9180) to avoid a curve split: the same secp256k1 stack already required for Ethereum signing handles encryption. Clients can encrypt to `tx_io_pk` using libraries they already have for signatures (libsecp256k1, ethers, viem, web3.py, etc.) — no separate X25519 dependency
+* The trade-off is that we use a custom ECIES variant instead of a standardized HPKE suite. RFC 9180 defines KEMs for X25519/X448/P-256/P-384/P-521 but not secp256k1, so adopting HPKE would have required switching curves
+
+## Reference implementations
+
+All implementations produce byte-identical ciphertexts for the same inputs.
+
+* **Rust (ECIES primitive):** [`enclave/crates/enclave/src/crypto.rs`](https://github.com/SeismicSystems/enclave/tree/seismic/crates/enclave/src/crypto.rs) in the [`seismic-enclave`](https://github.com/SeismicSystems/enclave) crate. This is the source-of-truth Rust implementation, used by both the client side (via `seismic-alloy`) and the server side (via `seismic-enclave-server`)
+* **Rust (TxSeismic wire format + tx construction):** [`seismic-alloy/crates/consensus`](https://github.com/SeismicSystems/seismic-alloy/tree/seismic/crates/consensus) — depends on `seismic-enclave` for the ECIES math
+* **Python:** [`clients/py/src/seismic_web3/crypto/ecdh.py`](https://github.com/SeismicSystems/seismic/tree/main/clients/py/src/seismic_web3/crypto/ecdh.py) — independent reimplementation; matches the Rust shared-secret derivation by construction
+* **TypeScript:** [`clients/ts/`](https://github.com/SeismicSystems/seismic/tree/main/clients/ts) — independent reimplementation

--- a/docs/gitbook/reference/seismic-transaction/cryptography.md
+++ b/docs/gitbook/reference/seismic-transaction/cryptography.md
@@ -15,34 +15,27 @@ This page describes the cryptographic primitives and key material underlying Sei
 
 ## Client keys
 
-For each transaction the client uses a secp256k1 encryption keypair to encrypt calldata to `tx_io_pk`. The client's encryption public key is sent on-chain as part of `TxSeismicMetadata`. Two strategies are supported, with different convenience/privacy trade-offs:
+For each transaction the client uses a secp256k1 encryption keypair to encrypt calldata to `tx_io_pk`. The client's encryption public key is sent on-chain as part of `TxSeismicMetadata`. A client's key strategy is two independent choices:
 
-### Strategy 1 — ephemeral key per tx (default, recommended)
+### Axis 1 — Rotation frequency
 
-* Generate a fresh secp256k1 keypair for each transaction; use it once; discard `eph_sk` after submission
-* Each tx has its own AES key — a different `eph_sk` produces a different ECDH output, a different `shared_secret`, and therefore a different `K`. The AES-GCM `encryptionNonce` can be a **fixed constant** (the reference clients use all-zeros) because `(K, nonce)` pairs are unique by construction, never reused
-* **Self-decryption is unavailable once `eph_sk` is discarded** — the client can no longer reproduce `K` for that tx, and the protocol exposes no validator-side recovery mechanism. Clients that want to view their own historical calldata must persist `eph_sk` (or `K`) per tx in wallet-side storage at submission time
-* **Privacy benefit:** a discarded `eph_sk` removes the client's *own* ability to recover the plaintext from the on-chain ciphertext. Reduces blast-radius of a wallet compromise (only txs whose ephemerals are still cached are decryptable), and provides strong forward deniability — even the client themselves cannot prove what was in past calldata
+* **Per-tx (ephemeral)** — fresh keypair per tx, discarded after submission. Each tx has its own AES key, so the `encryptionNonce` can be a fixed constant (the reference clients use all-zeros). Strongest forward deniability — the client itself cannot recover past plaintext once the key is discarded. No offline self-decryption: wallets wanting to view tx history must cache the key per tx
+* **Long-lived (per-session or longer)** — same keypair reused across many txs. The `encryptionNonce` **must** be unique per tx under this key (incrementing counter or random 12-byte value; birthday-bound at ~2⁴⁸ random nonces) — same AES key + same nonce breaks AES-GCM. Enables offline self-decryption: the client recomputes `K` once and decrypts any past tx
 
-### Strategy 2 — long-lived client key
+### Axis 2 — Key source
 
-* Use a persistent secp256k1 keypair across many transactions
-* `(client_sk, tx_io_pk)` produces the same `shared_secret` and therefore the same `K` for every tx the client sends; the `encryptionNonce` **must** be unique per tx under this `K`. Use an incrementing counter, or a freshly random 12-byte value (birthday-bound — collision-probable after ~2⁴⁸ txs)
-* **Self-decryption is offline and free:** the client recomputes `K` once from `(client_sk, tx_io_pk)` and decrypts any of their past transactions directly from on-chain data. Useful for wallets that want to display a user's tx history without round-tripping a validator
-* **Trade-off:** loss of `client_sk` exposes every transaction ever encrypted under it. Strategy 1 doesn't have this exposure by construction
+* **Random (CSPRNG)** — `client_sk = OsRng(32)`. The key must be persisted out-of-band to reuse it; lost key = lost access
+* **Derived from signing key (direct)** — `client_sk = HKDF(signing_sk, info)`. Requires the dApp/SDK to have raw access to `signing_sk` (mnemonic-based JS wallets, server-side signers, programmatic test setups). No extra backup needed beyond the wallet seed; forward deniability is lost — signing-key compromise exposes the encryption key
+* **Derived from a wallet signature** — for wallets that hide `signing_sk` (MetaMask, Ledger, Trezor, Fireblocks, KMS, etc.): ask the wallet to sign a fixed message and use the signature (or `SHA-256(signature)`) as the seed. RFC 6979-deterministic ECDSA makes re-signing reproducible. The signature must be kept secret — sharing it reveals every derived encryption key
 
-### Strategy 3 — deterministic derivation from the signing key
+### Common combinations
 
-Derive each per-tx encryption key deterministically from a seed bound to the user's wallet. Gives offline self-decryption without managing a separate encryption key — the only thing the user needs to back up is their normal signing seed.
+* **Ephemeral × random** — recommended default, used by the seismic-viem and seismic_web3 reference clients. Privacy-maxing; no self-decryption without explicit per-tx caching
+* **Ephemeral × derived (direct)** — fresh keypair per tx, deterministically derived from `signing_sk`. Combines "no separate backup" with "fresh K per tx (no nonce-reuse concern)." Suitable when the dApp has direct access to `signing_sk`
+* **Long-lived × random** — single CSPRNG key reused. Enables offline self-decryption; the encryption key must be backed up separately from the wallet seed
+* **Long-lived × signature-derived** — single key derived from one wallet signature at session start. **Used by the [Fireblocks SDK](https://github.com/fireblocks/seismic-sdk)**: signs a fixed seed via Fireblocks RAW signing, hashes the signature into a session-scoped encryption key. Re-derives on session restart without user re-approval (MPC signatures are deterministic); no out-of-band backup needed — the wallet covers both signing and encryption
 
-* `eph_sk = HKDF(seed, chain_id, tx_nonce)`; `seed` source depends on the wallet (see below)
-* **Self-decryption is offline:** any past `eph_sk` re-derives from the seed plus on-chain `(chain_id, tx_nonce)`. No per-tx storage required
-* **Trade-off:** loss of the wallet's signing material exposes every past Seismic tx (no forward deniability)
-
-Two sub-cases depending on what the wallet exposes:
-
-* **(a) Direct** — if the dApp can access `signing_sk` (mnemonic-based JS wallets, server-side signers, programmatic test setups): `seed = signing_sk`
-* **(b) Session signature** — if the wallet only exposes signing (MetaMask, Ledger, Trezor, KMS): prompt the user once at session start to `personal_sign` a fixed message (e.g., `"Seismic encryption session for {address}"`); use the resulting signature as `seed`, cached in dApp memory for the session lifetime. The same prompt always yields the same signature (deterministic ECDSA), so refresh-recovery works. The signature must not be exposed — sharing it grants offline decryption of every past tx
+Other combinations (e.g., per-tx × signature-derived, which would require a wallet-signature prompt per tx) are valid but operationally rare.
 
 ## Encryption scheme
 

--- a/docs/gitbook/reference/seismic-transaction/signed-reads.md
+++ b/docs/gitbook/reference/seismic-transaction/signed-reads.md
@@ -4,15 +4,20 @@ icon: file-signature
 
 # Signed Reads
 
-* The Seismic transaction has a counterpart, which we call "signed reads"
-* The motivation for a signed read is: in the EVM, users can make an `eth_call` and set the "from" field to any address they'd like to spoof
-* We want to give contract developers the ability to validate contract reads against msg.sender. For example, a user could implement an ERC20 token where only the owner can view their balance
-* To solve this, we do two things: (1) we zero out the "from" field when users make a vanilla `eth_call` and (2) we created the "signed read" to allow users to make a call with a specific `from` address
-* Signed reads are sent to Seismic's `eth_call` endpoint in the same way we would send a signed Seismic transaction to `eth_sendRawTransaction`. This can be either with a normal raw transaction, or an EIP-712 transaction
-* Signed reads must be a valid Seismic transaction (type `0x4a`). They cannot be made with any other transaction type
-* The response to a signed read will be encrypted to the encryption public key included in the transaction's Seismic elements. Therefore anyone who manages to intercept the response still cannot decrypt the response to the signed read.
-* Users can set the `signed_read` field in SeismicElements to `true`. We encourage this, and it is the default behaviour in our client implementations. The purpose of this is to prevent anyone who has managed to intercept this `eth_call` from sending that same payload to `eth_sendRawTransaction`, which would otherwise trigger a write transaction. When validating a transaction before it hits the pool, we check if the `signed_read` field is set to true; if it is, the transaction is rejected
-  * This does not apply the other way around. Meaning, if `signed_read` is `false` (and the user wants to create a transaction), it can still be passed to `eth_call`. We think this validation is unnecessary because:
-    * For an attacker to decrypt the response to a signed read, they'd need the user's secret encryption key
-    * The account's transaction nonce will increment right after their Seismic transaction is included in a block, after which the read will fail
-    * This also allows `eth_estimateGas` to function properly; otherwise it would not pass validation on the `signed_read` field
+A signed read is a Seismic transaction (type `0x4a`) sent to `eth_call` instead of `eth_sendRawTransaction`. It lets contracts authenticate the reader's `msg.sender` for read-only queries — e.g., "only the owner can view their balance."
+
+## Why signed reads exist
+
+In the EVM, anyone can set the `from` field of an `eth_call` to spoof any address. Seismic closes this in two parts:
+
+1. Vanilla `eth_call` has its `from` field **zeroed out** by the node — `msg.sender == 0` inside contract code
+2. A signed read is a Seismic tx where the validator recovers the signer from the signature and uses *that* address as `msg.sender`
+
+## How signed reads differ from write txs
+
+A signed read is built exactly like a write tx (same `SeismicElements`, same encryption flow — see [Tx Lifecycle](tx-lifecycle.md) and [Cryptography](cryptography.md)). The differences are:
+
+* **Sent to `eth_call`**, not `eth_sendRawTransaction`. Either a raw tx or an EIP-712 envelope (`message_version = 2`)
+* The **`signed_read`** field should be set to `true` (default in our clients). The tx-pool rejects `signed_read = true` at write submission, so an intercepted signed read can't be replayed as a write tx
+* The validator decrypts the calldata, runs the call inside the EVM, and returns the result **encrypted to the client's `encryption_pubkey`** — an on-path interceptor can't read the response either
+* `signed_read = false` is also valid for `eth_call` — the same tx body can be passed to either endpoint. This is intentional so that `eth_estimateGas` works on **write** txs: gas estimation simulates the tx via the same `eth_call` path internally, so if `eth_call` rejected `signed_read = false`, clients couldn't estimate gas on a normal write tx without building a separate tx variant. Safety still holds: decrypting the response requires the client's `eph_sk`, and once the account's tx nonce increments, a captured `eth_call` payload can no longer execute as a write

--- a/docs/gitbook/reference/seismic-transaction/tx-lifecycle.md
+++ b/docs/gitbook/reference/seismic-transaction/tx-lifecycle.md
@@ -4,52 +4,65 @@ icon: arrows-spin
 
 # Tx Lifecycle
 
-## Key management
+How a Seismic transaction is built, signed, submitted, validated, and executed. For the encryption primitives themselves (ECIES on secp256k1, KDF, AEAD, AAD binding), see [Cryptography](cryptography.md).
 
-* The network manages its keys through the [`seismic-enclave-server`](https://github.com/SeismicSystems/enclave/tree/seismic/crates/enclave-server) crate. Reth (and Summit) can make RPC calls to this server. One such call is to get the network keys
-* Enclave can boot in either `--genesis-node` or `--peers <ip>` mode. The former generates its own root key and shares it with peers after they pass validation. The latter loops through its peer IPs until it receives the root key from one of them
-* Enclave then derives a few different keys from that root key. Most importantly, it derives the encryption secret key. This is the key used to decrypt Seismic transaction calldata
-* When [`seismic-reth`](https://github.com/SeismicSystems/seismic-reth/tree/seismic/bin/seismic-reth) boots, it requests the derived keys from the enclave and keeps them in memory
-* We exposed a new RPC method, [`seismic_getTeePublicKey`](../rpc-methods/seismic-get-tee-public-key.md). Its response is the public key of the aforementioned secret key that decrypts Seismic transactions. Calling this endpoint is the first step that a client takes to build a Seismic transaction
-* Clients also generate their own secret key, which can be either ephemeral (default) or long-lived, if they prefer to manage this themselves
-* Their secret key and the network public key combine to create an AES key, which is used to encrypt calldata
+## Building a Seismic transaction
 
-## Encryption & Metadata
+A Seismic transaction is a legacy Ethereum tx with two additions: encrypted calldata in the `data` field, and a metadata struct called **`SeismicElements`**. The tx type is `74` / `0x4a`.
 
-* The client will include their encryption public key in the transaction, along with four other parameters to tighten the security of encryption. These are:
-  * a 12-byte `encryptionNonce`
-  * `recentBlockHash`, which must be within 100 blocks of the latest block
-  * an `expiresAtBlock` number, after which this transaction is invalid
-  * optionally, a boolean `signedRead`. If set, it only allows the transaction to be used for signed reads. Otherwise, it will be rejected by transaction pool validation
-* There is one other field in Seismic transaction metadata: an integer called `messageVersion`. This field is a hack to allow browser extension wallets (e.g. MetaMask) to support the Seismic transaction type. Message version 0, the default, means a standard Seismic transaction as described above. Message version 2 corresponds to a transaction sent as EIP-712 typed data, which browser extension wallets can sign. There is no message version 1, but we reserved this for implementing Seismic transactions via `eth_personalSign`
-* These six Seismic-specific fields are called `SeismicElements`: the client encryption public key, the four security fields above, and the message version. They are combined with the EOA address (`sender`), `chainId`, `nonce`, `to` address, and `value`. The full set of 11 fields is referred to as the Seismic transaction metadata (`TxSeismicMetadata`) in [`seismic-alloy-consensus`](https://github.com/SeismicSystems/seismic-alloy/tree/seismic/crates/consensus)
-* To encrypt calldata, we use AES with AEAD. The AEAD is an RLP encoding of the `TxSeismicMetadata`. The nonce for this encryption is the same 12-byte encryption nonce as we included in the metadata
-* The encrypted calldata is then passed to a Seismic transaction in the data/input field. Seismic transactions work just like Legacy Ethereum transactions, except:
-  * they have a tx type of `74` or `0x4a`
-  * they have these `SeismicElements` attached as well
+`SeismicElements` consists of six Seismic-specific fields:
 
-## Decryption
+* **`encryption_pubkey`** — the client's encryption pubkey for this tx (see [Cryptography → Client keys](cryptography.md#client-keys) for the available strategies)
+* **`encryption_nonce`** — 12-byte AES-GCM nonce
+* **`recentBlockHash`** — must be within 100 blocks of the latest block
+* **`expires_at_block`** — block number after which the tx is invalid
+* **`signed_read`** — boolean (defaults to `true` in our client implementations); if `true`, restricts the tx to signed-read use only — see [Signed reads](#signed-reads-read-variant)
+* **`message_version`** — integer controlling the signing format; see [Wire vs. signing format](#wire-vs-signing-format)
 
-* Transactions sent with type `0x4a` but incomplete Seismic elements are rejected from the tx pool, as are transactions not marked as `0x4a` but do contain Seismic elements
-* Nodes will decrypt Seismic transactions by:
-  * decoding the transaction
-  * recovering the signer
-  * assembling the metadata
-  * encoding it as AEAD via RLP
-  * generating the AES key by combining the network's secret key with the transaction's encryption public key
-* If transaction decryption fails, the transaction is removed from the transaction pool
-* If it succeeds, it passes to the revm transaction environment _as plaintext_
-* Calls to get transaction information after they have landed on chain should return input as the encrypted calldata, and not the plaintext
-* A note on calldata encoding: s-types are encoded the same way as their public analogues. The consequence is an interesting artifact of the Seismic protocol (and maybe a security concern): Solidity has no clue whether functions are called with Seismic transactions or not. As a result, it's totally allowed to alter shielded state with vanilla Ethereum transactions. It's also allowed to do the reverse, by altering public state with Seismic transactions
+Combined with the standard Ethereum fields (`sender`, `chain_id`, `nonce`, `to`, `value`), the full 11-field bundle is **`TxSeismicMetadata`**, which is RLP-encoded and used as AAD when the AEAD seals the calldata (see [Cryptography → Encryption scheme](cryptography.md#encryption-scheme)). Definitions in [`seismic-alloy-consensus`](https://github.com/SeismicSystems/seismic-alloy/tree/seismic/crates/consensus).
 
-## Shielded storage
+The encrypted calldata is placed in the standard `data` / `input` field of the tx envelope.
 
-* Inside Solidity, we've defined two new opcodes: `CLOAD` and `CSTORE`. These are the shielded analogues to `SLOAD` and `SSTORE`. We use `CLOAD`/`CSTORE` when the underlying type is an s-type.
-* Importantly, we maintain only one state tree, as you can see in [`seismic-trie`](https://github.com/SeismicSystems/seismic-trie/) (a fork of alloy-trie). We modified the state tree by adding an extra boolean flag, `is_private`, to leaves. This is wrapped inside the struct called `FlaggedStorage`, which replaces `StorageValue` (a plain `U256`). We use this flag to validate `CLOAD`/`CSTORE` calls, and to know whether we can expose this piece of storage, via e.g. `eth_getStorageAt`
-* When we see a `CLOAD` opcode inside [`seismic-revm`](https://github.com/SeismicSystems/seismic-revm), we load the storage slot and validate that it either has `is_private` set to `true` or is an uninitialized slot. For `CSTORE`, we write the storage value with `is_private = true`. We throw errors when trying to `CLOAD`/`CSTORE` a `FlaggedStorage` that has `is_private = false` ("Invalid public storage access"). Similarly, we throw errors when trying to `SLOAD`/`SSTORE` on `FlaggedStorage` that has `is_private = true` ("Invalid private storage access"). These errors are thrown inside `seismic-revm`.
-* Unlike SSTORE/SLOAD, the gas cost of CLOAD/CSTORE does not change based on the length of the word stored. This is to prevent attackers from deducing information about shielded storage values
+## Wire vs. signing format
 
-## Notes
+A Seismic transaction has the same **wire format** in every case: an RLP-encoded type-`0x4a` envelope containing the tx fields, the encrypted calldata, and a signature. What can differ is the **signing format** — the bytes the ECDSA signature actually covers. This is controlled by the `message_version` field in `SeismicElements`:
 
-* Outside of `SeismicElements` and the encrypted calldata, Seismic transactions have the same fields as legacy transactions. In particular, they use the same gas parameters: `gasPrice` and `gasLimit`
-* Seismic transactions cannot be used to deploy bytecode via `Create` calls. Instead, we only allow Seismic transactions to be sent to a specific address. We did this to make metadata validation easier, and we can't see a good reason to deploy encrypted bytecode
+* **`message_version = 0`** — Standard. Signature covers the RLP-encoded preimage of the tx (same shape as other Ethereum typed txs, e.g. EIP-2930, EIP-1559). The validator re-RLP-encodes the preimage and recovers the signer from the signature.
+* **`message_version = 2`** — EIP-712 typed-data form. Signature covers an EIP-712 hash of the tx as a structured-data message. **This is what makes Seismic txs signable by MetaMask and other browser-extension wallets**, which don't natively understand tx type `0x4a` but do support `eth_signTypedData`. The validator reconstructs the typed-data hash and recovers the signer accordingly.
+* **`message_version = 1`** — Reserved (originally planned for `eth_personalSign`-style signing; not implemented).
+
+The wire-level type byte is always `0x4a`; only how the signer was authenticated differs.
+
+## Submission and validation
+
+Send to `eth_sendRawTransaction` like any Ethereum tx. Tx-pool validation rejects:
+
+* Txs of type `0x4a` with incomplete or malformed `SeismicElements`
+* Txs not marked `0x4a` but containing `SeismicElements`
+* Txs with `signed_read = true` (those are for `eth_call`, not write txs)
+* Calldata that fails to decrypt (see below)
+
+Validated txs land in the pool and are included in blocks as usual.
+
+## Node-side decryption
+
+For each Seismic tx in the pool, the validator:
+
+1. Decodes the tx and recovers the signer (using the `message_version`-appropriate signing format)
+2. Assembles the metadata, RLP-encodes it — this is the AAD
+3. Derives the AES key from `tx_io_sk` and the client's `encryption_pubkey` via ECDH + HKDF (see [Cryptography](cryptography.md))
+4. AEAD-opens the ciphertext with the derived key, the `encryption_nonce`, and the AAD
+
+On decryption failure, the tx is removed from the pool. On success, the plaintext calldata is passed to revm for execution inside the validator.
+
+**`eth_getTransactionByHash` returns the on-chain ciphertext form, not the plaintext.** Clients that want to view their own historical calldata must arrange this client-side — see [Cryptography → Client keys](cryptography.md#client-keys) for the available strategies.
+
+## Read variant
+
+For authenticated reads — `eth_call` requests that prove `msg.sender` identity to a contract — Seismic uses **signed reads**: the same Seismic tx protocol, sent to `eth_call` instead of `eth_sendRawTransaction`. See [Signed Reads](signed-reads.md) for the specifics.
+
+## Other notes
+
+* Seismic txs use the same gas parameters as legacy txs: `gasPrice` and `gasLimit`
+* Seismic txs cannot deploy bytecode. They must be sent to a specific address; `CREATE` / `CREATE2` from a Seismic tx is rejected. This simplifies metadata validation, and there's no useful reason to deploy encrypted bytecode
+* **Calldata encoding subtlety:** shielded types (`suint`, `sbool`, etc.) are encoded the same way as their public analogues. Solidity has no idea whether a function is called with a Seismic tx or a plain tx — so it's legal (though usually wrong) to alter shielded state via a plain tx, or to alter public state via a Seismic tx. Be deliberate about which kind of tx your contract accepts


### PR DESCRIPTION
Restructure the reference so cryptographic primitives, tx flow, and the read variant each have a focused page. The previous tx-lifecycle was imprecise about the encryption scheme ("AES with AEAD" without naming ECIES) and mixed in shielded-storage content that belongs in opcodes.md. Also this new cryptography page will be the goto for experts who want to get a quick high-level summary of our protocol.

* Cryptography (new): names the scheme explicitly — ECIES on secp256k1
  + HKDF-SHA256 + AES-256-GCM, with RLP(TxSeismicMetadata) as AAD. Documents three client key strategies: ephemeral (default), long-lived, and deterministic-from-signing-key (incl. session-signature sub-case for MetaMask / Ledger / KMS).

* Tx Lifecycle: dropped key-management (→ Cryptography) and shielded- storage (→ reference/opcodes.md) sections. Added "Wire vs. signing format" explaining message_version v0 (RLP preimage) vs v2 (EIP-712, enabling MetaMask to sign tx type 0x4a via eth_signTypedData). Signed reads is now a one-paragraph pointer.

* Signed Reads: rewritten standalone; references Cryptography + Tx Lifecycle instead of re-explaining the encryption flow. Clarified the eth_estimateGas / signed_read=false rationale.