### PR TITLE
3.6: treat non-32-byte return as failure in batchBalancesDetailed

### DIFF
--- a/contracts/src/seismic-std-lib/SRC20Multicall.sol
+++ b/contracts/src/seismic-std-lib/SRC20Multicall.sol
@@ -27,10 +27,13 @@ contract SRC20Multicall {
 
             (bool success, bytes memory returnData) = tokens[i].staticcall(data);
 
-            results[i].success = success;
-            if (success && returnData.length >= 32) {
+            // A non-reverting call that doesn't return exactly one word is malformed:
+            // reporting it as success would make it indistinguishable from a real zero balance.
+            if (success && returnData.length == 32) {
+                results[i].success = true;
                 results[i].balance = abi.decode(returnData, (uint256));
             } else {
+                results[i].success = false;
                 results[i].balance = 0;
             }
 

--- a/contracts/test/BatchRead.t.sol
+++ b/contracts/test/BatchRead.t.sol
@@ -17,6 +17,32 @@ contract TestSRC20 is SRC20 {
     }
 }
 
+/// @notice Answers balanceOfSigned without reverting but returns fewer than 32 bytes.
+contract ShortReturnToken {
+    fallback() external {
+        assembly {
+            return(0, 16)
+        }
+    }
+}
+
+/// @notice Answers balanceOfSigned without reverting but returns more than 32 bytes.
+contract LongReturnToken {
+    fallback() external {
+        assembly {
+            mstore(0, 42)
+            return(0, 48)
+        }
+    }
+}
+
+/// @notice Reverts on any call.
+contract RevertingToken {
+    fallback() external {
+        revert("RevertingToken: always reverts");
+    }
+}
+
 contract BatchReadTest is Test {
     SRC20Multicall multicall;
     TestSRC20[] tokens;
@@ -157,6 +183,37 @@ contract BatchReadTest is Test {
             assertEq(results[i].token, address(tokens[i]));
             assertEq(results[i].balance, (i + 1) * 1e18);
         }
+    }
+
+    // Zellic 3.6: a non-reverting token that returns a payload other than 32 bytes
+    // must be reported as a failure, not as a successful zero balance.
+    function test_batchBalancesDetailedMalformedReturn() public {
+        uint256 expiry = block.timestamp + 1 hours;
+        bytes memory sig = _signBalanceRead(USER_PRIVATE_KEY, user, expiry);
+
+        address[] memory testTokens = new address[](4);
+        testTokens[0] = address(tokens[0]);
+        testTokens[1] = address(new ShortReturnToken());
+        testTokens[2] = address(new LongReturnToken());
+        testTokens[3] = address(new RevertingToken());
+
+        SRC20Multicall.BalanceResult[] memory results = multicall.batchBalancesDetailed(user, testTokens, expiry, sig);
+
+        assertEq(results.length, 4);
+
+        // (a) well-formed token: success with the real balance
+        assertTrue(results[0].success);
+        assertEq(results[0].balance, 1e18);
+
+        // (b) malformed returns (16 and 48 bytes): must not look like a real zero balance
+        assertFalse(results[1].success);
+        assertEq(results[1].balance, 0);
+        assertFalse(results[2].success);
+        assertEq(results[2].balance, 0);
+
+        // (c) reverting token: failure
+        assertFalse(results[3].success);
+        assertEq(results[3].balance, 0);
     }
 
     function test_staticcallErrorHandling() public {


### PR DESCRIPTION
## Zellic audit finding 3.6 (Informational)

`SRC20Multicall.batchBalancesDetailed` copied the raw staticcall success flag and only decoded when `returnData.length >= 32`, so a non-reverting token returning a malformed (non-32-byte) payload was reported as `{success: true, balance: 0}` — indistinguishable from a genuine zero balance.

## Before / after

- **Before:** `success` = raw staticcall result; 16-byte return → `{success: true, balance: 0}`; 48-byte return → `{success: true, balance: <first word>}`.
- **After:** `success` is true only when the call succeeded **and** returned exactly 32 bytes; otherwise `{success: false, balance: 0}`. `success == true` now guarantees a genuinely decoded `uint256`.

`batchBalances` and `batchBalancesInterface` are unchanged (they already revert / use typed calls).

## Test plan

- New `test_batchBalancesDetailedMalformedReturn` in `BatchRead.t.sol` covers: well-formed token (success, correct balance), 16-byte and 48-byte assembly-crafted returns (failure, zero balance), and a reverting token (failure). Committed first and confirmed failing against the unmodified contract.
- Full suite: `sforge build --via-ir --unsafe-via-ir && sforge test --via-ir --unsafe-via-ir -vv` — 164 tests passed, 0 failed (Intelligence suite included). `sforge fmt --check` clean.