### PR TITLE
3.5: reject zero-address owner in transferOwnership

### DIFF
--- a/contracts/src/intelligence/Intelligence.sol
+++ b/contracts/src/intelligence/Intelligence.sol
@@ -55,6 +55,7 @@ contract Intelligence is IIntelligence {
     }
 
     function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "ZERO_OWNER");
         owner = newOwner;
         emit OwnershipTransferred(newOwner);
     }

--- a/contracts/test/Intelligence.t.sol
+++ b/contracts/test/Intelligence.t.sol
@@ -119,4 +119,25 @@ contract IntelligenceTest is Test {
         intelligence.addProvider(charlie);
         assertEq(intelligence.numProviders(), 3);
     }
+
+    function test_RevertWhen_TransferOwnershipToZeroAddress() public {
+        vm.prank(intelligence.owner());
+        vm.expectRevert("ZERO_OWNER");
+        intelligence.transferOwnership(address(0));
+    }
+
+    function test_OwnerNotDisplacedByZeroAddressTransfer() public {
+        vm.prank(intelligence.owner());
+        intelligence.transferOwnership(alice);
+
+        vm.prank(alice);
+        vm.expectRevert("ZERO_OWNER");
+        intelligence.transferOwnership(address(0));
+        assertEq(intelligence.owner(), alice);
+
+        address charlie = makeAddr("charlie");
+        vm.prank(intelligence.INITIAL_OWNER());
+        vm.expectRevert("UNAUTHORIZED");
+        intelligence.addProvider(charlie);
+    }
 }


### PR DESCRIPTION
## Finding

Zellic seismic-std-lib audit, finding 3.5 (Informational). `Intelligence.transferOwnership` had no zero-address guard, and the `onlyOwner` modifier lazily resets `owner = INITIAL_OWNER` whenever `owner == address(0)` before checking `msg.sender`. So `transferOwnership(address(0))` handed control of the provider registry back to the hardcoded deployer key, and the prior owner couldn't recover. The sister contract `ProtocolParams` already rejects `address(0)`, so this was also an internal inconsistency.

## Fix

Add `require(newOwner != address(0), "ZERO_OWNER")` to `transferOwnership` (string revert matches Intelligence's existing error style). Since Intelligence has no renounce path, the owner can never return to zero post-bootstrap, so the lazy `INITIAL_OWNER` init only ever fires on first use.

- **Before:** `transferOwnership(address(0))` succeeds; the next `onlyOwner` call rebinds ownership to `INITIAL_OWNER`.
- **After:** `transferOwnership(address(0))` reverts with `ZERO_OWNER`; the current owner keeps control.

## Test plan

Two commits, test-first (`test:` fails on the unmodified contract, `fix:` makes it pass):

- `test_RevertWhen_TransferOwnershipToZeroAddress` — zero-address transfer reverts with `ZERO_OWNER`.
- `test_OwnerNotDisplacedByZeroAddressTransfer` — a legitimately-set owner keeps control after an attempted zero transfer; `INITIAL_OWNER` stays `UNAUTHORIZED`.

Verified locally: `sforge build --via-ir --unsafe-via-ir`, `sforge test --via-ir --unsafe-via-ir -vv` (165/165 pass, including the full `IntelligenceTest` suite — the previously-documented setUp failure no longer reproduces), `sforge fmt --check`.

Merge via rebase-and-merge (do not squash).