### PR TITLE
3.7a: add direct unit tests for the four uncovered std-lib functions

### DIFF
--- a/contracts/test/CryptoUtils.t.sol
+++ b/contracts/test/CryptoUtils.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+
+import {CryptoUtils} from "seismic-std-lib/utils/precompiles/CryptoUtils.sol";
+
+/// @notice Exposes CryptoUtils internal functions for direct testing
+contract CryptoUtilsHarness {
+    function generateRandomNonce() external view returns (uint96) {
+        return CryptoUtils.generateRandomNonce();
+    }
+
+    function hkdfDeriveKey(bytes memory input) external view returns (uint256) {
+        return uint256(CryptoUtils.HKDFDeriveKey(input));
+    }
+}
+
+contract CryptoUtilsTest is Test {
+    address constant HKDF_PRECOMPILE = address(0x68);
+
+    CryptoUtilsHarness harness;
+
+    function setUp() public {
+        harness = new CryptoUtilsHarness();
+    }
+
+    function test_GenerateRandomNonceReturnsDistinctValues() public view {
+        uint96 first = harness.generateRandomNonce();
+        uint96 second = harness.generateRandomNonce();
+
+        assertNotEq(first, second);
+    }
+
+    function test_HKDFDeriveKeyReturnsNonzeroKey() public {
+        bytes memory input = abi.encodePacked("hkdf test input keying material");
+
+        // Skip (rather than fail) if the HKDF precompile is absent from the
+        // test EVM, so a harness environment gap doesn't read as a red test.
+        (bool available,) = HKDF_PRECOMPILE.staticcall(input);
+        vm.skip(!available, "HKDF precompile (0x68) unavailable in test EVM");
+
+        uint256 derived = harness.hkdfDeriveKey(input);
+        assertNotEq(derived, 0);
+    }
+}

--- a/contracts/test/Directory.t.sol
+++ b/contracts/test/Directory.t.sol
@@ -30,6 +30,39 @@ contract DirectoryTest is Test {
         assertEq(decryptResult, sampleMsg);
     }
 
+    function test_CheckHasKeyReturnsFalseForUnsetAddress() public {
+        address carol = makeAddr("carol");
+        assertFalse(directory.checkHasKey(carol));
+    }
+
+    function test_CheckHasKeyReturnsTrueAfterSetKey() public {
+        address carol = makeAddr("carol");
+        vm.prank(carol);
+        directory.setKey(suint256(0x123));
+
+        assertTrue(directory.checkHasKey(carol));
+    }
+
+    function test_PackEncryptedDataAppendsTwelveByteNonce() public view {
+        bytes memory ciphertext = hex"deadbeefcafe";
+        uint96 nonce = 0x0102030405060708090a0b0c;
+
+        bytes memory packed = directory.packEncryptedData(ciphertext, nonce);
+
+        assertEq(packed.length, ciphertext.length + 12);
+    }
+
+    function test_PackEncryptedDataRoundTripsThroughParse() public view {
+        bytes memory ciphertext = hex"00112233445566778899aabbccddeeff0011223344";
+        uint96 nonce = type(uint96).max - 7;
+
+        bytes memory packed = directory.packEncryptedData(ciphertext, nonce);
+        (bytes memory parsedCiphertext, uint96 parsedNonce) = directory.parseEncryptedData(packed);
+
+        assertEq(parsedCiphertext, ciphertext);
+        assertEq(parsedNonce, nonce);
+    }
+
     function testEncryptSequence() public {
         bytes memory encryptedDataBob = directory.encrypt(bob, sampleMsg);
         bytes memory encryptedDataAlice = directory.encrypt(alice, sampleMsg);


### PR DESCRIPTION
Remediates the test-coverage half of Zellic finding 3.7 (3.7a). Coverage-only — no production code changes.

Adds direct sforge unit tests for the four in-scope functions Zellic flagged as uncovered:

- `Directory.checkHasKey(address)` — false for an unset address; true after `setKey` with a nonzero key (`test/Directory.t.sol`)
- `Directory.packEncryptedData(bytes,uint96)` — output length is ciphertext length + 12; round-trips through `parseEncryptedData` to recover the exact ciphertext and nonce (`test/Directory.t.sol`)
- `CryptoUtils.generateRandomNonce()` — returns without reverting; successive calls are distinct (`test/CryptoUtils.t.sol`, via a `CryptoUtilsHarness` since the function is `internal`)
- `CryptoUtils.HKDFDeriveKey(bytes)` — returns a nonzero 32-byte key without reverting (`test/CryptoUtils.t.sol`)

Env note: the HKDF precompile (0x68) turned out to be available in the sforge test EVM, so the HKDF assertion runs for real; the test still probes availability and `vm.skip`s (rather than failing red) if a harness environment lacks the precompile.

Verified locally: `sforge build --via-ir --unsafe-via-ir`, `sforge test --via-ir --unsafe-via-ir -vv` (169/169 pass), `sforge fmt --check`.

The live-sreth integration suite (3.7b) is a separate follow-up task.