### PR TITLE
test: replay Summit deposit-request golden vectors

### DIFF
--- a/clients/py/src/seismic_web3/contract/shielded.py
+++ b/clients/py/src/seismic_web3/contract/shielded.py
@@ -195,8 +195,10 @@ class _TransparentWriteNamespace:
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
         private_key: PrivateKey | None = None,
+        encryption: EncryptionState | None = None,
     ) -> None:
         self._w3 = w3
+        self._encryption = encryption
         self._address = address
         self._abi = abi
         self._private_key = private_key
@@ -206,13 +208,18 @@ class _TransparentWriteNamespace:
 
         def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
-            if "gas" not in tx_params and self._private_key is not None:
+            if (
+                "gas" not in tx_params
+                and self._private_key is not None
+                and self._encryption is not None
+            ):
                 tx_params["gas"] = estimate_transparent_gas(
                     self._w3,
                     to=self._address,
                     data=data.to_0x_hex(),
                     value=value,
                     private_key=self._private_key,
+                    encryption=self._encryption,
                 )
             tx: dict[str, Any] = {
                 "to": self._address,
@@ -306,6 +313,7 @@ class _SmartWriteNamespace:
                         data=data.to_0x_hex(),
                         value=value,
                         private_key=self._private_key,
+                        encryption=self._encryption,
                     )
                 tx: dict[str, Any] = {
                     "to": self._address,
@@ -520,8 +528,10 @@ class _AsyncTransparentWriteNamespace:
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
         private_key: PrivateKey | None = None,
+        encryption: EncryptionState | None = None,
     ) -> None:
         self._w3 = w3
+        self._encryption = encryption
         self._address = address
         self._abi = abi
         self._private_key = private_key
@@ -531,13 +541,18 @@ class _AsyncTransparentWriteNamespace:
 
         async def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
-            if "gas" not in tx_params and self._private_key is not None:
+            if (
+                "gas" not in tx_params
+                and self._private_key is not None
+                and self._encryption is not None
+            ):
                 tx_params["gas"] = await async_estimate_transparent_gas(
                     self._w3,
                     to=self._address,
                     data=data.to_0x_hex(),
                     value=value,
                     private_key=self._private_key,
+                    encryption=self._encryption,
                 )
             tx: dict[str, Any] = {
                 "to": self._address,
@@ -631,6 +646,7 @@ class _AsyncSmartWriteNamespace:
                         data=data.to_0x_hex(),
                         value=value,
                         private_key=self._private_key,
+                        encryption=self._encryption,
                     )
                 tx: dict[str, Any] = {
                     "to": self._address,
@@ -779,6 +795,7 @@ class ShieldedContract:
             address,
             abi,
             private_key=private_key,
+            encryption=encryption,
         )
         self.tread = _TransparentReadNamespace(w3, address, abi)
         self.dwrite = _ShieldedDebugWriteNamespace(
@@ -871,6 +888,7 @@ class AsyncShieldedContract:
             address,
             abi,
             private_key=private_key,
+            encryption=encryption,
         )
         self.tread = _AsyncTransparentReadNamespace(w3, address, abi)
         self.dwrite = _AsyncShieldedDebugWriteNamespace(

--- a/clients/py/src/seismic_web3/module.py
+++ b/clients/py/src/seismic_web3/module.py
@@ -469,6 +469,7 @@ class SeismicNamespace(SeismicPublicNamespace):
             data=data.to_0x_hex(),
             value=value,
             private_key=self._private_key,
+            encryption=self.encryption,
         )
         return self._w3.eth.send_transaction(
             {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},
@@ -717,6 +718,7 @@ class AsyncSeismicNamespace(AsyncSeismicPublicNamespace):
             data=data.to_0x_hex(),
             value=value,
             private_key=self._private_key,
+            encryption=self.encryption,
         )
         return await self._w3.eth.send_transaction(
             {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -229,6 +229,12 @@ def estimate_transparent_gas(
         cast("ChecksumAddress", to),
         value,
         None,
+        # signed_read=True makes the provisional tx a non-broadcastable
+        # simulation: the consensus/pooled decoders reject signed reads as state
+        # transitions, so an intercepted estimate payload cannot be replayed via
+        # eth_sendRawTransaction. Gas is unchanged (flag never reaches EVM
+        # execution); the final transparent tx is signed separately.
+        signed_read=True,
     )
     metadata = build_metadata(w3, params)
     encrypted = encryption.encrypt(
@@ -264,6 +270,12 @@ async def async_estimate_transparent_gas(
         cast("ChecksumAddress", to),
         value,
         None,
+        # signed_read=True makes the provisional tx a non-broadcastable
+        # simulation: the consensus/pooled decoders reject signed reads as state
+        # transitions, so an intercepted estimate payload cannot be replayed via
+        # eth_sendRawTransaction. Gas is unchanged (flag never reaches EVM
+        # execution); the final transparent tx is signed separately.
+        signed_read=True,
     )
     metadata = await async_build_metadata(w3, params)
     encrypted = encryption.encrypt(
@@ -369,10 +381,27 @@ def _prepare_shielded_transaction(
     if gas is not None:
         resolved_gas = gas
     else:
+        # Non-broadcastable signed-read twin for the estimate: separate metadata
+        # with signed_read=True and a fresh encryption nonce (avoids AES-GCM
+        # nonce reuse vs the write). Signed reads are rejected by the
+        # consensus/pooled decoders, so an intercepted estimate payload cannot be
+        # replayed via eth_sendRawTransaction. The tx signed below still uses
+        # `metadata`/`encrypted_data` (signed_read=False), unchanged.
+        estimate_params = _build_metadata_params(
+            private_key, encryption, to, value, None, signed_read=True, eip712=eip712
+        )
+        estimate_metadata = build_metadata(w3, estimate_params)
+        estimate_encrypted = HexBytes(
+            encryption.encrypt(
+                data,
+                estimate_metadata.seismic_elements.encryption_nonce,
+                estimate_metadata,
+            )
+        )
         resolved_gas = estimate_shielded_gas(
             w3,
-            encrypted_data=encrypted_data,
-            metadata=metadata,
+            encrypted_data=estimate_encrypted,
+            metadata=estimate_metadata,
             gas_price=resolved_gas_price,
             private_key=private_key,
         )
@@ -418,10 +447,27 @@ async def _async_prepare_shielded_transaction(
     if gas is not None:
         resolved_gas = gas
     else:
+        # Non-broadcastable signed-read twin for the estimate: separate metadata
+        # with signed_read=True and a fresh encryption nonce (avoids AES-GCM
+        # nonce reuse vs the write). Signed reads are rejected by the
+        # consensus/pooled decoders, so an intercepted estimate payload cannot be
+        # replayed via eth_sendRawTransaction. The tx signed below still uses
+        # `metadata`/`encrypted_data` (signed_read=False), unchanged.
+        estimate_params = _build_metadata_params(
+            private_key, encryption, to, value, None, signed_read=True, eip712=eip712
+        )
+        estimate_metadata = await async_build_metadata(w3, estimate_params)
+        estimate_encrypted = HexBytes(
+            encryption.encrypt(
+                data,
+                estimate_metadata.seismic_elements.encryption_nonce,
+                estimate_metadata,
+            )
+        )
         resolved_gas = await async_estimate_shielded_gas(
             w3,
-            encrypted_data=encrypted_data,
-            metadata=metadata,
+            encrypted_data=estimate_encrypted,
+            metadata=estimate_metadata,
             gas_price=resolved_gas_price,
             private_key=private_key,
         )

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from eth_account import Account as EthAccount
 from eth_keys.main import KeyAPI as eth_keys
 from hexbytes import HexBytes
 from web3.types import RPCEndpoint
@@ -209,31 +208,41 @@ def estimate_transparent_gas(
     data: str,
     value: int,
     private_key: PrivateKey,
+    encryption: EncryptionState,
 ) -> int:
-    """Estimate gas for a transparent tx by signing it first (sync).
+    """Estimate gas for a transparent tx via a provisional shielded tx (sync).
 
-    Signs a temporary standard transaction using the block gas limit as
-    a placeholder and sends the signed bytes to ``eth_estimateGas``.
-    This prevents the node from zeroing ``msg.value`` during simulation.
+    The node's raw-bytes ``eth_estimateGas`` path only accepts Seismic
+    transactions (a signed read must carry ``seismic_elements``), so a
+    signed plain transaction is rejected there.  Unsigned estimation is
+    no substitute: the node strips ``from`` and ``value`` from unsigned
+    requests, which breaks payable calls and misestimates
+    sender-dependent gas paths.  Instead, estimate a provisional
+    ``TxSeismic`` carrying the same sender, ``to``, ``value``, and
+    (encrypted) calldata: after decryption the node executes the same
+    call with authenticated caller context, and the ciphertext's
+    slightly higher intrinsic calldata cost can only overestimate.
     """
-    acct = EthAccount.from_key(private_key)
-    block_gas_limit = w3.eth.get_block("latest")["gasLimit"]
-    tx = {
-        "to": to,
-        "data": data,
-        "value": value,
-        "gas": block_gas_limit,
-        "gasPrice": w3.eth.gas_price,
-        "nonce": w3.eth.get_transaction_count(acct.address),
-        "chainId": w3.eth.chain_id,
-    }
-    signed = acct.sign_transaction(tx)
-
-    response = w3.provider.make_request(
-        RPCEndpoint("eth_estimateGas"),
-        [signed.raw_transaction.to_0x_hex()],
+    params = _build_metadata_params(
+        private_key,
+        encryption,
+        cast("ChecksumAddress", to),
+        value,
+        None,
     )
-    return int(_check_rpc_response(response), 16)
+    metadata = build_metadata(w3, params)
+    encrypted = encryption.encrypt(
+        HexBytes(data),
+        metadata.seismic_elements.encryption_nonce,
+        metadata,
+    )
+    return estimate_shielded_gas(
+        w3,
+        encrypted_data=HexBytes(encrypted),
+        metadata=metadata,
+        gas_price=w3.eth.gas_price,
+        private_key=private_key,
+    )
 
 
 async def async_estimate_transparent_gas(
@@ -243,29 +252,32 @@ async def async_estimate_transparent_gas(
     data: str,
     value: int,
     private_key: PrivateKey,
+    encryption: EncryptionState,
 ) -> int:
-    """Estimate gas for a transparent tx by signing it first (async).
+    """Estimate gas for a transparent tx via a provisional shielded tx (async).
 
     Async variant of :func:`estimate_transparent_gas`.
     """
-    acct = EthAccount.from_key(private_key)
-    block_gas_limit = (await w3.eth.get_block("latest"))["gasLimit"]
-    tx = {
-        "to": to,
-        "data": data,
-        "value": value,
-        "gas": block_gas_limit,
-        "gasPrice": await w3.eth.gas_price,
-        "nonce": await w3.eth.get_transaction_count(acct.address),
-        "chainId": await w3.eth.chain_id,
-    }
-    signed = acct.sign_transaction(tx)
-
-    response = await w3.provider.make_request(
-        RPCEndpoint("eth_estimateGas"),
-        [signed.raw_transaction.to_0x_hex()],
+    params = _build_metadata_params(
+        private_key,
+        encryption,
+        cast("ChecksumAddress", to),
+        value,
+        None,
     )
-    return int(_check_rpc_response(response), 16)
+    metadata = await async_build_metadata(w3, params)
+    encrypted = encryption.encrypt(
+        HexBytes(data),
+        metadata.seismic_elements.encryption_nonce,
+        metadata,
+    )
+    return await async_estimate_shielded_gas(
+        w3,
+        encrypted_data=HexBytes(encrypted),
+        metadata=metadata,
+        gas_price=await w3.eth.gas_price,
+        private_key=private_key,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/clients/py/tests/fixtures/deposit_requests.json
+++ b/clients/py/tests/fixtures/deposit_requests.json
@@ -1,0 +1,49 @@
+{
+  "description": "Deposit-request golden vectors: 288-byte EL wire format with valid Ed25519 + BLS signatures over as_message(deposit_signature_domain(genesis_hash, namespace)). Consumed by summit-types tests and by the Seismic client SDK tests (seismic monorepo, clients/). Regenerate with: cargo test -p summit-types regenerate_deposit_request_fixtures -- --ignored",
+  "genesis_hash": "0x683713729fcb72be6f3d8b88c8cda3e10569d73b9640d3bf6f5184d94bd97616",
+  "namespace": "_SUMMIT",
+  "vectors": [
+    {
+      "name": "new_validator_32eth",
+      "comment": "Fresh validator depositing exactly the minimum stake; activates after the warm-up.",
+      "node_private_key": "0x747da9456ae7632794bcd3292ed3ec8d370ad63f76e6daf97da1896ed6249f9a",
+      "bls_private_key": "0x5dbaea2b49f0dc7fcb2e5ac753fa489e6f25f200226dbe34b0aed6cbc3503001",
+      "node_pubkey": "0xae3a9bc6eb721b7b8a34d23aa0d5b1623e89bc6f092815ea13b92f79a39c7d38",
+      "consensus_pubkey": "0xa14001719d5b45c5552452779faf655b380f821fb0949de004dd4745383480ffa3a7b8e0a1ff70605e886af77411976e",
+      "withdrawal_credentials": "0x010000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "amount_gwei": 32000000000,
+      "node_signature": "0x91a882803611856e5f8a682df8d4a5b4eec07ce6c0128716e88b16d5c1b263612726515a3ea3b867967bf4ac60e52e3a694d94b4b7f7847cd2f3ab20aac4a605",
+      "consensus_signature": "0x931ac77b245ba8f8d43ec1e6b681166c3dd41772626527c5c0076f3c893248850f83e21c1a7bfa44d02345e6ee11a5f6000ba262f55b9e6ef968144d7d7cdd43639c18c7df1ae1cfcdb0ed2b3872c8c4e237cfcbb1fba35ce5aa220a2d430a30",
+      "index": 0,
+      "expected_request": "0xae3a9bc6eb721b7b8a34d23aa0d5b1623e89bc6f092815ea13b92f79a39c7d38a14001719d5b45c5552452779faf655b380f821fb0949de004dd4745383480ffa3a7b8e0a1ff70605e886af77411976e010000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa004059730700000091a882803611856e5f8a682df8d4a5b4eec07ce6c0128716e88b16d5c1b263612726515a3ea3b867967bf4ac60e52e3a694d94b4b7f7847cd2f3ab20aac4a605931ac77b245ba8f8d43ec1e6b681166c3dd41772626527c5c0076f3c893248850f83e21c1a7bfa44d02345e6ee11a5f6000ba262f55b9e6ef968144d7d7cdd43639c18c7df1ae1cfcdb0ed2b3872c8c4e237cfcbb1fba35ce5aa220a2d430a300000000000000000"
+    },
+    {
+      "name": "new_validator_1eth_below_min",
+      "comment": "Fresh validator depositing the contract minimum (1 ETH); stays Inactive below the minimum stake.",
+      "node_private_key": "0x29090ac8555c09b8fe99a886f7ed6ae1c20c6cce107257cf9888a501daf9fb75",
+      "bls_private_key": "0x258dc58544dbc05ebe17de3c42a5c2bd844a20e44e81d612afcd7206f0c779cf",
+      "node_pubkey": "0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f",
+      "consensus_pubkey": "0x84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a",
+      "withdrawal_credentials": "0x010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "amount_gwei": 1000000000,
+      "node_signature": "0xde49e00a559a48a20ea49a1e80f085b9fa9932e63df1d983ef9e3bb6e4b957d2f081989668556bcc5d1fc9d2c0774bb25c229030b66fb452a6f14a8f6742c202",
+      "consensus_signature": "0x880caf63f7b0f0e5194928a1bc5dc585f8f9dc7e268a2816e3e7b3c6ebbabdc6821e69334124546977667fe09d201c270555f7c1151c108f39b358534246f789d02ed3e27371b6c1b8bfc3d19c96b78925bd1cd645ec462d279584e8c8249cdb",
+      "index": 1,
+      "expected_request": "0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00ca9a3b00000000de49e00a559a48a20ea49a1e80f085b9fa9932e63df1d983ef9e3bb6e4b957d2f081989668556bcc5d1fc9d2c0774bb25c229030b66fb452a6f14a8f6742c202880caf63f7b0f0e5194928a1bc5dc585f8f9dc7e268a2816e3e7b3c6ebbabdc6821e69334124546977667fe09d201c270555f7c1151c108f39b358534246f789d02ed3e27371b6c1b8bfc3d19c96b78925bd1cd645ec462d279584e8c8249cdb0100000000000000"
+    },
+    {
+      "name": "top_up_31eth_reaches_min",
+      "comment": "Top-up for the 1 ETH validator with the same keys; lifts the balance to the minimum stake.",
+      "node_private_key": "0x29090ac8555c09b8fe99a886f7ed6ae1c20c6cce107257cf9888a501daf9fb75",
+      "bls_private_key": "0x258dc58544dbc05ebe17de3c42a5c2bd844a20e44e81d612afcd7206f0c779cf",
+      "node_pubkey": "0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f",
+      "consensus_pubkey": "0x84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a",
+      "withdrawal_credentials": "0x010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "amount_gwei": 31000000000,
+      "node_signature": "0xb19a2f8797485d81f1e8c8e74e87194a1b50625e974533848220b4b780af93784db94937243f358730a1bf35ce854210f3642928dc3ab5f7875e33c94a839d04",
+      "consensus_signature": "0xa759c78a7bd9e358d79120f26ff4a4a3012085f91025f42fe812cae73f71b85427a850f3ad83fbff145500b87a5e038b0dbd595d5148b5adf26bc35f03c3ed1462a8964571d4adb62641b7ed39994838124a4aaa4a5d74d944917d9012f57b89",
+      "index": 2,
+      "expected_request": "0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0076be3707000000b19a2f8797485d81f1e8c8e74e87194a1b50625e974533848220b4b780af93784db94937243f358730a1bf35ce854210f3642928dc3ab5f7875e33c94a839d04a759c78a7bd9e358d79120f26ff4a4a3012085f91025f42fe812cae73f71b85427a850f3ad83fbff145500b87a5e038b0dbd595d5148b5adf26bc35f03c3ed1462a8964571d4adb62641b7ed39994838124a4aaa4a5d74d944917d9012f57b890200000000000000"
+    }
+  ]
+}

--- a/clients/py/tests/integration/test_deposit_contract.py
+++ b/clients/py/tests/integration/test_deposit_contract.py
@@ -1,8 +1,13 @@
 """Integration tests for the DepositContract (Eth2 validator staking)."""
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 from hexbytes import HexBytes
 from web3 import Web3
+from web3.contract import Contract
 
 from seismic_web3.abis.deposit_contract import compute_deposit_data_root
 from seismic_web3.contract.shielded import ShieldedContract
@@ -10,6 +15,10 @@ from tests.integration.contracts import (
     DEPOSIT_CONTRACT_ABI,
     DEPOSIT_CONTRACT_BYTECODE,
     deploy_contract,
+)
+
+DEPOSIT_VECTORS_PATH = (
+    Path(__file__).parent.parent / "fixtures" / "deposit_requests.json"
 )
 
 # ---------------------------------------------------------------------------
@@ -318,3 +327,96 @@ class TestDepositActions:
             address=deposit_address,
         )
         assert root_before != root_after
+
+
+# ---------------------------------------------------------------------------
+# Tests — Summit golden vectors
+# ---------------------------------------------------------------------------
+
+
+def _unhex(value: str) -> bytes:
+    return bytes.fromhex(value.removeprefix("0x"))
+
+
+class TestDepositRequestVectors:
+    """Replay Summit's golden deposit-request vectors through the client.
+
+    The vectors (``tests/fixtures/deposit_requests.json``, canonical copy in
+    the summit repo at ``types/fixtures/deposit_requests.json``) carry valid
+    Ed25519 + BLS signatures and the exact 288-byte execution-layer request
+    that Summit parses and validates. Submitting each vector and reassembling
+    the emitted ``DepositEvent`` must reproduce ``expected_request`` byte for
+    byte, proving the client transports deposit data unmangled into the
+    format the consensus layer accepts.
+
+    The vectors are submitted in file order onto a fresh contract so the
+    contract assigns the deposit indices the fixtures were frozen with.
+    """
+
+    def _submit_and_check_event(
+        self,
+        w3: Web3,
+        plain_contract: Contract,
+        deposit_address: str,
+        vector: dict[str, Any],
+    ) -> None:
+        deposit_data_root = compute_deposit_data_root(
+            node_pubkey=_unhex(vector["node_pubkey"]),
+            consensus_pubkey=_unhex(vector["consensus_pubkey"]),
+            withdrawal_credentials=_unhex(vector["withdrawal_credentials"]),
+            node_signature=_unhex(vector["node_signature"]),
+            consensus_signature=_unhex(vector["consensus_signature"]),
+            amount_gwei=vector["amount_gwei"],
+        )
+        tx_hash = w3.seismic.deposit(
+            node_pubkey=_unhex(vector["node_pubkey"]),
+            consensus_pubkey=_unhex(vector["consensus_pubkey"]),
+            withdrawal_credentials=_unhex(vector["withdrawal_credentials"]),
+            node_signature=_unhex(vector["node_signature"]),
+            consensus_signature=_unhex(vector["consensus_signature"]),
+            deposit_data_root=deposit_data_root,
+            value=vector["amount_gwei"] * 10**9,
+            address=deposit_address,
+        )
+        receipt = w3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+        assert receipt["status"] == 1, f"{vector['name']}: deposit failed"
+
+        events = plain_contract.events.DepositEvent().process_receipt(receipt)
+        assert len(events) == 1, f"{vector['name']}: expected one DepositEvent"
+        args = events[0]["args"]
+
+        emitted_request = b"".join(
+            [
+                args["node_pubkey"],
+                args["consensus_pubkey"],
+                args["withdrawal_credentials"],
+                args["amount"],
+                args["node_signature"],
+                args["consensus_signature"],
+                args["index"],
+            ]
+        )
+        assert emitted_request == _unhex(vector["expected_request"]), (
+            f"{vector['name']}: emitted DepositEvent does not reassemble to "
+            "Summit's expected execution-layer request"
+        )
+        assert int.from_bytes(args["index"], "little") == vector["index"]
+
+    def test_deposit_events_match_summit_vectors(
+        self,
+        w3: Web3,
+        plain_w3: Web3,
+        deposit_address: str,
+    ) -> None:
+        vectors = json.loads(DEPOSIT_VECTORS_PATH.read_text())["vectors"]
+        plain_contract = plain_w3.eth.contract(
+            address=Web3.to_checksum_address(deposit_address),
+            abi=DEPOSIT_CONTRACT_ABI,
+        )
+        for vector in vectors:
+            self._submit_and_check_event(
+                w3,
+                plain_contract,
+                deposit_address,
+                vector,
+            )

--- a/clients/py/tests/test_send.py
+++ b/clients/py/tests/test_send.py
@@ -1,13 +1,26 @@
-"""Tests for seismic_web3.transaction.send — address derivation."""
+"""Tests for seismic_web3.transaction.send — address derivation, estimation."""
 
-from seismic_web3._types import PrivateKey
-from seismic_web3.transaction.send import _address_from_key
+from unittest.mock import MagicMock
+
+from seismic_web3._types import CompressedPublicKey, PrivateKey
+from seismic_web3.client import get_encryption
+from seismic_web3.transaction.send import (
+    _address_from_key,
+    estimate_transparent_gas,
+)
 
 # Anvil account #0
 ANVIL_PK = PrivateKey(
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 )
 ANVIL_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+_NETWORK_PK = CompressedPublicKey(
+    "0x028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0"
+)
+_CLIENT_SK = PrivateKey(
+    "0xa30363336e1bb949185292a2a302de86e447d98f3a43d823c8c234d9e3e5ad77"
+)
 
 
 class TestAddressFromKey:
@@ -21,3 +34,46 @@ class TestAddressFromKey:
         address = _address_from_key(ANVIL_PK)
         # Checksummed addresses have uppercase letters
         assert any(c.isupper() for c in address[2:])
+
+
+class TestEstimateTransparentGas:
+    """Transparent gas estimation must go through a Seismic (0x4a) tx.
+
+    The node's raw-bytes ``eth_estimateGas`` path rejects plain signed
+    transactions (a signed read must carry ``seismic_elements``), and
+    unsigned estimation strips ``from`` and ``value``, which breaks
+    payable and sender-dependent calls.  The only request form that
+    preserves authenticated caller context is a provisional shielded
+    transaction.
+    """
+
+    def test_submits_seismic_tx_to_estimate_gas(self):
+        w3 = MagicMock()
+        w3.eth.chain_id = 31337
+        w3.eth.get_transaction_count.return_value = 7
+        w3.eth.get_block.return_value = {
+            "hash": b"\x11" * 32,
+            "number": 100,
+            "gasLimit": 30_000_000,
+        }
+        w3.eth.gas_price = 10**9
+        w3.provider.make_request.return_value = {"result": "0x5208"}
+
+        encryption = get_encryption(_NETWORK_PK, _CLIENT_SK)
+        gas = estimate_transparent_gas(
+            w3,
+            to="0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            data="0xd09de08a",
+            value=32 * 10**18,
+            private_key=ANVIL_PK,
+            encryption=encryption,
+        )
+
+        assert gas == 0x5208
+        method, params = w3.provider.make_request.call_args[0]
+        assert method == "eth_estimateGas"
+        assert params[0].startswith("0x4a"), (
+            "transparent estimation must submit a provisional Seismic "
+            "(0x4a) transaction: the node rejects plain signed txs on the "
+            "raw-bytes path and strips from/value from unsigned requests"
+        )

--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "seismic-client",

--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -42,7 +42,7 @@
     },
     "packages/seismic-encrypt": {
       "name": "seismic-encrypt",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "dependencies": {
         "@noble/ciphers": "^1.2.0",
         "@noble/curves": "^1.8.0",
@@ -1378,11 +1378,11 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.0.2", "", {}, "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA=="],
 
-    "seismic-bot/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "seismic-bot/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "seismic-spammer/seismic-viem": ["seismic-viem@1.0.15", "", { "dependencies": { "@noble/ciphers": "^1.2.0", "@noble/curves": "^1.8.0", "@noble/hashes": "^1.7.0", "viem": "^2.21.50" } }, "sha512-xw6lZuZ0l1SeoAFfaqpIY2Hd09WtsjqKWlqtDqWZ3ZNStOCYEFR6m8W7MQYnc1fKpSV93JJNsV9m0GOoclPYXQ=="],
 
-    "seismic-viem-tests/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "seismic-viem-tests/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "socket.io-client/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
 
@@ -1438,9 +1438,9 @@
 
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
-    "seismic-bot/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "seismic-bot/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "seismic-viem-tests/@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "seismic-viem-tests/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositContract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositContract.ts
@@ -4,11 +4,12 @@ import {
   createShieldedPublicClient,
   createShieldedWalletClient,
 } from 'seismic-viem'
-import { Account, Chain, parseEther } from 'viem'
-import { http } from 'viem'
+import { Account, Chain, concatHex, parseEther } from 'viem'
+import { http, parseEventLogs } from 'viem'
 
 import { depositContractAbi } from '@sviem-tests/tests/contract/depositContractAbi.ts'
 import { depositContractBytecode } from '@sviem-tests/tests/contract/depositContractBytecode.ts'
+import { summitDepositRequestFixture } from '@sviem-tests/tests/contract/depositRequestVectors.ts'
 
 export type ContractTestArgs = {
   chain: Chain
@@ -144,6 +145,91 @@ function computeDepositDataRoot(
     .digest()
 
   return `0x${depositDataRoot.toString('hex')}` as `0x${string}`
+}
+
+/**
+ * Replay Summit's golden deposit-request vectors through the client.
+ *
+ * The vectors (vendored in depositRequestVectors.ts; canonical copy in the
+ * summit repo at types/fixtures/deposit_requests.json) carry valid Ed25519 +
+ * BLS signatures and the exact 288-byte execution-layer request that Summit
+ * parses and validates. Submitting each vector and reassembling the emitted
+ * DepositEvent must reproduce expected_request byte for byte, proving the
+ * client transports deposit data unmangled into the format the consensus
+ * layer accepts.
+ *
+ * The vectors are submitted in file order onto a fresh contract so the
+ * contract assigns the deposit indices the fixtures were frozen with.
+ */
+export const testDepositEventsMatchSummitVectors = async ({
+  chain,
+  url,
+  account,
+}: ContractTestArgs) => {
+  const publicClient = createShieldedPublicClient({
+    chain,
+    transport: http(url),
+  })
+  const walletClient = await createShieldedWalletClient({
+    chain,
+    transport: http(url),
+    account,
+  })
+
+  const bytecode: `0x${string}` = `0x${depositContractBytecode.object.replace(/^0x/, '')}`
+  const deployTx = await walletClient.deployContract({
+    abi: depositContractAbi,
+    bytecode,
+    chain: walletClient.chain,
+  })
+  const deployReceipt = await publicClient.waitForTransactionReceipt({
+    hash: deployTx,
+  })
+  const address = deployReceipt.contractAddress!
+
+  for (const vector of summitDepositRequestFixture.vectors) {
+    const valueWei = BigInt(vector.amount_gwei) * 10n ** 9n
+    const depositDataRoot = computeDepositDataRoot(
+      vector.node_pubkey,
+      vector.consensus_pubkey,
+      vector.withdrawal_credentials,
+      vector.node_signature,
+      vector.consensus_signature,
+      valueWei
+    )
+    const depositTx = await walletClient.deposit({
+      address,
+      nodePubkey: vector.node_pubkey,
+      consensusPubkey: vector.consensus_pubkey,
+      withdrawalCredentials: vector.withdrawal_credentials,
+      nodeSignature: vector.node_signature,
+      consensusSignature: vector.consensus_signature,
+      depositDataRoot,
+      value: valueWei,
+    })
+    const receipt = await publicClient.waitForTransactionReceipt({
+      hash: depositTx,
+    })
+    expect(receipt.status).toBe('success')
+
+    const events = parseEventLogs({
+      abi: depositContractAbi,
+      eventName: 'DepositEvent',
+      logs: receipt.logs,
+    })
+    expect(events).toHaveLength(1)
+    const args = events[0].args
+    const emittedRequest = concatHex([
+      args.node_pubkey,
+      args.consensus_pubkey,
+      args.withdrawal_credentials,
+      args.amount,
+      args.node_signature,
+      args.consensus_signature,
+      args.index,
+    ])
+    expect(emittedRequest).toBe(vector.expected_request)
+  }
 }
 
 export const testDepositContract = async ({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositRequestVectors.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositRequestVectors.ts
@@ -1,0 +1,87 @@
+// Vendored copy of Summit's deposit-request golden vectors
+// (summit repo: types/fixtures/deposit_requests.json). Do not edit by hand:
+// regenerate in summit with
+//   cargo test -p summit-types regenerate_deposit_request_fixtures -- --ignored
+// and copy the result here (and to seismic clients/py/tests/fixtures/).
+// Each expected_request is the 288-byte EL wire format Summit parses via
+// DepositRequest::try_from_eth_bytes; signatures are valid for the recorded
+// (genesis_hash, namespace) signature domain.
+
+export const summitDepositRequestFixture = {
+  description:
+    'Deposit-request golden vectors: 288-byte EL wire format with valid Ed25519 + BLS signatures over as_message(deposit_signature_domain(genesis_hash, namespace)). Consumed by summit-types tests and by the Seismic client SDK tests (seismic monorepo, clients/). Regenerate with: cargo test -p summit-types regenerate_deposit_request_fixtures -- --ignored',
+  genesis_hash:
+    '0x683713729fcb72be6f3d8b88c8cda3e10569d73b9640d3bf6f5184d94bd97616',
+  namespace: '_SUMMIT',
+  vectors: [
+    {
+      name: 'new_validator_32eth',
+      comment:
+        'Fresh validator depositing exactly the minimum stake; activates after the warm-up.',
+      node_private_key:
+        '0x747da9456ae7632794bcd3292ed3ec8d370ad63f76e6daf97da1896ed6249f9a',
+      bls_private_key:
+        '0x5dbaea2b49f0dc7fcb2e5ac753fa489e6f25f200226dbe34b0aed6cbc3503001',
+      node_pubkey:
+        '0xae3a9bc6eb721b7b8a34d23aa0d5b1623e89bc6f092815ea13b92f79a39c7d38',
+      consensus_pubkey:
+        '0xa14001719d5b45c5552452779faf655b380f821fb0949de004dd4745383480ffa3a7b8e0a1ff70605e886af77411976e',
+      withdrawal_credentials:
+        '0x010000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      amount_gwei: 32000000000,
+      node_signature:
+        '0x91a882803611856e5f8a682df8d4a5b4eec07ce6c0128716e88b16d5c1b263612726515a3ea3b867967bf4ac60e52e3a694d94b4b7f7847cd2f3ab20aac4a605',
+      consensus_signature:
+        '0x931ac77b245ba8f8d43ec1e6b681166c3dd41772626527c5c0076f3c893248850f83e21c1a7bfa44d02345e6ee11a5f6000ba262f55b9e6ef968144d7d7cdd43639c18c7df1ae1cfcdb0ed2b3872c8c4e237cfcbb1fba35ce5aa220a2d430a30',
+      index: 0,
+      expected_request:
+        '0xae3a9bc6eb721b7b8a34d23aa0d5b1623e89bc6f092815ea13b92f79a39c7d38a14001719d5b45c5552452779faf655b380f821fb0949de004dd4745383480ffa3a7b8e0a1ff70605e886af77411976e010000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa004059730700000091a882803611856e5f8a682df8d4a5b4eec07ce6c0128716e88b16d5c1b263612726515a3ea3b867967bf4ac60e52e3a694d94b4b7f7847cd2f3ab20aac4a605931ac77b245ba8f8d43ec1e6b681166c3dd41772626527c5c0076f3c893248850f83e21c1a7bfa44d02345e6ee11a5f6000ba262f55b9e6ef968144d7d7cdd43639c18c7df1ae1cfcdb0ed2b3872c8c4e237cfcbb1fba35ce5aa220a2d430a300000000000000000',
+    },
+    {
+      name: 'new_validator_1eth_below_min',
+      comment:
+        'Fresh validator depositing the contract minimum (1 ETH); stays Inactive below the minimum stake.',
+      node_private_key:
+        '0x29090ac8555c09b8fe99a886f7ed6ae1c20c6cce107257cf9888a501daf9fb75',
+      bls_private_key:
+        '0x258dc58544dbc05ebe17de3c42a5c2bd844a20e44e81d612afcd7206f0c779cf',
+      node_pubkey:
+        '0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f',
+      consensus_pubkey:
+        '0x84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a',
+      withdrawal_credentials:
+        '0x010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      amount_gwei: 1000000000,
+      node_signature:
+        '0xde49e00a559a48a20ea49a1e80f085b9fa9932e63df1d983ef9e3bb6e4b957d2f081989668556bcc5d1fc9d2c0774bb25c229030b66fb452a6f14a8f6742c202',
+      consensus_signature:
+        '0x880caf63f7b0f0e5194928a1bc5dc585f8f9dc7e268a2816e3e7b3c6ebbabdc6821e69334124546977667fe09d201c270555f7c1151c108f39b358534246f789d02ed3e27371b6c1b8bfc3d19c96b78925bd1cd645ec462d279584e8c8249cdb',
+      index: 1,
+      expected_request:
+        '0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00ca9a3b00000000de49e00a559a48a20ea49a1e80f085b9fa9932e63df1d983ef9e3bb6e4b957d2f081989668556bcc5d1fc9d2c0774bb25c229030b66fb452a6f14a8f6742c202880caf63f7b0f0e5194928a1bc5dc585f8f9dc7e268a2816e3e7b3c6ebbabdc6821e69334124546977667fe09d201c270555f7c1151c108f39b358534246f789d02ed3e27371b6c1b8bfc3d19c96b78925bd1cd645ec462d279584e8c8249cdb0100000000000000',
+    },
+    {
+      name: 'top_up_31eth_reaches_min',
+      comment:
+        'Top-up for the 1 ETH validator with the same keys; lifts the balance to the minimum stake.',
+      node_private_key:
+        '0x29090ac8555c09b8fe99a886f7ed6ae1c20c6cce107257cf9888a501daf9fb75',
+      bls_private_key:
+        '0x258dc58544dbc05ebe17de3c42a5c2bd844a20e44e81d612afcd7206f0c779cf',
+      node_pubkey:
+        '0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f',
+      consensus_pubkey:
+        '0x84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a',
+      withdrawal_credentials:
+        '0x010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      amount_gwei: 31000000000,
+      node_signature:
+        '0xb19a2f8797485d81f1e8c8e74e87194a1b50625e974533848220b4b780af93784db94937243f358730a1bf35ce854210f3642928dc3ab5f7875e33c94a839d04',
+      consensus_signature:
+        '0xa759c78a7bd9e358d79120f26ff4a4a3012085f91025f42fe812cae73f71b85427a850f3ad83fbff145500b87a5e038b0dbd595d5148b5adf26bc35f03c3ed1462a8964571d4adb62641b7ed39994838124a4aaa4a5d74d944917d9012f57b89',
+      index: 2,
+      expected_request:
+        '0xf4f2b48f107be2146fa8545ad8dd3dac832d684a7df72038df4d3dda1d9b703f84d0508a1d844407ca3408b69c6d45051e51e4fd80ee359eb577bc265c35754f13fb5fa1c57d82a1294bfde24a05d45a010000000000000000000000bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0076be3707000000b19a2f8797485d81f1e8c8e74e87194a1b50625e974533848220b4b780af93784db94937243f358730a1bf35ce854210f3642928dc3ab5f7875e33c94a839d04a759c78a7bd9e358d79120f26ff4a4a3012085f91025f42fe812cae73f71b85427a850f3ad83fbff145500b87a5e038b0dbd595d5148b5adf26bc35f03c3ed1462a8964571d4adb62641b7ed39994838124a4aaa4a5d74d944917d9012f57b890200000000000000',
+    },
+  ],
+} as const

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -169,13 +169,37 @@ export async function sendShieldedTransaction<
       // When gas is not provided, sign a temporary tx and send it to
       // eth_estimateGas so the node can authenticate the sender.
       // This prevents caller-spoofing against msg.sender-gated state.
+      //
+      // Estimate with a non-broadcastable signed-read twin: a separate
+      // signedRead=true metadata (with a fresh encryptionNonce to avoid
+      // AES-GCM nonce reuse against the write) re-encrypts the calldata for
+      // the estimate only. The consensus/pooled decoders reject signed reads
+      // as state transitions, so an intercepted estimate payload cannot be
+      // replayed via eth_sendRawTransaction. The final tx below is still built
+      // from `metadata`/`encryptedCalldata` (signedRead=false), unchanged.
       const resolvedGas =
         gas ??
-        (await estimateShieldedGas(client, {
-          encryptedData: encryptedCalldata,
-          metadata,
-          gasPrice: resolvedGasPrice,
-        }))
+        (await (async () => {
+          const estimateMetadata = await buildTxSeismicMetadata(client, {
+            account: account_,
+            nonce,
+            to: to!,
+            value,
+            blocksWindow,
+            signedRead: true,
+            recentBlockHash,
+            expiresAtBlock,
+          })
+          const estimateEncryptedCalldata = await client.encrypt(
+            plaintextCalldata,
+            estimateMetadata
+          )
+          return estimateShieldedGas(client, {
+            encryptedData: estimateEncryptedCalldata,
+            metadata: estimateMetadata,
+            gasPrice: resolvedGasPrice,
+          })
+        })())
 
       // Fill remaining fee fields via prepareTransactionRequest.
       // Gas is already resolved so viem won't call eth_estimateGas.

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -261,7 +261,7 @@ export async function sendShieldedTransaction<
  * Signs a temporary shielded transaction and sends it to `eth_estimateGas`
  * so the node can authenticate the sender during simulation.
  */
-async function estimateShieldedGas<
+export async function estimateShieldedGas<
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account,

--- a/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
@@ -124,12 +124,18 @@ export async function sendTransparentTransaction<
     const gasEstimate =
       gas ??
       (await (async () => {
+        // signedRead: true makes the provisional tx a non-broadcastable
+        // simulation: the consensus/pooled decoders reject signed reads as
+        // state transitions, so an intercepted estimate payload cannot be
+        // replayed via eth_sendRawTransaction. The gas result is unchanged
+        // (the flag never reaches EVM execution); the final transparent tx
+        // below is a separate standard transaction.
         const metadata = await buildTxSeismicMetadata(client, {
           account,
           nonce: request.nonce,
           to: to!,
           value,
-          signedRead: false,
+          signedRead: true,
         })
         const encryptedData = await client.encrypt(data, metadata)
         const gasPrice_ = (request.gasPrice ??

--- a/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
@@ -16,16 +16,17 @@ import { assertRequest, getAction, getTransactionError } from 'viem/utils'
 
 import { ShieldedWalletClient } from '@sviem/client.ts'
 import { AccountNotFoundError } from '@sviem/error/account.ts'
-
-const DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT = 30_000_000n
+import { buildTxSeismicMetadata } from '@sviem/tx/metadata.ts'
+import { estimateShieldedGas } from '@sviem/tx/sendShielded.ts'
 
 /**
  * Executes the transparent transaction path for Seismic wallet clients.
  *
  * This is still an Ethereum-style send, but Seismic needs authenticated gas
- * estimation for some transactions. When the account is `local`, the client can
- * sign a provisional raw transaction and send those bytes to `eth_estimateGas`
- * so the node simulates execution with the real caller context.
+ * estimation for some transactions. When the account is `local`, the client
+ * estimates gas via a provisional Seismic (0x4a) transaction carrying the
+ * same sender, to, value, and (encrypted) calldata, so the node simulates
+ * execution with the real caller context.
  *
  * For `json-rpc` accounts, the SDK does not have the signing key locally, so
  * this falls back to viem's standard `sendTransaction` flow and its unsigned
@@ -109,30 +110,37 @@ export async function sendTransparentTransaction<
     } as any)
 
     const serializer = chain?.serializers?.transaction
+
+    // Estimate gas via a provisional Seismic (0x4a) transaction carrying the
+    // same sender, to, value, and calldata (encrypted), so the node simulates
+    // with authenticated caller context. The node's raw-bytes estimate path
+    // only accepts Seismic envelopes (signed reads must carry
+    // seismic_elements), so a signed *plain* tx is rejected there; unsigned
+    // estimation is no substitute because the node strips `from` and `value`
+    // from unsigned requests, which breaks payable and sender-dependent
+    // calls. Execution after decryption matches the transparent tx; the
+    // ciphertext's slightly higher intrinsic calldata cost can only
+    // overestimate, which is the safe direction.
     const gasEstimate =
       gas ??
-      BigInt(
-        await client.request(
-          {
-            // Estimate gas from a signed raw transaction so the node can
-            // recover the real sender and simulate execution with authenticated
-            // caller context. We use a large temporary gas limit here only for
-            // the estimation request; the final tx is re-signed below with the
-            // actual estimated gas.
-            method: 'eth_estimateGas',
-            params: [
-              await account.signTransaction(
-                {
-                  ...request,
-                  gas: DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT,
-                },
-                { serializer }
-              ),
-            ],
-          } as any,
-          { retryCount: 0 }
-        )
-      )
+      (await (async () => {
+        const metadata = await buildTxSeismicMetadata(client, {
+          account,
+          nonce: request.nonce,
+          to: to!,
+          value,
+          signedRead: false,
+        })
+        const encryptedData = await client.encrypt(data, metadata)
+        const gasPrice_ = (request.gasPrice ??
+          request.maxFeePerGas ??
+          (await client.getGasPrice())) as bigint
+        return estimateShieldedGas(client, {
+          encryptedData,
+          metadata,
+          gasPrice: gasPrice_,
+        })
+      })())
 
     // Re-sign the final transparent transaction with the resolved gas limit
     // and submit it normally as a raw transaction.

--- a/clients/ts/tests/seismic-viem/src/viem.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem.test.ts
@@ -14,7 +14,10 @@ import {
   testConcurrentShieldedTransactions,
 } from '@sviem-tests/tests/concurrency.ts'
 import { testSeismicTx } from '@sviem-tests/tests/contract/contract.ts'
-import { testDepositContract } from '@sviem-tests/tests/contract/depositContract.ts'
+import {
+  testDepositContract,
+  testDepositEventsMatchSummitVectors,
+} from '@sviem-tests/tests/contract/depositContract.ts'
 import { testSeismicTxEncoding } from '@sviem-tests/tests/encoding.ts'
 import {
   testGetStorageAtThrows,
@@ -198,6 +201,14 @@ describe('Deposit Contract', async () => {
   test(
     'deploy & test deposit contract functionality',
     async () => await testDepositContract({ chain, url, account }),
+    {
+      timeout: CONTRACT_TIMEOUT_MS,
+    }
+  )
+  test(
+    'deposit events match summit golden vectors',
+    async () =>
+      await testDepositEventsMatchSummitVectors({ chain, url, account }),
     {
       timeout: CONTRACT_TIMEOUT_MS,
     }


### PR DESCRIPTION
Vendors Summit's deposit-request golden vectors (summit repo, `types/fixtures/deposit_requests.json`) and adds a replay test to both SDKs:

- **Python** — `TestDepositRequestVectors` submits each vector via `w3.seismic.deposit(...)`, decodes the emitted `DepositEvent`, and asserts the seven fields reassemble byte-for-byte into the vector's `expected_request`
- **TypeScript** — `testDepositEventsMatchSummitVectors` does the same via `walletClient.deposit(...)` + `parseEventLogs`
