### PR TITLE
3.3: bind balanceOfSigned to an EIP-712 chainId domain

### DIFF
--- a/contracts/src/seismic-std-lib/SRC20.sol
+++ b/contracts/src/seismic-std-lib/SRC20.sol
@@ -240,7 +240,13 @@ abstract contract SRC20 {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Read any user's balance with their signature authorization.
-    /// @dev Signature is token-agnostic: uses personal sign over ("SRC20_BALANCE_READ", owner, expiry).
+    /// @dev The signature is bound to `block.chainid` via an EIP-712 domain, but deliberately
+    ///      NOT to the token address: it stays valid across SRC20 deployments on the same chain
+    ///      (SRC20Multicall relies on one signature covering many tokens) while cross-chain replay
+    ///      is blocked. The domain separator is recomputed from `block.chainid` on every call so it
+    ///      is fork-safe. Because this is a `view` function it cannot consume a per-owner nonce, so
+    ///      a leaked signature stays a valid viewing key on `balances[owner]` until `expiry` — keep
+    ///      expiries short.
     function balanceOfSigned(address owner, uint256 expiry, bytes calldata signature)
         external
         view
@@ -250,8 +256,17 @@ abstract contract SRC20 {
         require(block.timestamp <= expiry, "signature expired");
         require(signature.length == 65, "invalid signature length");
 
-        bytes32 messageHash = keccak256(abi.encodePacked("SRC20_BALANCE_READ", owner, expiry));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId)"),
+                keccak256(bytes("SRC20BalanceRead")),
+                keccak256(bytes("1")),
+                block.chainid
+            )
+        );
+        bytes32 structHash =
+            keccak256(abi.encode(keccak256("BalanceRead(address owner,uint256 expiry)"), owner, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
         bytes32 r;
         bytes32 s;
@@ -262,7 +277,7 @@ abstract contract SRC20 {
             v := byte(0, calldataload(add(signature.offset, 64)))
         }
 
-        address signer = ecrecover(ethSignedHash, v, r, s);
+        address signer = ecrecover(digest, v, r, s);
         require(signer != address(0) && signer == owner, "invalid signature");
 
         return uint256(balances[owner]);

--- a/contracts/test/BatchRead.t.sol
+++ b/contracts/test/BatchRead.t.sol
@@ -52,6 +52,14 @@ contract BatchReadTest is Test {
 
     uint256 constant NUM_TOKENS = 10;
 
+    // EIP-712 chainId-bound balance-read domain (mirrors SRC20.balanceOfSigned).
+    // Token-agnostic on purpose: binds name/version/chainId but NOT verifyingContract,
+    // so one signature stays valid across SRC20 deployments on the same chain (which is
+    // what SRC20Multicall relies on) while cross-chain replay is blocked.
+    bytes32 constant BALANCE_READ_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId)");
+    bytes32 constant BALANCE_READ_TYPEHASH = keccak256("BalanceRead(address owner,uint256 expiry)");
+
     function setUp() public {
         user = vm.addr(USER_PRIVATE_KEY);
 
@@ -73,9 +81,14 @@ contract BatchReadTest is Test {
     }
 
     function _signBalanceRead(uint256 privateKey, address owner, uint256 expiry) internal returns (bytes memory) {
-        bytes32 messageHash = keccak256(abi.encodePacked("SRC20_BALANCE_READ", owner, expiry));
-        bytes32 ethSignedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash));
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedHash);
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                BALANCE_READ_DOMAIN_TYPEHASH, keccak256(bytes("SRC20BalanceRead")), keccak256(bytes("1")), block.chainid
+            )
+        );
+        bytes32 structHash = keccak256(abi.encode(BALANCE_READ_TYPEHASH, owner, expiry));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
     }
 
@@ -132,6 +145,35 @@ contract BatchReadTest is Test {
         assertEq(tokens[0].balanceOfSigned(user, expiry, sig), 1e18);
         assertEq(tokens[4].balanceOfSigned(user, expiry, sig), 5e18);
         assertEq(tokens[9].balanceOfSigned(user, expiry, sig), 10e18);
+    }
+
+    // Zellic 3.3: a signed balance read must be bound to the chain it was minted on.
+    // Before the fix the digest carried no chainId, so one signature was a durable
+    // cross-chain viewing key on balances[owner]; a leak on any chain read the balance
+    // on every chain. After the fix the digest binds block.chainid.
+    function test_signatureDoesNotReplayAcrossChains() public {
+        uint256 expiry = block.timestamp + 1 hours;
+
+        // Mint a signature under chain A.
+        uint256 chainA = 1;
+        uint256 chainB = 2;
+        vm.chainId(chainA);
+        bytes memory sig = _signBalanceRead(USER_PRIVATE_KEY, user, expiry);
+
+        // (b) A valid signature on its own chain still returns the balance.
+        assertEq(tokens[0].balanceOfSigned(user, expiry, sig), 1e18);
+
+        // (c) Token-agnostic on the same chain is preserved: the same signature
+        //     validates against a second SRC20 instance (SRC20Multicall depends on this).
+        assertEq(tokens[4].balanceOfSigned(user, expiry, sig), 5e18);
+        TestSRC20 second = new TestSRC20("Second", "SEC", 18);
+        second.mint(user, 7e18);
+        assertEq(second.balanceOfSigned(user, expiry, sig), 7e18);
+
+        // (a) Replaying the same signature on a different chain must revert.
+        vm.chainId(chainB);
+        vm.expectRevert("invalid signature");
+        tokens[0].balanceOfSigned(user, expiry, sig);
     }
 
     // timestamp == expiry is valid


### PR DESCRIPTION
## 3.3 — `SRC20.balanceOfSigned` leaked/expired signature is a cross-context viewing key (High)

### Bug
The signed balance-read digest was `keccak256(abi.encodePacked("SRC20_BALANCE_READ", owner, expiry))` wrapped in a `personal_sign` prefix — **no chainId and no EIP-712 domain**. A single signature therefore validated on **every chain** (and every SRC20 deployment), and — with a node honoring `BlockOverrides.time` — past its `expiry`. A leaked signature was a durable, cross-chain viewing key on `balances[owner]`.

### Fix (contract-side)
Bind the read to `block.chainid` via an EIP-712 domain:

- `domainSeparator = keccak256(EIP712Domain(string name,string version,uint256 chainId))` with `name="SRC20BalanceRead"`, `version="1"`, computed **dynamically from `block.chainid`** at call time (fork-safe).
- `structHash = keccak256(BalanceRead(address owner,uint256 expiry))`; digest `= keccak256(0x1901 ‖ domainSeparator ‖ structHash)`.
- Kept `ecrecover`, the `signer != 0 && signer == owner` check, the `block.timestamp <= expiry` check, and the 65-byte length check.

### Why token-agnostic is preserved (design choice A)
The domain **intentionally omits `verifyingContract`**, so one signature stays valid across SRC20 deployments on the **same chain** — which `SRC20Multicall` relies on to read balances across many tokens with a single signature. **`SRC20Multicall` is unchanged.** Cross-**chain** replay is now blocked because the digest binds `block.chainid`.

### Accepted limitation
`balanceOfSigned` remains `view`, so it cannot consume a per-owner nonce. A leaked signature stays a valid viewing key on `balances[owner]` until `expiry`; keep expiries short. Documented in the function's NatSpec.

### Tests (test-first)
`test(src20): show balanceOfSigned signature replays across chains` asserts:
- **(a)** a signature minted under chainId X **reverts** when replayed under chainId Y (`vm.chainId`) — failed on the old code, passes post-fix;
- **(b)** a valid signature on the correct chain still returns `balances[owner]`;
- **(c)** token-agnostic preserved — the same signature validates against a second SRC20 instance on the same chain.

The shared `_signBalanceRead` helper in `BatchRead.t.sol` now builds the EIP-712 chainId digest, so the whole signed-read + multicall suite exercises the new scheme. Full `BatchReadTest` (12) and `SRC20EventsTest` (20) suites pass. (The 4 `Intelligence`/`Directory` zero-key failures are pre-existing on the base branch — they need the node's state-override/genesis env, unrelated to this change.)

### Verify (CI mirror)
```
cd contracts && sforge build --via-ir --unsafe-via-ir \
  && sforge test --via-ir --unsafe-via-ir -vv \
  && sforge fmt --check
```

### Owed downstream work (separate PRs — not in this PR)
- **Node half:** the timestamp-rewind (`expiry`) revival is node-owned — `seismic-reth` must reject `BlockOverrides.time` on `balanceOfSigned` calls (separate seismic-reth PR).
- **Clients:** any consumer that *constructs* `balanceOfSigned` signatures (seismic-viem, `src20-factory` clients) must switch from the old `personal_sign("SRC20_BALANCE_READ", …)` scheme to the EIP-712 chainId digest. No such constructor exists in this monorepo's `clients/`.
- **Artifacts:** none. `SRC20` is an abstract base (not a genesis contract), so `artifacts/` is unaffected. The function's ABI signature is unchanged.
