### PR TITLE
fix: estimate transparent txs via a provisional Seismic tx

### DIFF
--- a/clients/py/src/seismic_web3/contract/shielded.py
+++ b/clients/py/src/seismic_web3/contract/shielded.py
@@ -195,8 +195,10 @@ class _TransparentWriteNamespace:
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
         private_key: PrivateKey | None = None,
+        encryption: EncryptionState | None = None,
     ) -> None:
         self._w3 = w3
+        self._encryption = encryption
         self._address = address
         self._abi = abi
         self._private_key = private_key
@@ -206,13 +208,18 @@ class _TransparentWriteNamespace:
 
         def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
-            if "gas" not in tx_params and self._private_key is not None:
+            if (
+                "gas" not in tx_params
+                and self._private_key is not None
+                and self._encryption is not None
+            ):
                 tx_params["gas"] = estimate_transparent_gas(
                     self._w3,
                     to=self._address,
                     data=data.to_0x_hex(),
                     value=value,
                     private_key=self._private_key,
+                    encryption=self._encryption,
                 )
             tx: dict[str, Any] = {
                 "to": self._address,
@@ -306,6 +313,7 @@ class _SmartWriteNamespace:
                         data=data.to_0x_hex(),
                         value=value,
                         private_key=self._private_key,
+                        encryption=self._encryption,
                     )
                 tx: dict[str, Any] = {
                     "to": self._address,
@@ -520,8 +528,10 @@ class _AsyncTransparentWriteNamespace:
         address: ChecksumAddress,
         abi: list[dict[str, Any]],
         private_key: PrivateKey | None = None,
+        encryption: EncryptionState | None = None,
     ) -> None:
         self._w3 = w3
+        self._encryption = encryption
         self._address = address
         self._abi = abi
         self._private_key = private_key
@@ -531,13 +541,18 @@ class _AsyncTransparentWriteNamespace:
 
         async def call(*args: Any, value: int = 0, **tx_params: Any) -> HexBytes:
             data = encode_shielded_calldata(self._abi, fn_name, list(args))
-            if "gas" not in tx_params and self._private_key is not None:
+            if (
+                "gas" not in tx_params
+                and self._private_key is not None
+                and self._encryption is not None
+            ):
                 tx_params["gas"] = await async_estimate_transparent_gas(
                     self._w3,
                     to=self._address,
                     data=data.to_0x_hex(),
                     value=value,
                     private_key=self._private_key,
+                    encryption=self._encryption,
                 )
             tx: dict[str, Any] = {
                 "to": self._address,
@@ -631,6 +646,7 @@ class _AsyncSmartWriteNamespace:
                         data=data.to_0x_hex(),
                         value=value,
                         private_key=self._private_key,
+                        encryption=self._encryption,
                     )
                 tx: dict[str, Any] = {
                     "to": self._address,
@@ -779,6 +795,7 @@ class ShieldedContract:
             address,
             abi,
             private_key=private_key,
+            encryption=encryption,
         )
         self.tread = _TransparentReadNamespace(w3, address, abi)
         self.dwrite = _ShieldedDebugWriteNamespace(
@@ -871,6 +888,7 @@ class AsyncShieldedContract:
             address,
             abi,
             private_key=private_key,
+            encryption=encryption,
         )
         self.tread = _AsyncTransparentReadNamespace(w3, address, abi)
         self.dwrite = _AsyncShieldedDebugWriteNamespace(

--- a/clients/py/src/seismic_web3/module.py
+++ b/clients/py/src/seismic_web3/module.py
@@ -469,6 +469,7 @@ class SeismicNamespace(SeismicPublicNamespace):
             data=data.to_0x_hex(),
             value=value,
             private_key=self._private_key,
+            encryption=self.encryption,
         )
         return self._w3.eth.send_transaction(
             {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},
@@ -717,6 +718,7 @@ class AsyncSeismicNamespace(AsyncSeismicPublicNamespace):
             data=data.to_0x_hex(),
             value=value,
             private_key=self._private_key,
+            encryption=self.encryption,
         )
         return await self._w3.eth.send_transaction(
             {"to": address, "data": data.to_0x_hex(), "value": value, "gas": gas},

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -229,6 +229,12 @@ def estimate_transparent_gas(
         cast("ChecksumAddress", to),
         value,
         None,
+        # signed_read=True makes the provisional tx a non-broadcastable
+        # simulation: the consensus/pooled decoders reject signed reads as state
+        # transitions, so an intercepted estimate payload cannot be replayed via
+        # eth_sendRawTransaction. Gas is unchanged (flag never reaches EVM
+        # execution); the final transparent tx is signed separately.
+        signed_read=True,
     )
     metadata = build_metadata(w3, params)
     encrypted = encryption.encrypt(
@@ -264,6 +270,12 @@ async def async_estimate_transparent_gas(
         cast("ChecksumAddress", to),
         value,
         None,
+        # signed_read=True makes the provisional tx a non-broadcastable
+        # simulation: the consensus/pooled decoders reject signed reads as state
+        # transitions, so an intercepted estimate payload cannot be replayed via
+        # eth_sendRawTransaction. Gas is unchanged (flag never reaches EVM
+        # execution); the final transparent tx is signed separately.
+        signed_read=True,
     )
     metadata = await async_build_metadata(w3, params)
     encrypted = encryption.encrypt(
@@ -369,10 +381,27 @@ def _prepare_shielded_transaction(
     if gas is not None:
         resolved_gas = gas
     else:
+        # Non-broadcastable signed-read twin for the estimate: separate metadata
+        # with signed_read=True and a fresh encryption nonce (avoids AES-GCM
+        # nonce reuse vs the write). Signed reads are rejected by the
+        # consensus/pooled decoders, so an intercepted estimate payload cannot be
+        # replayed via eth_sendRawTransaction. The tx signed below still uses
+        # `metadata`/`encrypted_data` (signed_read=False), unchanged.
+        estimate_params = _build_metadata_params(
+            private_key, encryption, to, value, None, signed_read=True, eip712=eip712
+        )
+        estimate_metadata = build_metadata(w3, estimate_params)
+        estimate_encrypted = HexBytes(
+            encryption.encrypt(
+                data,
+                estimate_metadata.seismic_elements.encryption_nonce,
+                estimate_metadata,
+            )
+        )
         resolved_gas = estimate_shielded_gas(
             w3,
-            encrypted_data=encrypted_data,
-            metadata=metadata,
+            encrypted_data=estimate_encrypted,
+            metadata=estimate_metadata,
             gas_price=resolved_gas_price,
             private_key=private_key,
         )
@@ -418,10 +447,27 @@ async def _async_prepare_shielded_transaction(
     if gas is not None:
         resolved_gas = gas
     else:
+        # Non-broadcastable signed-read twin for the estimate: separate metadata
+        # with signed_read=True and a fresh encryption nonce (avoids AES-GCM
+        # nonce reuse vs the write). Signed reads are rejected by the
+        # consensus/pooled decoders, so an intercepted estimate payload cannot be
+        # replayed via eth_sendRawTransaction. The tx signed below still uses
+        # `metadata`/`encrypted_data` (signed_read=False), unchanged.
+        estimate_params = _build_metadata_params(
+            private_key, encryption, to, value, None, signed_read=True, eip712=eip712
+        )
+        estimate_metadata = await async_build_metadata(w3, estimate_params)
+        estimate_encrypted = HexBytes(
+            encryption.encrypt(
+                data,
+                estimate_metadata.seismic_elements.encryption_nonce,
+                estimate_metadata,
+            )
+        )
         resolved_gas = await async_estimate_shielded_gas(
             w3,
-            encrypted_data=encrypted_data,
-            metadata=metadata,
+            encrypted_data=estimate_encrypted,
+            metadata=estimate_metadata,
             gas_price=resolved_gas_price,
             private_key=private_key,
         )

--- a/clients/py/src/seismic_web3/transaction/send.py
+++ b/clients/py/src/seismic_web3/transaction/send.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from eth_account import Account as EthAccount
 from eth_keys.main import KeyAPI as eth_keys
 from hexbytes import HexBytes
 from web3.types import RPCEndpoint
@@ -209,31 +208,41 @@ def estimate_transparent_gas(
     data: str,
     value: int,
     private_key: PrivateKey,
+    encryption: EncryptionState,
 ) -> int:
-    """Estimate gas for a transparent tx by signing it first (sync).
+    """Estimate gas for a transparent tx via a provisional shielded tx (sync).
 
-    Signs a temporary standard transaction using the block gas limit as
-    a placeholder and sends the signed bytes to ``eth_estimateGas``.
-    This prevents the node from zeroing ``msg.value`` during simulation.
+    The node's raw-bytes ``eth_estimateGas`` path only accepts Seismic
+    transactions (a signed read must carry ``seismic_elements``), so a
+    signed plain transaction is rejected there.  Unsigned estimation is
+    no substitute: the node strips ``from`` and ``value`` from unsigned
+    requests, which breaks payable calls and misestimates
+    sender-dependent gas paths.  Instead, estimate a provisional
+    ``TxSeismic`` carrying the same sender, ``to``, ``value``, and
+    (encrypted) calldata: after decryption the node executes the same
+    call with authenticated caller context, and the ciphertext's
+    slightly higher intrinsic calldata cost can only overestimate.
     """
-    acct = EthAccount.from_key(private_key)
-    block_gas_limit = w3.eth.get_block("latest")["gasLimit"]
-    tx = {
-        "to": to,
-        "data": data,
-        "value": value,
-        "gas": block_gas_limit,
-        "gasPrice": w3.eth.gas_price,
-        "nonce": w3.eth.get_transaction_count(acct.address),
-        "chainId": w3.eth.chain_id,
-    }
-    signed = acct.sign_transaction(tx)
-
-    response = w3.provider.make_request(
-        RPCEndpoint("eth_estimateGas"),
-        [signed.raw_transaction.to_0x_hex()],
+    params = _build_metadata_params(
+        private_key,
+        encryption,
+        cast("ChecksumAddress", to),
+        value,
+        None,
     )
-    return int(_check_rpc_response(response), 16)
+    metadata = build_metadata(w3, params)
+    encrypted = encryption.encrypt(
+        HexBytes(data),
+        metadata.seismic_elements.encryption_nonce,
+        metadata,
+    )
+    return estimate_shielded_gas(
+        w3,
+        encrypted_data=HexBytes(encrypted),
+        metadata=metadata,
+        gas_price=w3.eth.gas_price,
+        private_key=private_key,
+    )
 
 
 async def async_estimate_transparent_gas(
@@ -243,29 +252,32 @@ async def async_estimate_transparent_gas(
     data: str,
     value: int,
     private_key: PrivateKey,
+    encryption: EncryptionState,
 ) -> int:
-    """Estimate gas for a transparent tx by signing it first (async).
+    """Estimate gas for a transparent tx via a provisional shielded tx (async).
 
     Async variant of :func:`estimate_transparent_gas`.
     """
-    acct = EthAccount.from_key(private_key)
-    block_gas_limit = (await w3.eth.get_block("latest"))["gasLimit"]
-    tx = {
-        "to": to,
-        "data": data,
-        "value": value,
-        "gas": block_gas_limit,
-        "gasPrice": await w3.eth.gas_price,
-        "nonce": await w3.eth.get_transaction_count(acct.address),
-        "chainId": await w3.eth.chain_id,
-    }
-    signed = acct.sign_transaction(tx)
-
-    response = await w3.provider.make_request(
-        RPCEndpoint("eth_estimateGas"),
-        [signed.raw_transaction.to_0x_hex()],
+    params = _build_metadata_params(
+        private_key,
+        encryption,
+        cast("ChecksumAddress", to),
+        value,
+        None,
     )
-    return int(_check_rpc_response(response), 16)
+    metadata = await async_build_metadata(w3, params)
+    encrypted = encryption.encrypt(
+        HexBytes(data),
+        metadata.seismic_elements.encryption_nonce,
+        metadata,
+    )
+    return await async_estimate_shielded_gas(
+        w3,
+        encrypted_data=HexBytes(encrypted),
+        metadata=metadata,
+        gas_price=await w3.eth.gas_price,
+        private_key=private_key,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/clients/py/tests/test_send.py
+++ b/clients/py/tests/test_send.py
@@ -1,13 +1,26 @@
-"""Tests for seismic_web3.transaction.send — address derivation."""
+"""Tests for seismic_web3.transaction.send — address derivation, estimation."""
 
-from seismic_web3._types import PrivateKey
-from seismic_web3.transaction.send import _address_from_key
+from unittest.mock import MagicMock
+
+from seismic_web3._types import CompressedPublicKey, PrivateKey
+from seismic_web3.client import get_encryption
+from seismic_web3.transaction.send import (
+    _address_from_key,
+    estimate_transparent_gas,
+)
 
 # Anvil account #0
 ANVIL_PK = PrivateKey(
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 )
 ANVIL_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+_NETWORK_PK = CompressedPublicKey(
+    "0x028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0"
+)
+_CLIENT_SK = PrivateKey(
+    "0xa30363336e1bb949185292a2a302de86e447d98f3a43d823c8c234d9e3e5ad77"
+)
 
 
 class TestAddressFromKey:
@@ -21,3 +34,46 @@ class TestAddressFromKey:
         address = _address_from_key(ANVIL_PK)
         # Checksummed addresses have uppercase letters
         assert any(c.isupper() for c in address[2:])
+
+
+class TestEstimateTransparentGas:
+    """Transparent gas estimation must go through a Seismic (0x4a) tx.
+
+    The node's raw-bytes ``eth_estimateGas`` path rejects plain signed
+    transactions (a signed read must carry ``seismic_elements``), and
+    unsigned estimation strips ``from`` and ``value``, which breaks
+    payable and sender-dependent calls.  The only request form that
+    preserves authenticated caller context is a provisional shielded
+    transaction.
+    """
+
+    def test_submits_seismic_tx_to_estimate_gas(self):
+        w3 = MagicMock()
+        w3.eth.chain_id = 31337
+        w3.eth.get_transaction_count.return_value = 7
+        w3.eth.get_block.return_value = {
+            "hash": b"\x11" * 32,
+            "number": 100,
+            "gasLimit": 30_000_000,
+        }
+        w3.eth.gas_price = 10**9
+        w3.provider.make_request.return_value = {"result": "0x5208"}
+
+        encryption = get_encryption(_NETWORK_PK, _CLIENT_SK)
+        gas = estimate_transparent_gas(
+            w3,
+            to="0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            data="0xd09de08a",
+            value=32 * 10**18,
+            private_key=ANVIL_PK,
+            encryption=encryption,
+        )
+
+        assert gas == 0x5208
+        method, params = w3.provider.make_request.call_args[0]
+        assert method == "eth_estimateGas"
+        assert params[0].startswith("0x4a"), (
+            "transparent estimation must submit a provisional Seismic "
+            "(0x4a) transaction: the node rejects plain signed txs on the "
+            "raw-bytes path and strips from/value from unsigned requests"
+        )

--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "seismic-client",

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -169,13 +169,37 @@ export async function sendShieldedTransaction<
       // When gas is not provided, sign a temporary tx and send it to
       // eth_estimateGas so the node can authenticate the sender.
       // This prevents caller-spoofing against msg.sender-gated state.
+      //
+      // Estimate with a non-broadcastable signed-read twin: a separate
+      // signedRead=true metadata (with a fresh encryptionNonce to avoid
+      // AES-GCM nonce reuse against the write) re-encrypts the calldata for
+      // the estimate only. The consensus/pooled decoders reject signed reads
+      // as state transitions, so an intercepted estimate payload cannot be
+      // replayed via eth_sendRawTransaction. The final tx below is still built
+      // from `metadata`/`encryptedCalldata` (signedRead=false), unchanged.
       const resolvedGas =
         gas ??
-        (await estimateShieldedGas(client, {
-          encryptedData: encryptedCalldata,
-          metadata,
-          gasPrice: resolvedGasPrice,
-        }))
+        (await (async () => {
+          const estimateMetadata = await buildTxSeismicMetadata(client, {
+            account: account_,
+            nonce,
+            to: to!,
+            value,
+            blocksWindow,
+            signedRead: true,
+            recentBlockHash,
+            expiresAtBlock,
+          })
+          const estimateEncryptedCalldata = await client.encrypt(
+            plaintextCalldata,
+            estimateMetadata
+          )
+          return estimateShieldedGas(client, {
+            encryptedData: estimateEncryptedCalldata,
+            metadata: estimateMetadata,
+            gasPrice: resolvedGasPrice,
+          })
+        })())
 
       // Fill remaining fee fields via prepareTransactionRequest.
       // Gas is already resolved so viem won't call eth_estimateGas.

--- a/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendShielded.ts
@@ -261,7 +261,7 @@ export async function sendShieldedTransaction<
  * Signs a temporary shielded transaction and sends it to `eth_estimateGas`
  * so the node can authenticate the sender during simulation.
  */
-async function estimateShieldedGas<
+export async function estimateShieldedGas<
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account,

--- a/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
@@ -124,12 +124,18 @@ export async function sendTransparentTransaction<
     const gasEstimate =
       gas ??
       (await (async () => {
+        // signedRead: true makes the provisional tx a non-broadcastable
+        // simulation: the consensus/pooled decoders reject signed reads as
+        // state transitions, so an intercepted estimate payload cannot be
+        // replayed via eth_sendRawTransaction. The gas result is unchanged
+        // (the flag never reaches EVM execution); the final transparent tx
+        // below is a separate standard transaction.
         const metadata = await buildTxSeismicMetadata(client, {
           account,
           nonce: request.nonce,
           to: to!,
           value,
-          signedRead: false,
+          signedRead: true,
         })
         const encryptedData = await client.encrypt(data, metadata)
         const gasPrice_ = (request.gasPrice ??

--- a/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/sendTransparent.ts
@@ -16,16 +16,17 @@ import { assertRequest, getAction, getTransactionError } from 'viem/utils'
 
 import { ShieldedWalletClient } from '@sviem/client.ts'
 import { AccountNotFoundError } from '@sviem/error/account.ts'
-
-const DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT = 30_000_000n
+import { buildTxSeismicMetadata } from '@sviem/tx/metadata.ts'
+import { estimateShieldedGas } from '@sviem/tx/sendShielded.ts'
 
 /**
  * Executes the transparent transaction path for Seismic wallet clients.
  *
  * This is still an Ethereum-style send, but Seismic needs authenticated gas
- * estimation for some transactions. When the account is `local`, the client can
- * sign a provisional raw transaction and send those bytes to `eth_estimateGas`
- * so the node simulates execution with the real caller context.
+ * estimation for some transactions. When the account is `local`, the client
+ * estimates gas via a provisional Seismic (0x4a) transaction carrying the
+ * same sender, to, value, and (encrypted) calldata, so the node simulates
+ * execution with the real caller context.
  *
  * For `json-rpc` accounts, the SDK does not have the signing key locally, so
  * this falls back to viem's standard `sendTransaction` flow and its unsigned
@@ -109,30 +110,37 @@ export async function sendTransparentTransaction<
     } as any)
 
     const serializer = chain?.serializers?.transaction
+
+    // Estimate gas via a provisional Seismic (0x4a) transaction carrying the
+    // same sender, to, value, and calldata (encrypted), so the node simulates
+    // with authenticated caller context. The node's raw-bytes estimate path
+    // only accepts Seismic envelopes (signed reads must carry
+    // seismic_elements), so a signed *plain* tx is rejected there; unsigned
+    // estimation is no substitute because the node strips `from` and `value`
+    // from unsigned requests, which breaks payable and sender-dependent
+    // calls. Execution after decryption matches the transparent tx; the
+    // ciphertext's slightly higher intrinsic calldata cost can only
+    // overestimate, which is the safe direction.
     const gasEstimate =
       gas ??
-      BigInt(
-        await client.request(
-          {
-            // Estimate gas from a signed raw transaction so the node can
-            // recover the real sender and simulate execution with authenticated
-            // caller context. We use a large temporary gas limit here only for
-            // the estimation request; the final tx is re-signed below with the
-            // actual estimated gas.
-            method: 'eth_estimateGas',
-            params: [
-              await account.signTransaction(
-                {
-                  ...request,
-                  gas: DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT,
-                },
-                { serializer }
-              ),
-            ],
-          } as any,
-          { retryCount: 0 }
-        )
-      )
+      (await (async () => {
+        const metadata = await buildTxSeismicMetadata(client, {
+          account,
+          nonce: request.nonce,
+          to: to!,
+          value,
+          signedRead: false,
+        })
+        const encryptedData = await client.encrypt(data, metadata)
+        const gasPrice_ = (request.gasPrice ??
+          request.maxFeePerGas ??
+          (await client.getGasPrice())) as bigint
+        return estimateShieldedGas(client, {
+          encryptedData,
+          metadata,
+          gasPrice: gasPrice_,
+        })
+      })())
 
     // Re-sign the final transparent transaction with the resolved gas limit
     // and submit it normally as a raw transaction.


### PR DESCRIPTION
For transparent txs without an explicit gas limit, the SDKs estimated gas by signing the plain (0x02) tx and submitting the raw bytes to `eth_estimateGas`, so the node could authenticate the sender. Since [seismic-reth #419](https://github.com/SeismicSystems/seismic-reth/pull/419), the node rejects any raw-bytes request without `seismic_elements`.

Falling back to standard unsigned estimation doesn't work: seismic-reth strips `from` and `value` from unsigned requests, so payable calls (e.g. `DepositContract.deposit`, which requires `msg.value >= 1 ether`) revert during estimation, and sender-dependent gas paths estimate wrong. Instead, gas is now estimated via a provisional Seismic (0x4a) tx carrying the same sender, `to`, `value`, and (encrypted) calldata; the final tx is still sent as a plain 0x02.

Changes:

- `packages/seismic-viem/src/tx/sendTransparent.ts`: replaced the gas-estimation step in `sendTransparentTransaction`: builds Seismic metadata (`buildTxSeismicMetadata`, `signedRead: false`), encrypts the calldata (`client.encrypt`), and estimates via a provisional 0x4a through `estimateShieldedGas`; removed the now-unused `DEFAULT_SIGNED_ESTIMATE_GAS_LIMIT` constant
- `packages/seismic-viem/src/tx/sendShielded.ts`: exported the previously-private `estimateShieldedGas` helper so the transparent path can reuse it (no behavior change)
- `clients/py/src/seismic_web3/transaction/send.py`: `estimate_transparent_gas` / `async_estimate_transparent_gas` now build a provisional `TxSeismic` (metadata → encrypt → `estimate_shielded_gas`) instead of signing a plain tx; new required `encryption` kwarg, threaded through the call sites in `module.py` and `contract/shielded.py`
- `clients/py/tests/test_send.py`: unit test pinning that estimation submits a 0x4a tx