### PR TITLE
feat(std-lib): add TxUtils.isSeismicTx()/txType() helpers

### DIFF
--- a/contracts/src/seismic-std-lib/utils/TxUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/TxUtils.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/// @title TxUtils
+/// @notice Helpers for reading transaction-level context on Seismic.
+library TxUtils {
+    uint256 internal constant SEISMIC_TX_TYPE = 0x4A;
+
+    /// @notice EIP-2718 transaction-type byte of the current transaction (74 = Seismic).
+    function txType() internal view returns (uint256 t) {
+        assembly {
+            t := txtype()
+        }
+    }
+
+    /// @notice True if the current transaction is a Seismic (type 0x4A) transaction.
+    function isSeismicTx() internal view returns (bool) {
+        return txType() == SEISMIC_TX_TYPE;
+    }
+}

--- a/contracts/src/seismic-std-lib/utils/TxUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/TxUtils.sol
@@ -13,7 +13,12 @@ library TxUtils {
         }
     }
 
-    /// @notice True if the current transaction is a Seismic (type 0x4A) transaction.
+    /// @notice True when executing in an authenticated Seismic context: a real Seismic
+    /// transaction (type 0x4A) or an authenticated signed read. False for a plain,
+    /// unauthenticated `eth_call`.
+    /// @dev Reports the transaction type only. This is NOT an authorization check, does not
+    /// prove the call is state-changing (authenticated signed reads also return true), and does
+    /// not by itself guarantee that every field of the RPC response is encrypted.
     function isSeismicTx() internal view returns (bool) {
         return txType() == SEISMIC_TX_TYPE;
     }

--- a/contracts/test/TxUtils.t.sol
+++ b/contracts/test/TxUtils.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {TxUtils} from "../src/seismic-std-lib/utils/TxUtils.sol";
+
+contract TxUtilsHarness {
+    function txType() external view returns (uint256) {
+        return TxUtils.txType();
+    }
+
+    function isSeismicTx() external view returns (bool) {
+        return TxUtils.isSeismicTx();
+    }
+}
+
+contract TxUtilsTest is Test {
+    TxUtilsHarness internal harness;
+
+    function setUp() public {
+        harness = new TxUtilsHarness();
+    }
+
+    function test_txType_isByteRange() public view {
+        assertLe(harness.txType(), 255);
+    }
+
+    function test_isSeismicTx_matchesTxType() public view {
+        assertEq(harness.isSeismicTx(), harness.txType() == 0x4A);
+    }
+}

--- a/contracts/test/TxUtils.t.sol
+++ b/contracts/test/TxUtils.t.sol
@@ -4,6 +4,12 @@ pragma solidity ^0.8.23;
 import {Test} from "forge-std/Test.sol";
 import {TxUtils} from "../src/seismic-std-lib/utils/TxUtils.sol";
 
+/// Minimal view of the Seismic `txType` cheatcode (sets the EIP-2718 tx type for
+/// subsequent calls), until forge-std's Vm interface is regenerated with it.
+interface VmTxType {
+    function txType(uint8 newTxType) external;
+}
+
 contract TxUtilsHarness {
     function txType() external view returns (uint256) {
         return TxUtils.txType();
@@ -16,21 +22,27 @@ contract TxUtilsHarness {
 
 contract TxUtilsTest is Test {
     TxUtilsHarness internal harness;
+    VmTxType internal vmTx;
 
     function setUp() public {
         harness = new TxUtilsHarness();
+        vmTx = VmTxType(address(vm));
     }
 
-    // In the forge unit executor the call is a standard (non-Seismic) tx, so txtype()
-    // must report 0 and isSeismicTx() false. This catches an opcode that wrongly returns
-    // a constant (e.g. always 74). Real Seismic-tx / signed-read cases (txtype()==74) are
-    // covered by the node integration tests (sanvil/sreth), which the unit harness cannot
-    // reproduce (no cheatcode sets the EIP-2718 tx type).
-    function test_txType_isZeroForStandardCall() public view {
+    function test_txType_defaultsToStandardCall() public view {
         assertEq(harness.txType(), 0);
+        assertFalse(harness.isSeismicTx());
     }
 
-    function test_isSeismicTx_falseForStandardCall() public view {
+    function test_isSeismicTx_trueForSeismicTxType() public {
+        vmTx.txType(0x4A);
+        assertEq(harness.txType(), 0x4A);
+        assertTrue(harness.isSeismicTx());
+    }
+
+    function test_isSeismicTx_falseForStandardTxType() public {
+        vmTx.txType(2);
+        assertEq(harness.txType(), 2);
         assertFalse(harness.isSeismicTx());
     }
 }

--- a/contracts/test/TxUtils.t.sol
+++ b/contracts/test/TxUtils.t.sol
@@ -21,11 +21,16 @@ contract TxUtilsTest is Test {
         harness = new TxUtilsHarness();
     }
 
-    function test_txType_isByteRange() public view {
-        assertLe(harness.txType(), 255);
+    // In the forge unit executor the call is a standard (non-Seismic) tx, so txtype()
+    // must report 0 and isSeismicTx() false. This catches an opcode that wrongly returns
+    // a constant (e.g. always 74). Real Seismic-tx / signed-read cases (txtype()==74) are
+    // covered by the node integration tests (sanvil/sreth), which the unit harness cannot
+    // reproduce (no cheatcode sets the EIP-2718 tx type).
+    function test_txType_isZeroForStandardCall() public view {
+        assertEq(harness.txType(), 0);
     }
 
-    function test_isSeismicTx_matchesTxType() public view {
-        assertEq(harness.isSeismicTx(), harness.txType() == 0x4A);
+    function test_isSeismicTx_falseForStandardCall() public view {
+        assertFalse(harness.isSeismicTx());
     }
 }


### PR DESCRIPTION
## Summary

Adds `TxUtils` to the Seismic std lib: `txType()` returns the EIP-2718 transaction-type byte
via the new `txtype()` builtin, and `isSeismicTx()` checks it `== 74` (`0x4A`).

## DRAFT — blocked on the release chain
This cannot compile in CI until a released `ssolc` knows the `txtype()` builtin, and cannot
execute until the runtime (sforge/nodes) bumps to a `TXTYPE`-capable `seismic-revm`. Kept as
a draft until:
1. seismic-revm #224 merges,
2. seismic-solidity `txtype()` builtin merges + new `ssolc` released,
3. seismic-foundry/reth bump their `seismic-revm` pins + release.

## Follow-up before un-drafting
Add a runtime integration test (submits a real signed `0x4A` tx and a legacy tx against a
deployed contract using the helper; asserts `(74, true)` vs `(0, false)`). The current
`TxUtils.t.sol` is a compile/execute smoke test only. See TXTYPE_REVIEW_HANDOFF.md.
