### PR TITLE
fix(clients)!: domain-separate request/response AES traffic keys

### DIFF
--- a/clients/py/src/seismic_web3/client.py
+++ b/clients/py/src/seismic_web3/client.py
@@ -22,7 +22,7 @@ from web3 import AsyncHTTPProvider, AsyncWeb3, Web3, WebSocketProvider
 
 from seismic_web3._types import Bytes32, CompressedPublicKey, PrivateKey
 from seismic_web3.crypto.aes import AesGcmCrypto
-from seismic_web3.crypto.ecdh import generate_aes_key
+from seismic_web3.crypto.ecdh import AesKeyDomain, generate_aes_key
 from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3.module import (
     AsyncSeismicNamespace,
@@ -42,24 +42,28 @@ if TYPE_CHECKING:
 
 @dataclass
 class EncryptionState:
-    """Holds the AES key and encryption keypair derived from ECDH.
+    """Holds directional AES keys and the encryption keypair derived from ECDH.
 
-    Created by :func:`get_encryption` during client setup.  Pure
+    Created by :func:`get_encryption` during client setup. Pure
     computation - works in both sync and async contexts.
 
     Attributes:
-        aes_key: 32-byte AES-256 key derived from ECDH + HKDF.
+        aes_key: Request AES-256 key used to encrypt calldata.
+        response_aes_key: Response AES-256 key used to decrypt signed reads.
         encryption_pubkey: Client's compressed secp256k1 public key.
         encryption_private_key: Client's secp256k1 private key.
     """
 
     aes_key: Bytes32
+    response_aes_key: Bytes32
     encryption_pubkey: CompressedPublicKey
     encryption_private_key: PrivateKey
-    _crypto: AesGcmCrypto = field(init=False, repr=False, compare=False)
+    _request_crypto: AesGcmCrypto = field(init=False, repr=False, compare=False)
+    _response_crypto: AesGcmCrypto = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        self._crypto = AesGcmCrypto(self.aes_key)
+        self._request_crypto = AesGcmCrypto(self.aes_key)
+        self._response_crypto = AesGcmCrypto(self.response_aes_key)
 
     def encrypt(
         self,
@@ -67,7 +71,7 @@ class EncryptionState:
         nonce: EncryptionNonce,
         metadata: TxSeismicMetadata,
     ) -> HexBytes:
-        """Encrypt plaintext calldata with metadata-bound AAD.
+        """Encrypt plaintext calldata with the request key and metadata-bound AAD.
 
         Args:
             plaintext: Raw calldata to encrypt.
@@ -78,7 +82,7 @@ class EncryptionState:
             Ciphertext with 16-byte authentication tag.
         """
         aad = encode_metadata_as_aad(metadata)
-        return self._crypto.encrypt(plaintext, nonce, aad)
+        return self._request_crypto.encrypt(plaintext, nonce, aad)
 
     def decrypt(
         self,
@@ -86,7 +90,7 @@ class EncryptionState:
         nonce: EncryptionNonce,
         metadata: TxSeismicMetadata,
     ) -> HexBytes:
-        """Decrypt ciphertext with metadata-bound AAD.
+        """Decrypt signed-read ciphertext with the response key and metadata-bound AAD.
 
         Args:
             ciphertext: Encrypted data (includes auth tag).
@@ -100,14 +104,14 @@ class EncryptionState:
             cryptography.exceptions.InvalidTag: If authentication fails.
         """
         aad = encode_metadata_as_aad(metadata)
-        return self._crypto.decrypt(ciphertext, nonce, aad)
+        return self._response_crypto.decrypt(ciphertext, nonce, aad)
 
 
 def get_encryption(
     network_pk: CompressedPublicKey,
     client_sk: PrivateKey | None = None,
 ) -> EncryptionState:
-    """Derive encryption state from a TEE public key.
+    """Derive direction-separated encryption state from a TEE public key.
 
     Pure computation (no I/O).  If ``client_sk`` is not provided,
     a random ephemeral private key is generated.
@@ -123,11 +127,21 @@ def get_encryption(
     if client_sk is None:
         client_sk = PrivateKey(os.urandom(32))
 
-    aes_key = generate_aes_key(client_sk, network_pk)
+    aes_key = generate_aes_key(
+        client_sk,
+        network_pk,
+        AesKeyDomain.TX_REQUEST,
+    )
+    response_aes_key = generate_aes_key(
+        client_sk,
+        network_pk,
+        AesKeyDomain.TX_RESPONSE,
+    )
     client_pubkey = private_key_to_compressed_public_key(client_sk)
 
     return EncryptionState(
         aes_key=aes_key,
+        response_aes_key=response_aes_key,
         encryption_pubkey=client_pubkey,
         encryption_private_key=client_sk,
     )

--- a/clients/py/src/seismic_web3/crypto/ecdh.py
+++ b/clients/py/src/seismic_web3/crypto/ecdh.py
@@ -9,12 +9,14 @@ Implements the Seismic key derivation pipeline:
 3. **HKDF-SHA256** — standard key derivation to produce a 32-byte
    AES-256 key (``cryptography`` / OpenSSL backend).
 
-The full pipeline is exposed as :func:`generate_aes_key`.
+The full pipeline is exposed as :func:`generate_aes_key`, parameterized by
+:class:`AesKeyDomain`.
 """
 
 from __future__ import annotations
 
 import hashlib
+from enum import Enum
 
 from coincurve import PublicKey as _CoincurvePublicKey
 from cryptography.hazmat.primitives.hashes import SHA256
@@ -22,8 +24,29 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from seismic_web3._types import Bytes32, CompressedPublicKey, PrivateKey
 
-#: HKDF info string matching the Rust / TypeScript implementations.
-_HKDF_INFO = b"aes-gcm key"
+
+class AesKeyDomain(str, Enum):
+    """Domain-separation labels for AES keys derived from an ECDH secret.
+
+    HKDF info labels must match the Rust ``AesKeyDomain`` enum (in
+    seismic-crypto); keys from different domains are independent.
+    """
+
+    #: Client-to-TEE transaction I/O: encrypted calldata, signed-read requests.
+    TX_REQUEST = "tx-request"
+    #: TEE-to-client transaction I/O: signed-read return data.
+    TX_RESPONSE = "tx-response"
+    #: The on-chain ECDH precompile's derivation (consensus-frozen label).
+    ECDH_PRECOMPILE = "ecdh-precompile"
+
+
+_DOMAIN_HKDF_INFO = {
+    # Request keeps the original "aes-gcm key" label for backward compat;
+    # only the response moved to a new one. See the Rust AesKeyDomain enum.
+    AesKeyDomain.TX_REQUEST: b"aes-gcm key",
+    AesKeyDomain.TX_RESPONSE: b"seismic/response/aes-256-gcm/v1",
+    AesKeyDomain.ECDH_PRECOMPILE: b"aes-gcm key",
+}
 
 
 def shared_secret_point(
@@ -69,46 +92,42 @@ def shared_key_from_point(shared_secret: bytes) -> Bytes32:
     return Bytes32(digest)
 
 
-def derive_aes_key(shared_key: Bytes32) -> Bytes32:
-    """HKDF-SHA256 key derivation.
-
-    Derives a 32-byte AES-256 key from the shared key using HKDF
-    with an empty salt and ``info=b"aes-gcm key"``.
+def derive_aes_key(shared_key: Bytes32, domain: AesKeyDomain) -> Bytes32:
+    """Derive a domain-separated AES-256 key via HKDF-SHA256.
 
     Uses the ``cryptography`` library (OpenSSL backend).
 
     Args:
         shared_key: 32-byte input key material (from :func:`shared_key_from_point`).
+        domain: The protocol context the key is for.
 
     Returns:
-        32-byte AES-256 key.
+        32-byte AES-256 key, independent per domain.
     """
     hkdf = HKDF(
         algorithm=SHA256(),
         length=32,
         salt=None,
-        info=_HKDF_INFO,
+        info=_DOMAIN_HKDF_INFO[domain],
     )
-    derived = hkdf.derive(bytes(shared_key))
-    return Bytes32(derived)
+    return Bytes32(hkdf.derive(bytes(shared_key)))
 
 
 def generate_aes_key(
     private_key: PrivateKey,
     network_public_key: CompressedPublicKey,
+    domain: AesKeyDomain,
 ) -> Bytes32:
     """Full pipeline: ECDH → shared_key_from_point → HKDF → AES-256 key.
-
-    This is the main entry point for deriving the AES encryption key
-    used to encrypt ``TxSeismic`` calldata.
 
     Args:
         private_key: 32-byte local (encryption) private key.
         network_public_key: 33-byte compressed TEE public key.
+        domain: The protocol context the key is for.
 
     Returns:
-        32-byte AES-256 key ready for AES-GCM encryption.
+        32-byte AES-256 key, independent per domain.
     """
     point = shared_secret_point(private_key, network_public_key)
     shared = shared_key_from_point(point)
-    return derive_aes_key(shared)
+    return derive_aes_key(shared, domain)

--- a/clients/py/tests/integration/test_precompiles.py
+++ b/clients/py/tests/integration/test_precompiles.py
@@ -8,6 +8,7 @@ import pytest
 from web3 import AsyncWeb3, Web3
 
 from seismic_web3._types import Bytes32, PrivateKey
+from seismic_web3.crypto.ecdh import AesKeyDomain, generate_aes_key
 from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3.precompiles import (
     aes_gcm_decrypt,
@@ -70,14 +71,12 @@ class TestEcdh:
 
     def test_matches_client_side(self, w3: Web3):
         """On-chain ECDH should produce the same result as client-side."""
-        from seismic_web3.crypto.ecdh import generate_aes_key
-
         sk = PrivateKey(b"\x01" * 32)
         other_sk = PrivateKey(b"\x02" * 32)
         pk = private_key_to_compressed_public_key(other_sk)
 
         on_chain = ecdh(w3, sk=sk, pk=pk)
-        client_side = generate_aes_key(sk, pk)
+        client_side = generate_aes_key(sk, pk, AesKeyDomain.ECDH_PRECOMPILE)
 
         # The on-chain ECDH precompile does ECDH + HKDF together,
         # which matches the client-side generate_aes_key pipeline.

--- a/clients/py/tests/test_client.py
+++ b/clients/py/tests/test_client.py
@@ -19,8 +19,10 @@ from seismic_web3.client import (
     create_wallet_client,
     get_encryption,
 )
+from seismic_web3.crypto.aes import AesGcmCrypto
 from seismic_web3.crypto.secp import private_key_to_compressed_public_key
 from seismic_web3.module import SeismicPublicNamespace
+from seismic_web3.transaction.aead import encode_metadata_as_aad
 from seismic_web3.transaction_types import (
     LegacyFields,
     SeismicElements,
@@ -34,16 +36,22 @@ _NETWORK_PK = CompressedPublicKey(
 _CLIENT_SK = PrivateKey(
     "0xa30363336e1bb949185292a2a302de86e447d98f3a43d823c8c234d9e3e5ad77"
 )
-_EXPECTED_AES_KEY = Bytes32(
+# Request keeps the original "aes-gcm key" label; only the response is new.
+_EXPECTED_REQUEST_AES_KEY = Bytes32(
     "0xbf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90"
+)
+_EXPECTED_RESPONSE_AES_KEY = Bytes32(
+    "0x974b310e3990d555da33e2b0c1dc6036a9709400ec992dbfc9330cc00e673144"
 )
 
 
 class TestGetEncryption:
     def test_deterministic_with_known_keys(self):
-        """get_encryption with a fixed client key produces the expected AES key."""
+        """Fixed ECDH inputs produce the expected directional AES keys."""
         state = get_encryption(_NETWORK_PK, _CLIENT_SK)
-        assert state.aes_key == _EXPECTED_AES_KEY
+        assert state.aes_key == _EXPECTED_REQUEST_AES_KEY
+        assert state.response_aes_key == _EXPECTED_RESPONSE_AES_KEY
+        assert state.aes_key != state.response_aes_key
 
     def test_returns_encryption_state(self):
         state = get_encryption(_NETWORK_PK, _CLIENT_SK)
@@ -90,19 +98,26 @@ class TestEncryptionState:
             ),
         )
 
-    def test_encrypt_decrypt_round_trip(self):
-        """Encrypting then decrypting should return the original plaintext."""
+    def test_directional_request_and_response_round_trips(self):
+        """Each traffic direction uses its matching independent AES key."""
         state = get_encryption(_NETWORK_PK, _CLIENT_SK)
         metadata = self._make_metadata()
         nonce = EncryptionNonce("0x46a2b6020bba77fcb1e676a6")
-        plaintext = HexBytes(b"Hello Seismic!")
+        request_plaintext = HexBytes(b"request data")
+        response_plaintext = HexBytes(b"response data")
+        aad = encode_metadata_as_aad(metadata)
 
-        ciphertext = state.encrypt(plaintext, nonce, metadata)
-        assert ciphertext != plaintext
-        assert len(ciphertext) > len(plaintext)  # includes auth tag
+        encrypted_request = state.encrypt(request_plaintext, nonce, metadata)
+        tee_request_crypto = AesGcmCrypto(state.aes_key)
+        assert (
+            tee_request_crypto.decrypt(encrypted_request, nonce, aad)
+            == request_plaintext
+        )
 
-        decrypted = state.decrypt(ciphertext, nonce, metadata)
-        assert bytes(decrypted) == bytes(plaintext)
+        tee_response_crypto = AesGcmCrypto(state.response_aes_key)
+        encrypted_response = tee_response_crypto.encrypt(response_plaintext, nonce, aad)
+        assert state.decrypt(encrypted_response, nonce, metadata) == response_plaintext
+        assert encrypted_request != encrypted_response
 
     def test_encrypt_empty_data(self):
         """Encrypting empty data returns empty data."""

--- a/clients/py/tests/test_crypto.py
+++ b/clients/py/tests/test_crypto.py
@@ -9,6 +9,7 @@ from coincurve import PublicKey as _CoincurvePublicKey
 
 from seismic_web3._types import Bytes32, CompressedPublicKey, PrivateKey
 from seismic_web3.crypto.ecdh import (
+    AesKeyDomain,
     derive_aes_key,
     generate_aes_key,
     shared_key_from_point,
@@ -46,6 +47,13 @@ EXPECTED_SHARED_KEY_HEX = (
 EXPECTED_AES_KEY_HEX = (
     "0xbf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90"
 )
+# Equal to EXPECTED_AES_KEY_HEX: request keeps the original "aes-gcm key" label.
+EXPECTED_REQUEST_AES_KEY_HEX = (
+    "0xbf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90"
+)
+EXPECTED_RESPONSE_AES_KEY_HEX = (
+    "0x974b310e3990d555da33e2b0c1dc6036a9709400ec992dbfc9330cc00e673144"
+)
 
 # Private key whose compressed public key matches TEE_PK.
 KEYGEN_SK_HEX = "0x311d54d3bf8359c70827122a44a7b4458733adce3c51c6b59d9acfce85e07505"
@@ -74,18 +82,33 @@ class TestSharedKeyFromPoint:
 
 
 class TestDeriveAesKey:
-    def test_known_vector(self):
+    def test_known_vectors_per_domain(self):
         shared_key = Bytes32(EXPECTED_SHARED_KEY_HEX)
-        aes_key = derive_aes_key(shared_key)
-        assert isinstance(aes_key, Bytes32)
-        assert aes_key.to_0x_hex() == EXPECTED_AES_KEY_HEX
+        precompile_key = derive_aes_key(shared_key, AesKeyDomain.ECDH_PRECOMPILE)
+        request_key = derive_aes_key(shared_key, AesKeyDomain.TX_REQUEST)
+        response_key = derive_aes_key(shared_key, AesKeyDomain.TX_RESPONSE)
+
+        assert isinstance(precompile_key, Bytes32)
+        assert precompile_key.to_0x_hex() == EXPECTED_AES_KEY_HEX
+        assert request_key.to_0x_hex() == EXPECTED_REQUEST_AES_KEY_HEX
+        assert response_key.to_0x_hex() == EXPECTED_RESPONSE_AES_KEY_HEX
+        assert request_key != response_key
 
 
 class TestGenerateAesKey:
-    def test_full_pipeline(self):
-        aes_key = generate_aes_key(ENC_SK, TEE_PK)
-        assert isinstance(aes_key, Bytes32)
-        assert aes_key.to_0x_hex() == EXPECTED_AES_KEY_HEX
+    def test_full_pipeline_per_domain(self):
+        precompile_key = generate_aes_key(
+            ENC_SK,
+            TEE_PK,
+            AesKeyDomain.ECDH_PRECOMPILE,
+        )
+        request_key = generate_aes_key(ENC_SK, TEE_PK, AesKeyDomain.TX_REQUEST)
+        response_key = generate_aes_key(ENC_SK, TEE_PK, AesKeyDomain.TX_RESPONSE)
+
+        assert isinstance(precompile_key, Bytes32)
+        assert precompile_key.to_0x_hex() == EXPECTED_AES_KEY_HEX
+        assert request_key.to_0x_hex() == EXPECTED_REQUEST_AES_KEY_HEX
+        assert response_key.to_0x_hex() == EXPECTED_RESPONSE_AES_KEY_HEX
 
 
 # ---------------------------------------------------------------------------

--- a/clients/ts/packages/seismic-encrypt/src/index.ts
+++ b/clients/ts/packages/seismic-encrypt/src/index.ts
@@ -59,7 +59,14 @@ const toYParitySignatureArray = (signature?: {
 
 // ── Key derivation ──────────────────────────────────────────────────
 
-const deriveAesKey = (privateKey: Hex, networkPublicKey: string): Hex => {
+// Only the request key: this package encrypts write-tx calldata and never
+// decrypts TEE responses. The request uses the original "aes-gcm key" label.
+// A signed-read feature would need the response label
+// ("seismic/response/aes-256-gcm/v1") as well.
+const deriveRequestAesKey = (
+  privateKey: Hex,
+  networkPublicKey: string
+): Hex => {
   const privHex = privateKey.startsWith('0x') ? privateKey.slice(2) : privateKey
   const sharedPoint = secp256k1
     .getSharedSecret(privHex, networkPublicKey, false)
@@ -280,7 +287,7 @@ export const encryptSeismicTx = async ({
 
   // 2. Derive encryption keys
   const encPrivKey = encryptionPrivateKey ?? generatePrivateKey()
-  const aesKey = deriveAesKey(encPrivKey, teePubkey)
+  const aesKey = deriveRequestAesKey(encPrivKey, teePubkey)
   const uncompressedPk = privateKeyToAccount(encPrivKey).publicKey
   const encPubkey = compressPublicKey(uncompressedPk)
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/aesKeygen.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/aesKeygen.ts
@@ -1,5 +1,6 @@
 import { expect } from 'bun:test'
 import {
+  AesKeyDomain,
   deriveAesKey,
   sharedKeyFromPoint,
   sharedSecretPoint,
@@ -23,8 +24,23 @@ export const testAesKeygen = () => {
   expect(sharedSecret).toBe(
     '46a4d6fce8eca748ba8362e726de51a5c62202c887d6bb81fa6f4df1fb360999'
   )
-  const aesKey = deriveAesKey(sharedSecret)
-  expect(aesKey).toBe(
+  const precompileAesKey = deriveAesKey(
+    sharedSecret,
+    AesKeyDomain.EcdhPrecompile
+  )
+  expect(precompileAesKey).toBe(
     '0xbf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90'
   )
+
+  // Equal to precompileAesKey: request keeps the original "aes-gcm key" label.
+  const requestAesKey = deriveAesKey(sharedSecret, AesKeyDomain.TxRequest)
+  expect(requestAesKey).toBe(
+    '0xbf0dd6556618d1bf8d1602bf80be3a0f7cc729973829bb9acb75bd77770d5b90'
+  )
+
+  const responseAesKey = deriveAesKey(sharedSecret, AesKeyDomain.TxResponse)
+  expect(responseAesKey).toBe(
+    '0x974b310e3990d555da33e2b0c1dc6036a9709400ec992dbfc9330cc00e673144'
+  )
+  expect(requestAesKey).not.toBe(responseAesKey)
 }

--- a/clients/ts/packages/seismic-viem-tests/src/tests/precompiles.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/precompiles.ts
@@ -1,6 +1,6 @@
 import { expect } from 'bun:test'
 import { createShieldedPublicClient } from 'seismic-viem'
-import { generateAesKey } from 'seismic-viem'
+import { AesKeyDomain, generateAesKey } from 'seismic-viem'
 import { compressPublicKey } from 'seismic-viem'
 import { Chain, hexToBytes, http, recoverMessageAddress } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
@@ -47,10 +47,13 @@ export const testEcdh = async ({ chain, url }: PublicClientConfig) => {
   const pk2 = compressPublicKey(privateKeyToAccount(sk2).publicKey)
   const sharedSecret = await publicClient.ecdh({ sk: sk1, pk: pk2 })
   const ssBytes = hexToBytes(sharedSecret)
-  const expected = generateAesKey({
-    privateKey: sk1,
-    networkPublicKey: pk2.slice(2),
-  })
+  const expected = generateAesKey(
+    {
+      privateKey: sk1,
+      networkPublicKey: pk2.slice(2),
+    },
+    AesKeyDomain.EcdhPrecompile
+  )
   expect(ssBytes.length).toBe(32)
   expect(sharedSecret).toBe(expected)
 }

--- a/clients/ts/packages/seismic-viem/src/actions/encryption.ts
+++ b/clients/ts/packages/seismic-viem/src/actions/encryption.ts
@@ -6,6 +6,7 @@ import type { TxSeismicMetadata } from '@sviem/tx/metadata.ts'
 
 export type EncryptionActions = {
   getEncryption: () => Hex
+  getResponseEncryption: () => Hex
   getEncryptionPublicKey: () => Hex
   encrypt: (
     plaintext: Hex | undefined,
@@ -18,17 +19,19 @@ export type EncryptionActions = {
 }
 
 export const encryptionActions = (
-  encryption: Hex,
+  requestEncryption: Hex,
+  responseEncryption: Hex,
   encryptionPublicKey: Hex
 ): EncryptionActions => {
   return {
-    getEncryption: () => encryption,
+    getEncryption: () => requestEncryption,
+    getResponseEncryption: () => responseEncryption,
     getEncryptionPublicKey: () => encryptionPublicKey,
     encrypt: async (
       plaintext: Hex | undefined,
       metadata: TxSeismicMetadata
     ) => {
-      const aesCipher = new AesGcmCrypto(encryption)
+      const aesCipher = new AesGcmCrypto(requestEncryption)
       const aad = encodeSeismicMetadataAsAAD(metadata)
       const ciphertext = await aesCipher.encrypt(
         plaintext,
@@ -41,7 +44,7 @@ export const encryptionActions = (
       ciphertext: Hex | undefined,
       metadata: TxSeismicMetadata
     ) => {
-      const aesCipher = new AesGcmCrypto(encryption)
+      const aesCipher = new AesGcmCrypto(responseEncryption)
       const aad = encodeSeismicMetadataAsAAD(metadata)
       return await aesCipher.decrypt(
         ciphertext,

--- a/clients/ts/packages/seismic-viem/src/client.ts
+++ b/clients/ts/packages/seismic-viem/src/client.ts
@@ -27,7 +27,7 @@ import type { ShieldedPublicActions } from '@sviem/actions/public.ts'
 import { shieldedPublicActions } from '@sviem/actions/public.ts'
 import type { ShieldedWalletActions } from '@sviem/actions/wallet.ts'
 import { shieldedWalletActions } from '@sviem/actions/wallet.ts'
-import { generateAesKey } from '@sviem/crypto/aes.ts'
+import { AesKeyDomain, generateAesKey } from '@sviem/crypto/aes.ts'
 import { compressPublicKey } from '@sviem/crypto/secp.ts'
 import type {
   DepositContractPublicActions,
@@ -158,27 +158,40 @@ export type GetSeismicClientsParameters<
 }
 
 /**
- * Returns an AES key and its input keys
+ * Returns direction-separated AES traffic keys and their input keys.
  *
  * @param networkPk - The network's encryption public key (secp256k1)
  * @param clientSk - Optionally, the user's encryption private key. If not provided, this function will generate one
- * @returns {Object} An object with 3 fields:
- *   - `aesKey` (string) - The AES key used to encrypt calldata
+ * @returns {Object} An object with 4 fields:
+ *   - `aesKey` (string) - The request AES key used to encrypt calldata
+ *   - `responseAesKey` (string) - The response AES key used to decrypt signed-read results
  *   - `encryptionPrivateKey` (string) - Either `clientSk` if it was provided. Otherwise a newly generated secp256k1 private key
  *   - `encryptionPublicKey` (string) - The corresponding secp256k1 public key
  */
 export const getEncryption = (
   networkPk: string,
   clientSk?: Hex | undefined
-): { aesKey: Hex; encryptionPrivateKey: Hex; encryptionPublicKey: Hex } => {
+): {
+  aesKey: Hex
+  responseAesKey: Hex
+  encryptionPrivateKey: Hex
+  encryptionPublicKey: Hex
+} => {
   const encryptionPrivateKey = clientSk ?? generatePrivateKey()
-  const aesKey = generateAesKey({
+  const aesInputs = {
     privateKey: encryptionPrivateKey,
     networkPublicKey: networkPk,
-  })
+  }
+  const aesKey = generateAesKey(aesInputs, AesKeyDomain.TxRequest)
+  const responseAesKey = generateAesKey(aesInputs, AesKeyDomain.TxResponse)
   const uncompressedPk = privateKeyToAccount(encryptionPrivateKey).publicKey
   const encryptionPublicKey = compressPublicKey(uncompressedPk)
-  return { encryptionPrivateKey, encryptionPublicKey, aesKey }
+  return {
+    encryptionPrivateKey,
+    encryptionPublicKey,
+    aesKey,
+    responseAesKey,
+  }
 }
 
 /**
@@ -247,7 +260,7 @@ export const getSeismicClients = async <
     }))
 
   const networkPublicKey = await pubClient.getTeePublicKey()
-  const { aesKey, encryptionPublicKey } = getEncryption(
+  const { aesKey, responseAesKey, encryptionPublicKey } = getEncryption(
     networkPublicKey,
     encryptionSk
   )
@@ -262,7 +275,9 @@ export const getSeismicClients = async <
     // @ts-ignore
     .extend(() => publicActions(pubClient))
     // @ts-ignore
-    .extend(() => encryptionActions(aesKey, encryptionPublicKey))
+    .extend(() =>
+      encryptionActions(aesKey, responseAesKey, encryptionPublicKey)
+    )
     // @ts-ignore
     .extend(() => shieldedPublicActions(pubClient))
     // @ts-ignore

--- a/clients/ts/packages/seismic-viem/src/crypto/aes.ts
+++ b/clients/ts/packages/seismic-viem/src/crypto/aes.ts
@@ -148,18 +148,53 @@ export const generateSharedKey = (inputs: AesInputKeys): string => {
   return sharedKeyFromPoint(sharedSecret)
 }
 
-export const deriveAesKey = (sharedSecret: string): Hex => {
+/**
+ * Domain-separation labels for AES keys derived from an ECDH shared secret.
+ * HKDF info labels must match the Rust `AesKeyDomain` enum (in
+ * seismic-crypto); keys from different domains are independent.
+ */
+export const AesKeyDomain = {
+  /** Client-to-TEE transaction I/O: encrypted calldata, signed-read requests */
+  TxRequest: 'tx-request',
+  /** TEE-to-client transaction I/O: signed-read return data */
+  TxResponse: 'tx-response',
+  /** The on-chain ECDH precompile's derivation (consensus-frozen label) */
+  EcdhPrecompile: 'ecdh-precompile',
+} as const
+
+export type AesKeyDomain = (typeof AesKeyDomain)[keyof typeof AesKeyDomain]
+
+const DOMAIN_HKDF_INFO: Record<AesKeyDomain, string> = {
+  // Request keeps the original 'aes-gcm key' label for backward compat;
+  // only the response moved to a new one. See the Rust AesKeyDomain enum.
+  [AesKeyDomain.TxRequest]: 'aes-gcm key',
+  [AesKeyDomain.TxResponse]: 'seismic/response/aes-256-gcm/v1',
+  [AesKeyDomain.EcdhPrecompile]: 'aes-gcm key',
+}
+
+/**
+ * Derive a domain-separated AES-256 key from an ECDH shared secret using
+ * HKDF-SHA256.
+ */
+export const deriveAesKey = (
+  sharedSecret: string,
+  domain: AesKeyDomain
+): Hex => {
   const derivedKey = hkdf(
-    sha256, // Hash function
+    sha256,
     hexToBytes(`0x${sharedSecret}`),
-    new Uint8Array(0), // Salt
-    new TextEncoder().encode('aes-gcm key'), // Info (optional context string)
-    32 // Output length (32 bytes for AES-256)
+    new Uint8Array(0),
+    new TextEncoder().encode(DOMAIN_HKDF_INFO[domain]),
+    32
   )
   return bytesToHex(derivedKey)
 }
 
-export const generateAesKey = (aesKeys: AesInputKeys): Hex => {
+/** Run ECDH and derive a domain-separated AES-256 key. */
+export const generateAesKey = (
+  aesKeys: AesInputKeys,
+  domain: AesKeyDomain
+): Hex => {
   const sharedSecret = generateSharedKey(aesKeys)
-  return deriveAesKey(sharedSecret)
+  return deriveAesKey(sharedSecret, domain)
 }

--- a/clients/ts/packages/seismic-viem/src/index.ts
+++ b/clients/ts/packages/seismic-viem/src/index.ts
@@ -103,6 +103,7 @@ export {
 export { compressPublicKey } from '@sviem/crypto/secp.ts'
 export { encodeSeismicMetadataAsAAD } from '@sviem/crypto/aead.ts'
 export {
+  AesKeyDomain,
   AesGcmCrypto,
   generateAesKey,
   deriveAesKey,


### PR DESCRIPTION
Part of the AES key domain-separation fix; see
https://github.com/SeismicSystems/enclave/pull/210

> ⚠️ this should only be merged once we have updated our testnet

Adopt the domain-separated AES key schedule (AesKeyDomain, from seismic-crypto) in the Python and TypeScript clients so a signed read's request and response derive independent traffic keys. They share one public nonce; previously both directions used the same key, reusing an AES-GCM (key, nonce) pair and allowing plaintext recovery.

No consensus break: the request path keeps the original "aes-gcm key" label (TxRequest); only the response direction moves to a fresh "seismic/response/aes-256-gcm/v1" label (TxResponse). That difference alone closes the reuse.

Python (seismic_web3):
- crypto/ecdh.py: add AesKeyDomain + per-domain HKDF labels; derive_aes_key / generate_aes_key take a domain.
- client.py: EncryptionState now holds aes_key (request) and response_aes_key with separate request/response ciphers; get_encryption derives both.

TypeScript (seismic-viem):
- crypto/aes.ts: add AesKeyDomain + DOMAIN_HKDF_INFO and a domain arg to deriveAesKey; index.ts re-exports AesKeyDomain.
- client.ts / actions/encryption.ts: getEncryption returns aesKey + responseAesKey; encrypt uses the request key, decrypt uses the response key.
- seismic-encrypt: request encryption uses the "aes-gcm key" label.