### PR TITLE
ci: standardize sfoundry installation with sfoundryup

### DIFF
--- a/.github/actions/setup-sfoundry/action.yml
+++ b/.github/actions/setup-sfoundry/action.yml
@@ -1,0 +1,37 @@
+name: Setup sfoundry
+description: Install an sfoundry release channel with sfoundryup
+
+inputs:
+  channel:
+    description: sfoundry release channel to install
+    required: false
+    default: nightly
+
+outputs:
+  sanvil-path:
+    description: Absolute path to the installed sanvil binary
+    value: ${{ steps.install.outputs.sanvil-path }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      name: Install sfoundry (${{ inputs.channel }})
+      shell: bash
+      env:
+        SFOUNDRY_CHANNEL: ${{ inputs.channel }}
+      run: |
+        case "$SFOUNDRY_CHANNEL" in
+          stable|nightly) ;;
+          *)
+            echo "Unsupported sfoundry channel: $SFOUNDRY_CHANNEL" >&2
+            exit 1
+            ;;
+        esac
+
+        curl -fsSL https://raw.githubusercontent.com/SeismicSystems/seismic-foundry/seismic/foundryup/install | bash
+        SEISMIC_BIN="${XDG_CONFIG_HOME:-$HOME}/.seismic/bin"
+        "$SEISMIC_BIN/sfoundryup" --install "$SFOUNDRY_CHANNEL"
+        "$SEISMIC_BIN/sanvil" --version
+        echo "$SEISMIC_BIN" >> "$GITHUB_PATH"
+        echo "sanvil-path=$SEISMIC_BIN/sanvil" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/client-py.yml
+++ b/.github/workflows/client-py.yml
@@ -3,9 +3,15 @@ name: Python Client
 on:
   push:
     branches: [main]
-    paths: ["clients/py/**"]
+    paths:
+      - "clients/py/**"
+      - ".github/workflows/client-py.yml"
+      - ".github/actions/setup-sfoundry/**"
   pull_request:
-    paths: ["clients/py/**"]
+    paths:
+      - "clients/py/**"
+      - ".github/workflows/client-py.yml"
+      - ".github/actions/setup-sfoundry/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,19 +75,12 @@ jobs:
           enable-cache: true
       - run: uv sync --locked --dev
 
-      - name: Download sanvil from seismic-foundry nightly
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download nightly \
-            -R SeismicSystems/seismic-foundry \
-            -p 'sfoundry_nightly_linux_amd64.tar.gz' \
-            -D /tmp
-          mkdir -p "$HOME/.seismic/bin"
-          tar xzf /tmp/sfoundry_nightly_linux_amd64.tar.gz -C "$HOME/.seismic/bin" sanvil
-          chmod +x "$HOME/.seismic/bin/sanvil"
+      - id: sfoundry
+        uses: ./.github/actions/setup-sfoundry
+        with:
+          channel: nightly
 
       - name: Run integration tests
         env:
-          SANVIL_BIN: ~/.seismic/bin/sanvil
+          SANVIL_BIN: ${{ steps.sfoundry.outputs.sanvil-path }}
         run: uv run pytest tests/integration/ -v

--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -3,9 +3,19 @@ name: Typescript Client
 on:
   push:
     branches: ["main"]
-    paths: ["clients/ts/**"]
+    paths:
+      - "clients/ts/**"
+      - "mise.toml"
+      - "pitchfork.toml"
+      - ".github/workflows/client-ts.yml"
+      - ".github/actions/setup-sfoundry/**"
   pull_request:
-    paths: ["clients/ts/**"]
+    paths:
+      - "clients/ts/**"
+      - "mise.toml"
+      - "pitchfork.toml"
+      - ".github/workflows/client-ts.yml"
+      - ".github/actions/setup-sfoundry/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
+        with:
+          install_args: bun
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
@@ -40,12 +52,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v2
+        with:
+          install_args: bun pitchfork
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('clients/ts/bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
+      - uses: ./.github/actions/setup-sfoundry
+        with:
+          channel: nightly
       - run: mise run test::integration::sanvil
 
   test-sreth:
@@ -65,6 +82,7 @@ jobs:
       - uses: jdx/mise-action@v2
         with:
           working_directory: seismic
+          install_args: bun pitchfork
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ code seismic/workspace/seismic.code-workspace
 
 ### Dev Env
 
-We use mise to manage our dev environment, including dependency version management and running common tasks. It is not mandatory to use mise, but we recommend it for ease of use and consistency. Start by [installing mise](https://mise.jdx.dev/getting-started.html), and then run `mise install`. This will install the latest version of the Seismic Dev Environment, which includes all the tools you need to build and test Seismic (sforge, sanvil, scast, ssolc, etc.). It will also set up your PATH so that you can run these tools from anywhere inside the repo. Make sure to take a look at comments inside the various `mise.toml` files across the repos, and run `mise run` from anywhere to see the tasks available in that subdir.
+We use mise to manage supporting tools and run common tasks. It is not mandatory to use mise, but we recommend it for ease of use and consistency. Start by [installing mise](https://mise.jdx.dev/getting-started.html), then run `mise install`. Install the Seismic Foundry toolchain (`sforge`, `sanvil`, and `scast`) separately with [`sfoundryup`](docs/gitbook/getting-started/installation.md). Both installers set up your PATH so the tools are available inside the repo. Make sure to take a look at comments inside the various `mise.toml` files across the repos, and run `mise run` from anywhere to see the tasks available in that subdir.
 
 ![](assets/mise-demo.gif)
 

--- a/clients/ts/CLAUDE.md
+++ b/clients/ts/CLAUDE.md
@@ -64,7 +64,7 @@ mise run test::integration::sreth   # builds & starts reth, runs tests, stops re
 
 ```bash
 # Terminal 1: start a node
-sanvil                    # or: mise run anvil::start (from seismic/ root)
+sanvil                    # or: mise run sanvil::start (from seismic/ root)
 
 # Terminal 2: run tests
 bun run viem:test         # connects to http://127.0.0.1:8545 by default
@@ -74,7 +74,7 @@ bun run viem:test         # connects to http://127.0.0.1:8545 by default
 - `RPC_URL` — HTTP RPC URL (default: `http://127.0.0.1:8545`)
 - `WS_URL` — WebSocket URL (default: derived from `RPC_URL` by replacing `http` with `ws`)
 
-**Anvil tests** require `sanvil` on PATH (install via `mise` or `sfoundryup`).
+**Anvil tests** require `sanvil` on PATH (install via `sfoundryup`).
 
 **Reth tests** require `SRETH_ROOT` pointing to a [seismic-reth](https://github.com/SeismicSystems/seismic-reth) checkout (or defaulting to `../../seismic-reth`).
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,4 @@
 [tools]
-# Downloads the latest nightly release: https://github.com/SeismicSystems/seismic-foundry/releases/tag/nightly
-# We run a cron job that releases a new nightly version once per week, so this will always be up to date.
-# Just make sure to `mise install` at least weekly to get the latest version.
-# The release tarball contains sforge, sanvil, scast, and schisel — all added to PATH.
-# TODO(samlaf): we might want to move to use sfoundryup now that it also downloads releases (both versioned and nightlies).
-sfoundry = "nightly"
-
 # Downloads this release: https://github.com/SeismicSystems/seismic-solidity/releases/tag/2ebb36d
 # This is likely not needed in most cases as compilation should be done via sforge which manages its own ssolc.
 # However, this can be useful if we want to test with a different version of ssolc than the one that sforge manages.
@@ -19,7 +12,6 @@ bun = "1.3.9"
 pitchfork = "latest"
 
 [tool_alias]
-sfoundry = "github:SeismicSystems/seismic-foundry"
 ssolc = "github:SeismicSystems/seismic-solidity"
 
 ###################################### TASKS ####################################


### PR DESCRIPTION
Add a shared setup action for installing stable or nightly sfoundry releases and use it in the TypeScript and Python integration jobs.

Remove sfoundry from Mise so cached moving nightly aliases cannot shadow the explicitly installed release. Keep Mise responsible for Bun, Pitchfork, and other supporting tools, and update the development docs.