### PR TITLE
chore(vscode): cleanup folders

### DIFF
--- a/workspace/seismic.code-workspace
+++ b/workspace/seismic.code-workspace
@@ -5,6 +5,9 @@
 			"name": "seismic (monorepo)"
 		},
 		{
+			"path": "../../summit"
+		},
+		{
 			"path": "../../seismic-reth"
 		},
 		{
@@ -41,13 +44,10 @@
 			"path": "../../seismic-images"
 		},
 		{
-			"path": "../../tdx-init"
+			"path": "../../enclave"
 		},
 		{
 			"path": "../../deploy"
-		},
-		{
-			"path": "../../enclave"
 		},
 	],
 	"settings": {


### PR DESCRIPTION
tdx-init was moved to enclave repo so removing it as standalone repo. also added summit repo.