### PR TITLE
fix(clients): bind authorization list into EIP-712 signatures

### DIFF
--- a/clients/py/src/seismic_web3/transaction/eip712.py
+++ b/clients/py/src/seismic_web3/transaction/eip712.py
@@ -19,12 +19,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import rlp
 from eth_hash.auto import keccak
 from eth_keys.main import KeyAPI as eth_keys
 from hexbytes import HexBytes
 
 from seismic_web3._constants import TYPED_DATA_MESSAGE_VERSION
-from seismic_web3.transaction.serialize import serialize_signed
+from seismic_web3.transaction.serialize import (
+    _authorization_list_rlp_items,
+    serialize_signed,
+)
 from seismic_web3.transaction_types import Signature
 
 if TYPE_CHECKING:
@@ -56,7 +60,8 @@ TX_SEISMIC_TYPE_STR: str = (
     "uint8 messageVersion,"
     "bytes32 recentBlockHash,"
     "uint64 expiresAtBlock,"
-    "bool signedRead"
+    "bool signedRead,"
+    "bytes32 authorizationListHash"
     ")"
 )
 
@@ -175,7 +180,13 @@ def struct_hash(tx: UnsignedSeismicTx) -> bytes:
         + bytes(se.recent_block_hash)  # bytes32 (already 32 bytes)
         + _pad32_int(se.expires_at_block)  # uint64
         + _pad32_bool(se.signed_read)  # bool
+        + authorization_list_hash(tx)  # bytes32
     )
+
+
+def authorization_list_hash(tx: UnsignedSeismicTx) -> bytes:
+    """Hash the transaction's RLP-encoded EIP-7702 authorization list."""
+    return keccak(rlp.encode(_authorization_list_rlp_items(tx)))
 
 
 def eip712_signing_hash(tx: UnsignedSeismicTx) -> bytes:
@@ -235,6 +246,7 @@ def build_seismic_typed_data(tx: UnsignedSeismicTx) -> dict[str, Any]:
                 {"name": "recentBlockHash", "type": "bytes32"},
                 {"name": "expiresAtBlock", "type": "uint64"},
                 {"name": "signedRead", "type": "bool"},
+                {"name": "authorizationListHash", "type": "bytes32"},
             ],
         },
         "primaryType": "TxSeismic",
@@ -259,6 +271,7 @@ def build_seismic_typed_data(tx: UnsignedSeismicTx) -> dict[str, Any]:
             "recentBlockHash": HexBytes(bytes(se.recent_block_hash)).to_0x_hex(),
             "expiresAtBlock": se.expires_at_block,
             "signedRead": se.signed_read,
+            "authorizationListHash": HexBytes(authorization_list_hash(tx)).to_0x_hex(),
         },
     }
 

--- a/clients/py/src/seismic_web3/transaction/serialize.py
+++ b/clients/py/src/seismic_web3/transaction/serialize.py
@@ -50,6 +50,21 @@ def _bool_to_rlp_bytes(value: bool) -> bytes:
     return b"\x01" if value else b""
 
 
+def _authorization_list_rlp_items(tx: UnsignedSeismicTx) -> list[list[bytes]]:
+    """Build the nested RLP items for a transaction's authorization list."""
+    return [
+        [
+            _int_to_rlp_bytes(a.chain_id),
+            _address_to_bytes(a.address),
+            _int_to_rlp_bytes(a.nonce),
+            _int_to_rlp_bytes(a.y_parity),
+            _int_to_rlp_bytes(a.r),
+            _int_to_rlp_bytes(a.s),
+        ]
+        for a in tx.authorization_list
+    ]
+
+
 def _tx_rlp_fields(tx: UnsignedSeismicTx) -> list:
     """Build the ordered list of RLP fields for a Seismic transaction.
 
@@ -79,18 +94,7 @@ def _tx_rlp_fields(tx: UnsignedSeismicTx) -> list:
     ]
     # Authorization list: nested RLP list
     # [[chain_id, address, nonce, y_parity, r, s], ...]
-    auth_items = [
-        [
-            _int_to_rlp_bytes(a.chain_id),
-            _address_to_bytes(a.address),
-            _int_to_rlp_bytes(a.nonce),
-            _int_to_rlp_bytes(a.y_parity),
-            _int_to_rlp_bytes(a.r),
-            _int_to_rlp_bytes(a.s),
-        ]
-        for a in tx.authorization_list
-    ]
-    fields.append(auth_items)
+    fields.append(_authorization_list_rlp_items(tx))
     return fields
 
 

--- a/clients/py/tests/test_eip712.py
+++ b/clients/py/tests/test_eip712.py
@@ -23,6 +23,7 @@ from seismic_web3.transaction.eip712 import (
     TX_SEISMIC_TYPE_HASH,
     TX_SEISMIC_TYPE_STR,
     VERIFYING_CONTRACT,
+    authorization_list_hash,
     build_seismic_typed_data,
     domain_separator,
     eip712_signing_hash,
@@ -36,6 +37,7 @@ from seismic_web3.transaction.serialize import (
 from seismic_web3.transaction_types import (
     SeismicElements,
     Signature,
+    SignedAuthorization,
     UnsignedSeismicTx,
 )
 
@@ -148,11 +150,10 @@ class TestTypeHashes:
         assert " ," not in TX_SEISMIC_TYPE_STR
         assert ", " not in TX_SEISMIC_TYPE_STR
 
-    def test_tx_seismic_has_14_fields(self):
-        """TxSeismic struct has exactly 14 fields."""
-        # Count commas inside the parentheses: 13 commas = 14 fields
+    def test_tx_seismic_has_15_fields(self):
+        """TxSeismic struct has exactly 15 fields."""
         inner = TX_SEISMIC_TYPE_STR.split("(", 1)[1].rstrip(")")
-        assert inner.count(",") == 13
+        assert inner.count(",") == 14
 
     def test_domain_version_matches_constant(self):
         assert str(TYPED_DATA_MESSAGE_VERSION) == DOMAIN_VERSION
@@ -287,11 +288,39 @@ class TestStructHash:
         )
         assert struct_hash(tx_read) != struct_hash(tx)
 
+    def test_authorization_list_changes_hash(self):
+        tx = _make_eip712_tx()
+        tx_with_auth = UnsignedSeismicTx(
+            chain_id=tx.chain_id,
+            nonce=tx.nonce,
+            gas_price=tx.gas_price,
+            gas=tx.gas,
+            to=tx.to,
+            value=tx.value,
+            data=tx.data,
+            seismic=tx.seismic,
+            authorization_list=[
+                SignedAuthorization(
+                    chain_id=tx.chain_id,
+                    address="0x1111111111111111111111111111111111111111",
+                    nonce=7,
+                    y_parity=0,
+                    r=1,
+                    s=2,
+                )
+            ],
+        )
+        assert authorization_list_hash(tx).hex() == (
+            "1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        )
+        assert authorization_list_hash(tx_with_auth) != authorization_list_hash(tx)
+        assert struct_hash(tx_with_auth) != struct_hash(tx)
+
     def test_known_vector_rust(self):
         """Cross-validate struct hash with seismic-alloy test_eip712_hash."""
         tx = _make_rust_test_vector_tx()
         assert struct_hash(tx).hex() == (
-            "c9ae99a778a215dc1fd48f331e99aaff8a274c465c786ba3ba5e44facb5fcfb9"
+            "34de7016eca39d935e5b41954404d6c9cb3fb08d31776712fcfbc6bb5d5740ab"
         )
 
 
@@ -320,14 +349,14 @@ class TestEIP712SigningHash:
         """Known signing hash for the anvil test tx (chain 31337)."""
         tx = _make_eip712_tx()
         assert eip712_signing_hash(tx).hex() == (
-            "2eed0627f80abbb44c3b6af040f5325566c481806a1c90e3dfe570ca8cf864f3"
+            "97df07b716306c8ebb936d22d20b811d8050c8608083df60c303bcc31c58fe9f"
         )
 
     def test_known_vector_rust(self):
         """Cross-validate signing hash with seismic-alloy test_eip712_hash."""
         tx = _make_rust_test_vector_tx()
         assert eip712_signing_hash(tx).hex() == (
-            "6f2f9a96ba31694d65f039356a838cf932f799b545fd95a7ff53616c55adffc1"
+            "e3bd8539e48a9ea2cafaef070c11f9f82e20c08cdd5063b98a3818c0da9a5e41"
         )
 
     def test_different_chain_ids_produce_different_hashes(self):
@@ -385,10 +414,10 @@ class TestBuildSeismicTypedData:
         assert "EIP712Domain" in td["types"]
         assert "TxSeismic" in td["types"]
 
-    def test_tx_seismic_type_has_14_fields(self):
+    def test_tx_seismic_type_has_15_fields(self):
         tx = _make_eip712_tx()
         td = build_seismic_typed_data(tx)
-        assert len(td["types"]["TxSeismic"]) == 14
+        assert len(td["types"]["TxSeismic"]) == 15
 
     def test_message_fields_match_tx(self):
         tx = _make_eip712_tx()
@@ -402,6 +431,9 @@ class TestBuildSeismicTypedData:
         assert msg["messageVersion"] == tx.seismic.message_version
         assert msg["expiresAtBlock"] == tx.seismic.expires_at_block
         assert msg["signedRead"] == tx.seismic.signed_read
+        assert msg["authorizationListHash"] == (
+            "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        )
 
     def test_bytes_fields_are_hex(self):
         tx = _make_eip712_tx()
@@ -410,6 +442,7 @@ class TestBuildSeismicTypedData:
         assert msg["input"].startswith("0x")
         assert msg["encryptionPubkey"].startswith("0x")
         assert msg["recentBlockHash"].startswith("0x")
+        assert msg["authorizationListHash"].startswith("0x")
 
     def test_contract_creation_to_is_zero_address(self):
         tx = _make_eip712_tx()
@@ -470,9 +503,9 @@ EXPECTED_EIP712_SIGNED_TX = (
     "181885f6859ca848f5f01091d1957444a920a2bfb262fa043c6c239f906480b850"
     "bf645e68de8096b62950fac2d5bceb71ab1a085aed2e973a8b4f961ca77209f991"
     "16130edecd27c39fc62e1b3c05ff42d9e4382f987fc55c2011f8e4f2e66204e171"
-    "74e9d2756bb20f4cdfe48bd5d237c080a075f0104222864723bca4714783f66ebe"
-    "0137682e32cac7dca7113fded9f4126aa008ca7dbe13125a35fd5baf6bb5ad7052"
-    "e38f954e028ccd6ead85e9c39aafdbbe"
+    "74e9d2756bb20f4cdfe48bd5d237c001a07ab4bc33c64dff2b56023bb662219a9"
+    "950337e3cd3a6dd63f5760c0e7bdaceb3a060bccb842c9f6c6d87d47b5af0cb3"
+    "3dc208be79eb92786417a7c3caa9edd609c"
 )
 
 
@@ -577,13 +610,13 @@ class TestRustCrossValidation:
     def test_struct_hash_matches_rust(self):
         tx = _make_rust_test_vector_tx()
         assert struct_hash(tx).hex() == (
-            "c9ae99a778a215dc1fd48f331e99aaff8a274c465c786ba3ba5e44facb5fcfb9"
+            "34de7016eca39d935e5b41954404d6c9cb3fb08d31776712fcfbc6bb5d5740ab"
         )
 
     def test_signing_hash_matches_rust(self):
         tx = _make_rust_test_vector_tx()
         assert eip712_signing_hash(tx).hex() == (
-            "6f2f9a96ba31694d65f039356a838cf932f799b545fd95a7ff53616c55adffc1"
+            "e3bd8539e48a9ea2cafaef070c11f9f82e20c08cdd5063b98a3818c0da9a5e41"
         )
 
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/typedDataUnit.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/typedDataUnit.ts
@@ -1,0 +1,58 @@
+import { expect } from 'bun:test'
+import { encodeAuthorizationList, signSeismicTxTypedData } from 'seismic-viem'
+import { createWalletClient, http, keccak256 } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const EMPTY_AUTHORIZATION_LIST_HASH =
+  '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'
+
+const account = privateKeyToAccount(
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+)
+
+type SeismicTypedDataView = {
+  types: {
+    TxSeismic: readonly { name: string; type: string }[]
+  }
+  message: {
+    authorizationListHash: string
+  }
+}
+
+export const testEmptyAuthorizationListHash = () => {
+  expect(keccak256(encodeAuthorizationList())).toBe(
+    EMPTY_AUTHORIZATION_LIST_HASH
+  )
+}
+
+export const testTypedDataIncludesAuthorizationListHash = async () => {
+  const client = createWalletClient({
+    account,
+    transport: http('http://127.0.0.1:8545'),
+  })
+  const { typedData } = await signSeismicTxTypedData(client, {
+    type: 'seismic',
+    chainId: 31337,
+    nonce: 0,
+    gasPrice: 1n,
+    gas: 100_000n,
+    to: '0x1111111111111111111111111111111111111111',
+    value: 0n,
+    data: '0x',
+    encryptionPubkey:
+      '0x028e76821eb4d77fd30223ca971c49738eb5b5b71eabe93f96b348fdce788ae5a0',
+    encryptionNonce: '0x46a2b6020bba77fcb1e676a6',
+    messageVersion: 2,
+    recentBlockHash:
+      '0x934207181885f6859ca848f5f01091d1957444a920a2bfb262fa043c6c239f90',
+    expiresAtBlock: 100n,
+    signedRead: false,
+  })
+
+  const view = typedData as unknown as SeismicTypedDataView
+  expect(view.types.TxSeismic.at(-1)).toEqual({
+    name: 'authorizationListHash',
+    type: 'bytes32',
+  })
+  expect(view.message.authorizationListHash).toBe(EMPTY_AUTHORIZATION_LIST_HASH)
+}

--- a/clients/ts/packages/seismic-viem/src/index.ts
+++ b/clients/ts/packages/seismic-viem/src/index.ts
@@ -26,6 +26,7 @@ export {
   createSeismicTestnet,
 } from '@sviem/chain.ts'
 export {
+  encodeAuthorizationList,
   SEISMIC_TX_TYPE,
   serializeSeismicTransaction,
 } from '@sviem/tx/seismicTx.ts'

--- a/clients/ts/packages/seismic-viem/src/tx/seismicTx.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/seismicTx.ts
@@ -148,6 +148,7 @@ export type TxSeismic = {
   recentBlockHash: Hex
   expiresAtBlock: bigint
   signedRead: boolean
+  authorizationListHash?: Hex
   authorizationList?: {
     chainId: bigint
     contractAddress: `0x${string}`
@@ -157,6 +158,22 @@ export type TxSeismic = {
     s: `0x${string}`
   }[]
 }
+
+const authorizationListRlpItems = (
+  authorizationList: TxSeismic['authorizationList'] = []
+): Hex[][] =>
+  authorizationList.map((auth) => [
+    auth.chainId ? toHex(auth.chainId) : '0x',
+    auth.contractAddress,
+    auth.nonce ? toHex(auth.nonce) : '0x',
+    auth.yParity ? toHex(auth.yParity) : '0x',
+    auth.r,
+    auth.s,
+  ])
+
+export const encodeAuthorizationList = (
+  authorizationList: TxSeismic['authorizationList'] = []
+): Hex => toRlp(authorizationListRlpItems(authorizationList))
 
 export type SeismicTxSerializer = SerializeTransactionFn<
   TransactionSerializableSeismic,
@@ -229,15 +246,8 @@ export const serializeSeismicTransaction: SeismicTxSerializer = (
     toHex(expiresAtBlock),
     signedRead ? '0x01' : '0x',
     data ?? '0x',
-    ((authorizationList ?? []) as TxSeismic['authorizationList'] & []).map(
-      (auth) => [
-        auth.chainId ? toHex(auth.chainId) : '0x',
-        auth.contractAddress,
-        auth.nonce ? toHex(auth.nonce) : '0x',
-        auth.yParity ? toHex(auth.yParity) : '0x',
-        auth.r,
-        auth.s,
-      ]
+    authorizationListRlpItems(
+      authorizationList as TxSeismic['authorizationList']
     ),
     ...toYParitySignatureArray(tx as TransactionSerializableLegacy, signature),
   ]

--- a/clients/ts/packages/seismic-viem/src/tx/signSeismicTypedData.ts
+++ b/clients/ts/packages/seismic-viem/src/tx/signSeismicTypedData.ts
@@ -20,6 +20,7 @@ import {
   Hex,
   Transport,
   TypedData,
+  keccak256,
   numberToHex,
   parseSignature,
 } from 'viem'
@@ -28,6 +29,7 @@ import { SignTypedDataParameters, signTypedData } from 'viem/actions'
 import {
   type TransactionSerializableSeismic,
   type TxSeismic,
+  encodeAuthorizationList,
 } from '@sviem/tx/seismicTx.ts'
 
 /**
@@ -64,7 +66,6 @@ const seismicTxTypedData = <
   if (tx.signedRead === undefined) {
     throw new Error('Seismic transactions require signedRead')
   }
-
   const isCreate = tx.to === undefined || tx.to === null
   const message: TxSeismic = {
     chainId: tx.chainId,
@@ -81,6 +82,11 @@ const seismicTxTypedData = <
     recentBlockHash: tx.recentBlockHash,
     expiresAtBlock: tx.expiresAtBlock,
     signedRead: tx.signedRead,
+    authorizationListHash: keccak256(
+      encodeAuthorizationList(
+        tx.authorizationList as TxSeismic['authorizationList']
+      )
+    ),
   }
 
   // @ts-ignore
@@ -108,6 +114,7 @@ const seismicTxTypedData = <
         { name: 'recentBlockHash', type: 'bytes32' },
         { name: 'expiresAtBlock', type: 'uint64' },
         { name: 'signedRead', type: 'bool' },
+        { name: 'authorizationListHash', type: 'bytes32' },
       ],
     },
     primaryType: 'TxSeismic',

--- a/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
@@ -40,6 +40,10 @@ import {
   testParseEncryptedDataThrowsOnEmpty,
   testParseEncryptedDataThrowsOnEmptyString,
 } from '@sviem-tests/tests/src20Crypto.ts'
+import {
+  testEmptyAuthorizationListHash,
+  testTypedDataIncludesAuthorizationListHash,
+} from '@sviem-tests/tests/typedDataUnit.ts'
 
 describe('Explorer URL utilities', () => {
   test(
@@ -132,5 +136,13 @@ describe('Directory computeKeyHash', () => {
   test(
     'different keys produce different hashes',
     testComputeKeyHashDifferentKeysProduceDifferentHashes
+  )
+})
+
+describe('Seismic EIP-712 typed data', () => {
+  test('hashes an empty authorization list', testEmptyAuthorizationListHash)
+  test(
+    'includes authorizationListHash',
+    testTypedDataIncludesAuthorizationListHash
   )
 })

--- a/docs/gitbook/clients/python/api-reference/eip712/build-seismic-typed-data.md
+++ b/docs/gitbook/clients/python/api-reference/eip712/build-seismic-typed-data.md
@@ -53,7 +53,8 @@ The returned dictionary follows the `eth_signTypedData_v4` format:
       { "name": "messageVersion",   "type": "uint8"    },
       { "name": "recentBlockHash",  "type": "bytes32"  },
       { "name": "expiresAtBlock",   "type": "uint64"   },
-      { "name": "signedRead",       "type": "bool"     }
+      { "name": "signedRead",       "type": "bool"     },
+      { "name": "authorizationListHash", "type": "bytes32" }
     ]
   },
   "primaryType": "TxSeismic",
@@ -76,7 +77,8 @@ The returned dictionary follows the `eth_signTypedData_v4` format:
     "messageVersion": 2,
     "recentBlockHash": "0x1234...",
     "expiresAtBlock": 12345678,
-    "signedRead": false
+    "signedRead": false,
+    "authorizationListHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
   }
 }
 ```
@@ -87,9 +89,10 @@ The returned dictionary follows the `eth_signTypedData_v4` format:
 
 - **Numeric fields** — integers (not hex strings)
 - **Address fields** — checksummed `0x`-prefixed hex strings
-- **Bytes fields** (`input`, `encryptionPubkey`, `recentBlockHash`) — `0x`-prefixed hex strings
+- **Bytes fields** (`input`, `encryptionPubkey`, `recentBlockHash`, `authorizationListHash`) — `0x`-prefixed hex strings
 - **`encryptionNonce`** — the 12-byte nonce converted to an integer via `int.from_bytes(…, "big")`
 - **`to`** — becomes the zero address when `tx.to is None`
+- **`authorizationListHash`** — `keccak256(rlp(tx.authorization_list))`; for an empty list this is `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`
 
 ### `domain`
 

--- a/docs/gitbook/clients/typescript/viem/encryption.md
+++ b/docs/gitbook/clients/typescript/viem/encryption.md
@@ -145,6 +145,12 @@ Seismic uses AES-GCM with Additional Authenticated Data (AEAD) to bind encrypted
 - `value` -- ETH value
 - `seismicElements` -- the `encryptionPubkey`, `encryptionNonce`, `messageVersion`, `recentBlockHash`, `expiresAtBlock`, and `signedRead` fields
 
+For EIP-712 signing, the `TxSeismic` typed-data message also includes
+`authorizationListHash = keccak256(rlp(authorizationList))`. This binds the
+EIP-7702 authorization list carried on the transaction wire format into the
+signature. The hash for an empty authorization list is
+`0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`.
+
 ## Crypto Dependencies
 
 seismic-viem uses the following `@noble` libraries for client-side cryptography. These are bundled as direct dependencies and do not need to be installed separately.


### PR DESCRIPTION
This PR https://github.com/SeismicSystems/seismic-alloy/pull/106 included the authorization_list hash in the EIP-712 signing hash.
We have to update the python and ts clients to make them compatible with this change.

Changes:
- Added authorizationListHash to Python and TypeScript EIP-712 TxSeismic schemas.
- Compute it as keccak256(rlp(authorizationList)).
- Added authorizationListHash to generated typed-data messages.
- Updated Python EIP-712 hashes, signatures, and fixed test vectors.