### PR TITLE
docs: document predeploys and deterministic deployments

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -261,6 +261,8 @@
   * [AES-GCM Decrypt](reference/precompiles/aes-gcm-decrypt.md)
   * [HKDF](reference/precompiles/hkdf.md)
   * [secp256k1 Sign](reference/precompiles/secp256k1-sign.md)
+* [Predeploys](reference/predeploys.md)
+* [Deterministic Deployments](reference/deterministic-deployments.md)
 * [RPC Methods](reference/rpc-methods/README.md)
   * [seismic\_getTeePublicKey](reference/rpc-methods/seismic-get-tee-public-key.md)
   * [eth\_call](reference/rpc-methods/eth-call.md)

--- a/docs/gitbook/reference/deterministic-deployments.md
+++ b/docs/gitbook/reference/deterministic-deployments.md
@@ -1,0 +1,57 @@
+---
+icon: layer-group
+---
+
+# Deterministic deployments
+
+Seismic provides common infrastructure contracts at addresses shared with
+other EVM networks. These contracts are deployed after the chain starts using
+ordinary transactions whose senders, nonces, and creation code produce the
+same addresses on every compatible network.
+
+They are not [genesis predeploys](predeploys.md). A deterministic contract is
+unavailable until its deployment transaction has been included, and its
+deployment produces normal transaction history and a receipt.
+
+{% hint style="info" %}
+Availability can differ between Seismic networks. Use `eth_getCode` to confirm
+that a contract is installed before depending on it.
+{% endhint %}
+
+## Addresses
+
+| Contract | Address |
+| --- | --- |
+| Create2 — Nick's method | `0x4e59b44847b379578588920cA78FbF26c0B4956C` |
+| ERC-1820 Registry | `0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24` |
+| SingletonFactory (ERC-2470) | `0xce0042B868300000d44A59004Da54A005ffdcf9f` |
+| Multicall3 | `0xcA11bde05977b3631167028862bE2a173976CA11` |
+| Deterministic Deployment Proxy | `0x7A0D94F55792C434d74a40883C6ed8545E406D12` |
+| Inefficient ImmutableCreate2Factory | `0xcfA3A7637547094fF06246817a35B8333C315196` |
+| ImmutableCreate2Factory | `0x0000000000FFe8B47B3e2130213B802212439497` |
+| Permit2 | `0x000000000022D473030F116dDEE9F6B43aC78BA3` |
+| CreateX | `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed` |
+
+These contracts provide shared deployment factories, interface discovery,
+batched reads and calls, and token approval infrastructure. Keeping their
+canonical addresses makes applications and deployment tooling portable across
+EVM networks.
+
+{% hint style="warning" %}
+The contracts with “Proxy” in their names are deterministic **deployment**
+utilities. They are not upgradeability proxies for Seismic's genesis
+contracts.
+{% endhint %}
+
+## Verify a deployment
+
+Check an address before using it:
+
+```bash
+cast code \
+  0xcA11bde05977b3631167028862bE2a173976CA11 \
+  --rpc-url "$SEISMIC_RPC_URL"
+```
+
+An installed contract returns non-empty bytecode. `0x` means no contract is
+currently deployed at that address on the selected network.

--- a/docs/gitbook/reference/predeploys.md
+++ b/docs/gitbook/reference/predeploys.md
@@ -1,0 +1,76 @@
+---
+icon: cubes
+---
+
+# Predeploys
+
+A predeploy is an EVM contract whose runtime bytecode and initial storage are
+included directly in a network's genesis allocation. It is available from
+block 0 at a fixed address, without a deployment transaction.
+
+{% hint style="info" %}
+The exact predeploy set can differ between Seismic networks and protocol
+versions. A network's genesis file is the source of truth. The checked-in
+[genesis contract manifest](https://github.com/SeismicSystems/seismic-reth/blob/seismic/crates/seismic/chainspec/res/genesis/manifest.toml)
+defines the Solidity contracts included by Seismic's genesis builder. Use
+`eth_getCode` to confirm that a particular address contains code on the
+network you are using.
+{% endhint %}
+
+## Seismic genesis predeploys
+
+These Seismic contracts are installed by placing their runtime bytecode at a
+fixed address in the genesis allocation. Constructors do not run during this
+process, so any required initial state must also be supplied by the genesis
+configuration.
+
+| Contract | Address | Purpose |
+| --- | --- | --- |
+| Deposit contract | `0x00000000219ab540356cBB839Cbe05303d7705Fa` | Accepts validator deposits and maintains the deposit Merkle tree |
+| Protocol parameters | `0x0000000000000000000000000000506172616D73` | Stores owner-managed protocol configuration |
+| Shielded delegation account | `0x0000000000000000000000000000000000002001` | Experimental EIP-7702 delegation implementation with shielded session keys |
+| UpgradeOperator | `0x1000000000000000000000000000000000000001` | Stores TEE measurements permitted to participate in the network |
+| MultisigUpgradeOperator | `0x1000000000000000000000000000000000000002` | Authorizes changes to UpgradeOperator |
+| Directory | `0x1000000000000000000000000000000000000004` | Stores account viewing keys used by SRC20 encrypted events |
+| Intelligence | `0x1000000000000000000000000000000000000005` | Manages intelligence providers and encrypts data to their registered keys |
+| Operations sentinel | `0x1000000000000000000000000000000000000006` | Reserved target for node operations authorization messages; not an application contract |
+
+`UpgradeOperator` and `MultisigUpgradeOperator` are intended for TEE
+measurement admission. Despite their names, they do not upgrade contract
+bytecode. They are deployed at their fixed addresses but are not currently
+used by the network.
+
+The AES Solidity library is not an AES precompile. Current contracts call the
+AES and HKDF precompiles through internal `CryptoUtils` functions and do not
+link to this deployed library. The predeploy remains present for existing
+networks but is deprecated and slated for deletion from future genesis
+configurations.
+
+The operations sentinel is intercepted by Seismic node software. Its fixed
+address and ABI identify an operations request, while its behavior is not
+provided by the bytecode at that address.
+
+## Ethereum system predeploys
+
+Seismic also includes Ethereum-standard system contracts needed by the
+execution and consensus protocols.
+
+| Contract | Address | Standard |
+| --- | --- | --- |
+| Beacon block roots | `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` | EIP-4788 |
+| Withdrawal requests | `0x00000961Ef480Eb55e80D19ad83579A64c007002` | EIP-7002 |
+
+These contracts are part of protocol execution. Their bytecode should change
+only as part of a coordinated protocol upgrade, not through an application
+administrator.
+
+## Upgradeability
+
+The current genesis configuration installs the listed runtime bytecode
+directly at each predeploy address. It does not currently put the Seismic
+predeploys behind EIP-1967 proxies.
+
+Upgradeability is a property of an individual predeploy, not of the address
+range itself. Stateful Seismic services may move behind stable proxies in a
+future genesis version, while consensus-standard contracts, linked libraries,
+and EIP-7702 delegation implementations should remain direct code deployments.


### PR DESCRIPTION
- list Seismic and Ethereum system contracts included in genesis
- explain the TEE upgrade operators, deprecated AES library, and proxy status
- document deterministic contracts deployed after genesis at canonical addresses
- clarify the distinction between deployment utilities and upgradeability proxies
- link the public genesis manifest and add both pages to the GitBook navigation