### PR TITLE
chore: bump client package versions for release

### DIFF
--- a/clients/py/pyproject.toml
+++ b/clients/py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "seismic-web3"
-version = "0.2.2"
+version = "0.3.0"
 description = "Seismic Python SDK — web3.py extensions for the Seismic network"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/clients/py/uv.lock
+++ b/clients/py/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "seismic-web3"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "coincurve" },

--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/seismic-react": {
       "name": "seismic-react",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "peerDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
         "react": "^18",
@@ -78,7 +78,7 @@
     },
     "packages/seismic-viem": {
       "name": "seismic-viem",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.2.0",
         "@noble/curves": "^1.8.0",

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-react",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "React components for Seismic.",
   "type": "module",
   "main": "./dist/_cjs/index.js",
@@ -52,7 +52,7 @@
     "typescript": ">=5.0.4",
     "viem": "2.x",
     "wagmi": "^2.0.0",
-    "seismic-viem": ">=2.0.0"
+    "seismic-viem": ">=3.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-viem",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Typescript interface for Seismic",
   "type": "module",
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
## Summary

Bumps published client package versions ahead of publishing to npm and PyPI.

| Package | Registry | Old | New | Bump |
| --- | --- | --- | --- | --- |
| `seismic-viem` | npm | 2.0.1 | **3.0.0** | major |
| `seismic-react` | npm | 2.0.1 | **3.0.0** | major |
| `seismic-web3` | PyPI | 0.2.2 | **0.3.0** | minor |

### Why major for the TS packages
`seismic-viem` was last versioned on 2026-04-22 (2.0.0 → 2.0.1), and 2.0.0 landed 2026-04-16 — over three months of changes have accumulated since, so this goes up a major version rather than a minor. `seismic-react` tracks `seismic-viem` (as it did for the 2.0.0 bump), and its peer-dependency floor on `seismic-viem` is raised to `>=3.0.0`.

### Why minor for Python
`seismic-web3` is pre-1.0, so a minor bump (0.2.2 → 0.3.0) is the release increment per 0.x semver — consistent with the previous 0.1.2 → 0.2.0 bump.

Lockfiles (`bun.lock`, `uv.lock`) regenerated to match.

## Test plan
- [x] `bun install --frozen-lockfile` passes in `clients/ts/`
- [x] `uv lock --check` passes in `clients/py/`