### PR TITLE
chore(skills): fix frontmatter and trim duplication in Claude Code skills

### DIFF
--- a/.claude/skills/audit-commits/SKILL.md
+++ b/.claude/skills/audit-commits/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: audit-commits
 description: Wrap audit fix work into two commits (tests + fix)
+disable-model-invocation: true
 ---
 
 # Audit Commits Workflow
@@ -9,46 +10,23 @@ The work for an audit fix has been completed. Now we need to wrap it into two we
 
 ## Workflow
 
-Follow these steps to create the two commits:
-
 1. **Review the current changes**
   - Run `git status` and `git diff` to understand all modifications
   - Identify which changes are test additions vs. fix implementations
 
 2. **Stage and commit the tests first**
   - Stage only the test files/changes that expose the faulty behavior
-  - Create the first commit with the tests
+  - Commit as `test[optional scope]: <description>` (Conventional Commits)
 
 3. **Stage and commit the fix**
   - Stage all remaining changes (the actual fix)
-  - Create the second commit with the implementation
+  - Commit as `fix[optional scope]: <description>`, with an optional body explaining the approach and any trade-offs
 
-## Commit message format
+Do not mention that commits were authored or co-authored by Claude.
 
-Follow "Conventional Commits" format for both commits:
+## Invariants
 
-**Test commit:**
-test[optional scope]:
-
-Fix commit:
-fix[optional scope]: <description of the fix>
-
-<optional body explaining the approach and any trade-offs>
-
-Rules:
-
-- Structure: type[optional scope]: description followed by optional body and footer(s)
-- Core types for this task: test: (for tests) and fix: (for the fix)
-- Breaking changes: Add an exclamation mark after type/scope (like fix(api)!:) or use BREAKING CHANGE: footer
-- Optional scopes: A noun in parentheses for context, like fix(api):
-- A blank line must separate description from body
-- The first line (title) of the commit message must be 72 characters or less, per standard Git convention
-- Do not mention this was authored or co-authored by Claude
-
-Important Notes
-
-- The test commit should come FIRST chronologically
-- Tests should fail when checked out independently (before the fix)
-- The fix commit should make all tests pass
-- Ensure the full test suite passes before committing the fix
+- The test commit comes FIRST chronologically
+- Tests must fail when checked out independently (before the fix)
+- The fix commit must make all tests pass — run the full test suite before committing it
 - If you need to adjust anything, maintain the two-commit structure

--- a/.claude/skills/audit-fix/SKILL.md
+++ b/.claude/skills/audit-fix/SKILL.md
@@ -10,53 +10,30 @@ An auditor has found a problem in this codebase. We are tasked with fixing the i
 
 ## Workflow
 
-Follow these steps for all audit fixes:
-
 1. **Write tests that expose the faulty behaviour**
    - Create comprehensive tests that demonstrate the vulnerability or issue
-   - Tests should clearly show the problematic behavior
 
 2. **Run tests against the current code**
-   - Execute the tests to confirm they fail as expected
-   - This validates that our tests accurately capture the issue
+   - Confirm they fail as expected — this validates that the tests accurately capture the issue
    - The entire test suite is run in .github/workflows, usually called "seismic.yml" but sometimes "test.yml" or "ci.yml"
 
-3. **Commit the changes**
-   - All of the tests we have added should be in a single commit
-   - Important to not commit changes until you have run the added tests, and they have all failed
+3. **Commit the tests**
+   - All added tests go in a single `test[optional scope]:` commit (Conventional Commits)
+   - Do not commit until the added tests have run and all failed
 
-4. **Implement the fixes**
+4. **Implement the fix**
    - If the auditor clearly suggested a fix, follow that approach
    - Otherwise, think critically about the best solution
-   - Apply the fix to resolve the issue
 
 5. **Run tests again**
-   - Execute the tests to verify the fix works
    - Repeat steps 4 & 5 until all tests pass
 
 6. **Commit the fix**
-   - It's important that the full test suite passes before you commit your changes
-   - If you realized you needed to add more changes, make sure your finished product still contains two commits: (1) the test commit and (2) the actual fix
+   - The full test suite must pass before committing
+   - Commit as `fix[optional scope]: <description>` with an optional body explaining approach and trade-offs
+   - The finished product must be exactly two commits: (1) the tests, (2) the fix
 
-## Communication
-
-As you make progress, explain:
-- What we will do to fix the issue
-- Why we're taking this approach
-- Trade-offs or considerations in the solution
-
-## Commit message format
-It's important that your commit messages are good, and accurately describe the changes. We also want the formats of these commits to match the "Conventional Commits". A summary of these rules:
-- Structure: Every commit must follow the format: <type>[optional scope]: <description> followed by an optional body and footer(s).
-- Core Types for this task are:
-  - fix: we made the actual fix
-  - test: we added tests that exposed the faulty behaviour
-- Breaking Changes: Indicated by a ! after the type/scope (e.g., feat!:) or by including BREAKING CHANGE: as a footer. This correlates to a MAJOR in SemVer.
-- Optional Scopes: A noun in parentheses providing additional context (e.g., feat(api):).
-- Other Types: Allows for types like feat:, build:, chore:, ci:, docs:, style:, refactor:, perf:, and test:.
-- Format Rules: * A blank line must separate the description from the body and the body from the footer.
-- Footers must use a hyphenated token (e.g., Reviewed-by:) followed by a separator.
-- Don't mention this was authored or co-authored by Claude
+Do not mention that commits were authored or co-authored by Claude.
 
 ## Priorities (in order)
 

--- a/.claude/skills/ssol-test-mirror/SKILL.md
+++ b/.claude/skills/ssol-test-mirror/SKILL.md
@@ -190,7 +190,7 @@ When adapting `int` tests to `sint`:
 
 When skipping, tell the user why.
 
-## Complete Example: Arithmetic Test
+## Complete Example
 
 **Source** (`checked_add_v2.sol`):
 ```solidity
@@ -220,96 +220,6 @@ contract C {
 // f(suint16,suint16): 65535, 1 -> FAILURE, hex"4e487b71", 0x11
 ```
 
-## Complete Example: Storage + Assembly Test
-
-**Source** (`unchecked_cleanup.sol`):
-```solidity
-contract C {
-    uint8 a;
-    uint8 b;
-    function testDiv() public returns (uint) {
-        assembly {
-            sstore(a.slot, 0x0102)
-            sstore(b.slot, 0x0101)
-        }
-        unchecked { return a / b; }
-    }
-}
-```
-
-**Adapted** (`shielded_unchecked_cleanup.sol`):
-```solidity
-contract C {
-    suint8 a;
-    suint8 b;
-
-    function testDiv() public returns (uint) {
-        assembly {
-            cstore(a.slot, 0x0102)
-            cstore(b.slot, 0x0101)
-        }
-        unchecked {
-            return uint(a / b);
-        }
-    }
-}
-// ----
-// testDiv() -> 2
-```
-
-## Complete Example: Array Test
-
-**Source** (`array_copy_cleanup_uint40.sol`):
-```solidity
-contract C {
-    uint40[] x;
-    function f() public returns(bool) {
-        for (uint i = 0; i < 20; i++) x.push(42);
-        while (x.length > 1) x.pop();
-        x[0] = 23;
-        assembly { sstore(x.slot, 20) }
-        // ... assertions ...
-    }
-}
-```
-
-**Adapted** (`shielded_array_copy_cleanup_uint40.sol`):
-```solidity
-contract C {
-    suint40[] x;
-    function f() public returns(bool) {
-        for (uint i = 0; i < 20; i++) x.push(suint40(42));
-        while (uint256(x.length) > 1) x.pop();
-        x[0] = suint40(23);
-        assembly { cstore(x.slot, 20) }
-        assert(uint40(x[0]) == 23);
-        assert(uint40(x[1]) == 0);
-        // ... etc ...
-    }
-}
-```
-
 ## After Writing Tests
 
-Use the `/ssolc-tests` skill for detailed build and test commands. Quick summary:
-
-1. **Build the compiler** (if not already built):
-   ```bash
-   mkdir -p build && cd build && cmake .. && make -j$(nproc)
-   ```
-
-2. **Syntax tests**: Verify with isoltest (always pass `--no-semantic-tests`):
-   ```bash
-   build/test/tools/isoltest --no-semantic-tests -t "<test-filter>"
-   ```
-   Use `--accept-updates` only with explicit user approval to fix byte offsets in error expectations.
-
-3. **Semantic tests**: Run via seismic-revm's `revme` binary (see `/ssolc-tests` for full commands with all optimizer/via-ir configurations):
-   ```bash
-   cd <seismic-revm-repo-root> && cargo run -p revme -- semantics \
-     --keep-going --unsafe-via-ir \
-     -s "<solidity-repo-root>/build/solc/solc" \
-     -t "<solidity-repo-root>/test/libsolidity/semanticTests"
-   ```
-
-4. If a test fails, diagnose whether it's an adaptation error or a compiler bug. Fix adaptation errors; report compiler bugs to the user.
+Use the `ssolc-tests` skill for build and test commands (compiler build, isoltest for syntax tests with `--no-semantic-tests`, revme semantic tests with all optimizer/via-ir configurations). If a test fails, diagnose whether it's an adaptation error or a compiler bug — fix adaptation errors; report compiler bugs to the user.

--- a/.claude/skills/ssolc-tests/SKILL.md
+++ b/.claude/skills/ssolc-tests/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: ssolc-tests
+description: Build and test seismic-solidity locally — cmake build, soltest.sh Boost unit tests, revme semantic tests via seismic-revm, and isoltest for syntax test expectations. Use when running, filtering, or debugging solidity/ssolc tests, semantic tests, or updating test expectations.
+---
+
 # Running the Test Suite Locally
 
 Instructions for building and testing seismic-solidity.
@@ -30,50 +35,29 @@ You can filter tests with `-t`:
 
 ## Running Semantic Tests
 
-Semantic tests use the seismic-revm fork (not evmone). They must be run from `<workspace-root>/seismic-revm`, where `<workspace-root>` is the parent directory containing all seismic repos as siblings (the same directory that holds `seismic/`, `seismic-revm/`, `seismic-solidity/`, etc.). See the below sections for the specific commands.
+Semantic tests use the seismic-revm fork (not evmone). They must be run from `<workspace-root>/seismic-revm`, where `<workspace-root>` is the parent directory containing all seismic repos as siblings (the same directory that holds `seismic/`, `seismic-revm/`, `seismic-solidity/`, etc.).
 
 **Important:** Replace `<solidity-repo-root>` below with the absolute path to the seismic-solidity repo you are working in (e.g., for git worktrees, use the worktree path). Replace `<workspace-root>` with the absolute path to your seismic workspace directory.
 
-Note: the --unsafe-via-ir command will allow us to bypass a restriction in Seismic Solidity that prevents compiling --via-ir or --experimental-via-ir. It does not run all the tests --via-ir necessarily. You can read a more detailed writeup of this argument by calling --help on the `semantics` revme subcommand
+Note: `--unsafe-via-ir` bypasses a restriction in Seismic Solidity that prevents compiling `--via-ir` or `--experimental-via-ir`. It does not run all the tests via-ir necessarily. See `--help` on the `semantics` revme subcommand for details.
 
-### Without Optimizer, without --via-ir
-
-```bash
-cd <workspace-root>/seismic-revm && cargo run -p revme -- semantics \
-  --keep-going --unsafe-via-ir \
-  -s "<solidity-repo-root>/build/solc/solc" \
-  -t "<solidity-repo-root>/test/libsolidity/semanticTests"
-```
-
-### With Optimizer, without --via-ir
+Base command:
 
 ```bash
 cd <workspace-root>/seismic-revm && cargo run -p revme -- semantics \
   --keep-going --unsafe-via-ir \
-  --optimize --optimizer-runs 200 \
   -s "<solidity-repo-root>/build/solc/solc" \
   -t "<solidity-repo-root>/test/libsolidity/semanticTests"
 ```
 
-### Without Optimizer, with --via-ir
+Run all four configurations by adding flags to the base command:
 
-```bash
-cd <workspace-root>/seismic-revm && cargo run -p revme -- semantics \
-  --keep-going --unsafe-via-ir --via-ir \
-  -s "<solidity-repo-root>/build/solc/solc" \
-  -t "<solidity-repo-root>/test/libsolidity/semanticTests"
-```
-
-### With Optimizer, with --via-ir
-
-```bash
-cd <workspace-root>/seismic-revm && cargo run -p revme -- semantics \
-  --keep-going --unsafe-via-ir --via-ir \
-  --optimize --optimizer-runs 200 \
-  -s "<solidity-repo-root>/build/solc/solc" \
-  -t "<solidity-repo-root>/test/libsolidity/semanticTests"
-```
-
+| Configuration | Extra flags |
+|---|---|
+| No optimizer, no via-ir | (none) |
+| Optimizer, no via-ir | `--optimize --optimizer-runs 200` |
+| No optimizer, via-ir | `--via-ir` |
+| Optimizer, via-ir | `--via-ir --optimize --optimizer-runs 200` |
 
 ## Running isoltest
 
@@ -102,7 +86,5 @@ You may use `--accept-updates` to batch-fix test expectations, but **you must wa
 ## Notes
 
 - The compiler binary is `solc` (not `ssolc`) inside `build/solc/`
-- `--skip-via-ir` is required until the via-IR pipeline is re-enabled. You can find this on the `seismic-revm` branch called `ci-via-ir-support`
-- Some tests may only fail with the optimizer enabled
-- Some tests may only fail with the optimizer disabled
-- Always test both configurations when debugging issues
+- Semantic test runs require `--unsafe-via-ir` (see above); via-IR pipeline re-enablement work lives on the seismic-revm branch `ci-via-ir-support`
+- Some tests may only fail with the optimizer enabled, others only with it disabled — always test both configurations when debugging issues


### PR DESCRIPTION
## Summary

Token/trigger optimization pass over the four Claude Code skills in `.claude/skills/` (net **-153 lines**, no information loss):

- **ssolc-tests**: had no frontmatter at all, so Claude Code fell back to the H1 ("Running the Test Suite Locally") as its description — with no mention of solidity/ssolc/revme/isoltest, it essentially never auto-loaded. Added `name` + keyword-rich `description`. Also collapsed the four near-identical `revme semantics` blocks into one base command + a flag matrix, and fixed the stale `--skip-via-ir` note (the commands use `--unsafe-via-ir`).
- **ssol-test-mirror**: removed two of the three worked examples (they restated adaptation rules 1–6) and replaced the build/test tail with a pointer to `ssolc-tests` instead of re-deriving its commands.
- **audit-fix / audit-commits**: removed the duplicated Conventional Commits spec restatement (models know the spec); kept the repo-specific parts — two-commit invariants, upstream-diff priorities, no Claude co-author line.
- **audit-commits**: added `disable-model-invocation: true` to match `audit-fix` (the cleanup half of the workflow was model-invocable while the main workflow wasn't).

## Test plan
- [ ] Fresh Claude Code session in a seismic-solidity worktree: "how do I run the semantic tests" should now auto-load `ssolc-tests`
- [ ] `/ssol-test-mirror suint` still walks the full scan → report → adapt flow