### PR TITLE
ci(client-py): run the reth-backed integration tests in CI

### DIFF
--- a/.github/workflows/client-py.yml
+++ b/.github/workflows/client-py.yml
@@ -84,3 +84,44 @@ jobs:
         env:
           SANVIL_BIN: ${{ steps.sfoundry.outputs.sanvil-path }}
         run: uv run pytest tests/integration/ -v
+
+  integration-test-reth:
+    needs: [lint, typecheck]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      # seismic-reth is built from source and started directly from
+      # target/debug via SRETH_ROOT (same arrangement as client-ts.yml's
+      # test-sreth job).
+      # TODO: replace the checkout+build steps here and in client-ts.yml
+      # with a setup-sreth action mirroring setup-sfoundry, downloading a
+      # nightly seismic-reth release binary instead of building from source.
+      - uses: actions/checkout@v6
+        with:
+          repository: SeismicSystems/seismic-reth
+          path: seismic-reth
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+          enable-cache: true
+      - run: uv sync --locked --dev
+
+      - uses: dtolnay/rust-toolchain@stable
+      # rust-cache caches ~/.cargo plus the target dir of the Rust workspace
+      # checked out at ./seismic-reth ("<workspace-dir> -> <target-dir>"
+      # syntax). shared-key is deliberately identical to client-ts.yml's
+      # test-sreth job: both check out seismic-reth at the same path, so the
+      # two jobs restore one shared build cache — keep the blocks in sync.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: seismic-reth -> target
+          shared-key: seismic-reth-debug
+      - run: cargo build --bin seismic-reth
+        working-directory: seismic-reth
+
+      - name: Run integration tests
+        env:
+          CHAIN: reth
+          SRETH_ROOT: ${{ github.workspace }}/seismic-reth
+        run: uv run pytest tests/integration/ -v

--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -91,11 +91,16 @@ jobs:
             bun-${{ runner.os }}-
 
       # `mise run test::integration::sreth` below starts reth in the background using `cargo run`,
-      # so we cache the built binary to speed up the workflow.
+      # so we cache the built binary to speed up the workflow. rust-cache caches ~/.cargo plus the
+      # target dir of the Rust workspace checked out at ./seismic-reth ("<workspace-dir> ->
+      # <target-dir>" syntax). shared-key is deliberately identical to client-py.yml's
+      # integration-test-reth job: both check out seismic-reth at the same path, so the two jobs
+      # restore one shared build cache — keep the blocks in sync.
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: seismic-reth -> target
+          shared-key: seismic-reth-debug
       # Explicitly build first because `mise run` will timeout after 60 seconds, and building reth
       # can take longer than that, especially on the first run when the cargo registry cache is cold.
       - run: cargo build --bin seismic-reth

--- a/clients/py/tests/integration/conftest.py
+++ b/clients/py/tests/integration/conftest.py
@@ -187,10 +187,24 @@ def _start_reth(port: int) -> _StartResult:
         "--http",
         "--http.port",
         str(port),
-        # Enclave
-        "--enclave.mock-server",
-        # Logging
+        # Built-in dev purpose keys; the default source waits on the
+        # custodian socket, which only exists on TEE nodes
+        "--seismic.purpose-keys-source",
+        "built-in",
+        # The default IPC path and authrpc/p2p ports are global (keyed on
+        # chain ID at best), so they collide with any other local reth
+        "--ipcdisable",
+        "--authrpc.port",
+        str(_free_port()),
+        "--port",
+        "0",
+        "--disable-discovery",
+        # Logging: --log.file.directory keeps file logs (and boot panics
+        # when the directory is unwritable) inside this run's tmpdir
+        # instead of the machine-global reth cache
         "--quiet",
+        "--log.file.directory",
+        os.path.join(tmpdir, "logs"),
         # Data directories
         "--datadir",
         tmpdir,


### PR DESCRIPTION
The Python integration suite has a CHAIN=reth path, but CI only ever ran the sanvil job, so the reth launcher rotted unnoticed: it still passed --enclave.mock-server, which no longer exists (removed by the custodian split), making `make test-integration-reth` fail at node boot.

Fix the launcher and put the path under CI:

- conftest: replace --enclave.mock-server with --seismic.purpose-keys-source built-in (the default source waits on the custodian socket, which only exists on TEE nodes). Isolate the test node from any other local reth (--ipcdisable, ephemeral --authrpc.port, --port 0 --disable-discovery — the defaults are global, keyed on chain ID at best) and keep file logs in the run's tmpdir instead of the machine-global reth cache, which also surfaces boot failures somewhere inspectable.
- client-py.yml: add an integration-test-reth job mirroring client-ts.yml's test-sreth (sibling seismic-reth checkout, rust-cache, explicit cargo build, then CHAIN=reth pytest via SRETH_ROOT).
- both workflows: give rust-cache a common shared-key so the two jobs restore one seismic-reth build cache instead of maintaining two, and leave a TODO for a setup-sreth action that downloads a nightly release binary instead of building from source.

Verified locally: CHAIN=reth runs all 112 integration tests green.