### PR TITLE
ci: add setup-sreth action, use prebuilt seismic-reth binaries

### DIFF
--- a/.github/actions/setup-sreth/action.yml
+++ b/.github/actions/setup-sreth/action.yml
@@ -1,0 +1,50 @@
+name: Setup sreth
+description: Install a prebuilt seismic-reth release binary
+
+inputs:
+  version:
+    description: seismic-reth release to install (nightly or a vX.Y.Z tag)
+    required: false
+    default: nightly
+
+outputs:
+  seismic-reth-path:
+    description: Absolute path to the installed seismic-reth binary
+    value: ${{ steps.install.outputs.seismic-reth-path }}
+
+runs:
+  using: composite
+  steps:
+    - id: install
+      name: Install seismic-reth (${{ inputs.version }})
+      shell: bash
+      env:
+        SRETH_VERSION: ${{ inputs.version }}
+      run: |
+        case "$(uname -s)" in
+          Linux) platform=linux ;;
+          Darwin) platform=darwin ;;
+          *)
+            echo "Unsupported platform: $(uname -s)" >&2
+            exit 1
+            ;;
+        esac
+        case "$(uname -m)" in
+          x86_64) arch=amd64 ;;
+          aarch64 | arm64) arch=arm64 ;;
+          *)
+            echo "Unsupported architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+        esac
+
+        # Tarball published by seismic-reth's seismic-release.yml
+        # (https://github.com/SeismicSystems/seismic-reth/blob/seismic/.github/workflows/seismic-release.yml);
+        # the asset name embeds the version, which is "nightly" on the rolling release.
+        url="https://github.com/SeismicSystems/seismic-reth/releases/download/${SRETH_VERSION}/seismic-reth_${SRETH_VERSION}_${platform}_${arch}.tar.gz"
+        SEISMIC_BIN="${XDG_CONFIG_HOME:-$HOME}/.seismic/bin"
+        mkdir -p "$SEISMIC_BIN"
+        curl -fsSL "$url" | tar -xz -C "$SEISMIC_BIN"
+        "$SEISMIC_BIN/seismic-reth" --version
+        echo "$SEISMIC_BIN" >> "$GITHUB_PATH"
+        echo "seismic-reth-path=$SEISMIC_BIN/seismic-reth" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/client-py.yml
+++ b/.github/workflows/client-py.yml
@@ -7,11 +7,13 @@ on:
       - "clients/py/**"
       - ".github/workflows/client-py.yml"
       - ".github/actions/setup-sfoundry/**"
+      - ".github/actions/setup-sreth/**"
   pull_request:
     paths:
       - "clients/py/**"
       - ".github/workflows/client-py.yml"
       - ".github/actions/setup-sfoundry/**"
+      - ".github/actions/setup-sreth/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,40 +90,22 @@ jobs:
   integration-test-reth:
     needs: [lint, typecheck]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      # seismic-reth is built from source and started directly from
-      # target/debug via SRETH_ROOT (same arrangement as client-ts.yml's
-      # test-sreth job).
-      # TODO: replace the checkout+build steps here and in client-ts.yml
-      # with a setup-sreth action mirroring setup-sfoundry, downloading a
-      # nightly seismic-reth release binary instead of building from source.
-      - uses: actions/checkout@v6
-        with:
-          repository: SeismicSystems/seismic-reth
-          path: seismic-reth
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: "3.13"
           enable-cache: true
       - run: uv sync --locked --dev
 
-      - uses: dtolnay/rust-toolchain@stable
-      # rust-cache caches ~/.cargo plus the target dir of the Rust workspace
-      # checked out at ./seismic-reth ("<workspace-dir> -> <target-dir>"
-      # syntax). shared-key is deliberately identical to client-ts.yml's
-      # test-sreth job: both check out seismic-reth at the same path, so the
-      # two jobs restore one shared build cache — keep the blocks in sync.
-      - uses: Swatinem/rust-cache@v2
+      - id: sreth
+        uses: ./.github/actions/setup-sreth
         with:
-          workspaces: seismic-reth -> target
-          shared-key: seismic-reth-debug
-      - run: cargo build --bin seismic-reth
-        working-directory: seismic-reth
+          version: nightly
 
       - name: Run integration tests
         env:
           CHAIN: reth
-          SRETH_ROOT: ${{ github.workspace }}/seismic-reth
+          SRETH_BIN: ${{ steps.sreth.outputs.seismic-reth-path }}
         run: uv run pytest tests/integration/ -v

--- a/.github/workflows/client-py.yml
+++ b/.github/workflows/client-py.yml
@@ -50,7 +50,6 @@ jobs:
       - run: uv run ty check src/
 
   test:
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -66,7 +65,6 @@ jobs:
       - run: uv run pytest tests/ -v --ignore=tests/integration
 
   integration-test:
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -88,7 +86,6 @@ jobs:
         run: uv run pytest tests/integration/ -v
 
   integration-test-reth:
-    needs: [lint, typecheck]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -48,7 +48,6 @@ jobs:
       - run: mise run test::unit
 
   test-sanvil:
-    needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -68,7 +67,6 @@ jobs:
       - run: mise run test::integration::sanvil
 
   test-sreth:
-    needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/client-ts.yml
+++ b/.github/workflows/client-ts.yml
@@ -9,6 +9,7 @@ on:
       - "pitchfork.toml"
       - ".github/workflows/client-ts.yml"
       - ".github/actions/setup-sfoundry/**"
+      - ".github/actions/setup-sreth/**"
   pull_request:
     paths:
       - "clients/ts/**"
@@ -16,6 +17,7 @@ on:
       - "pitchfork.toml"
       - ".github/workflows/client-ts.yml"
       - ".github/actions/setup-sfoundry/**"
+      - ".github/actions/setup-sreth/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -68,43 +70,25 @@ jobs:
   test-sreth:
     needs: [check]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-        with:
-          path: seismic
-      # We checkout the seismic-reth repo as a sibling repo. `mise run test::integration::sreth` has this hardcoded requirement for now
-      # as it starts reth by cd'ing into ../seismic-reth and running `cargo run ...`
-      - uses: actions/checkout@v6
-        with:
-          repository: SeismicSystems/seismic-reth
-          path: seismic-reth
       - uses: jdx/mise-action@v2
         with:
-          working_directory: seismic
           install_args: bun pitchfork
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('seismic/clients/ts/bun.lock') }}
+          key: bun-${{ runner.os }}-${{ hashFiles('clients/ts/bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
-
-      # `mise run test::integration::sreth` below starts reth in the background using `cargo run`,
-      # so we cache the built binary to speed up the workflow. rust-cache caches ~/.cargo plus the
-      # target dir of the Rust workspace checked out at ./seismic-reth ("<workspace-dir> ->
-      # <target-dir>" syntax). shared-key is deliberately identical to client-py.yml's
-      # integration-test-reth job: both check out seismic-reth at the same path, so the two jobs
-      # restore one shared build cache — keep the blocks in sync.
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - id: sreth
+        uses: ./.github/actions/setup-sreth
         with:
-          workspaces: seismic-reth -> target
-          shared-key: seismic-reth-debug
-      # Explicitly build first because `mise run` will timeout after 60 seconds, and building reth
-      # can take longer than that, especially on the first run when the cargo registry cache is cold.
-      - run: cargo build --bin seismic-reth
-        working-directory: seismic-reth
-
-      - run: mise run test::integration::sreth
-        working-directory: seismic/clients/ts
+          version: nightly
+      # SRETH_BIN makes the sreth::start-local mise task (reached via
+      # pitchfork) run the prebuilt binary instead of a sibling
+      # seismic-reth checkout.
+      - env:
+          SRETH_BIN: ${{ steps.sreth.outputs.seismic-reth-path }}
+        run: mise run test::integration::sreth

--- a/clients/py/tests/integration/conftest.py
+++ b/clients/py/tests/integration/conftest.py
@@ -8,6 +8,7 @@ Environment variables:
     SEISMIC_PORT       - override the RPC port (default: pick a free port)
     SANVIL_BIN         - direct path to the sanvil binary (used by CI)
     SFOUNDRY_ROOT      - seismic-foundry repo root (target/debug/sanvil)
+    SRETH_BIN          - direct path to the seismic-reth binary (used by CI)
     SRETH_ROOT         - seismic-reth repo root (target/debug/seismic-reth)
     SEISMIC_WORKSPACE  - fallback: parent dir of seismic-foundry/ and seismic-reth/
 """
@@ -120,6 +121,10 @@ def _get_sanvil_bin() -> str:
 
 
 def _get_reth_bin() -> str:
+    # Direct path takes precedence (used by CI with pre-built binaries)
+    direct = os.environ.get("SRETH_BIN")
+    if direct:
+        return os.path.expanduser(direct)
     return _resolve_binary(
         "SRETH_ROOT", "seismic-reth", os.path.join("target", "debug", "seismic-reth")
     )

--- a/mise.toml
+++ b/mise.toml
@@ -67,7 +67,7 @@ fi
 rm -rf /tmp/seismic-reth-dev
 "$sreth" node \
   --dev \
-  --dev.block-time 2s \
+  --dev.block-max-transactions 1 \
   --chain ${usage_chain} \
   --datadir /tmp/seismic-reth-dev \
   --http --http.port ${usage_port} \

--- a/mise.toml
+++ b/mise.toml
@@ -44,21 +44,28 @@ run = "rm -f .cargo/config.toml && echo 'Local patches OFF: .cargo/config.toml r
 # sreth tasks
 
 [tasks."sreth::start-local"]
-description = "Build and start seismic-reth in dev mode"
-dir = "{{config_root}}/../seismic-reth"
+description = "Start seismic-reth in dev mode"
 raw = true
 usage = '''
 flag "--port <port>" help="HTTP and WS port" default="8545"
-flag "--chain <chain>" help="Path to chain genesis file (relative to ../seismic-reth)" default="crates/seismic/chainspec/res/genesis/dev.json"
+flag "--chain <chain>" help="Built-in chain name (dev/testnet/mainnet) or path to a genesis file" default="dev"
 flag "-q --quiet" help="Silence all log output"
 '''
+# SRETH_BIN points at a prebuilt seismic-reth binary (CI sets it via the
+# setup-sreth action); without it we build and run the sibling checkout.
 # TODO(samlaf): figure out a better way to manage the data dir for local development.
 # We could create a depends task that uses the reth db cli (https://reth.rs/cli/reth/db/drop)
 # to drop the db after use, but right now seismic-reth doesn't have the db cli, so we'd need to compile
 # the reth binary just to drop the db...
 run = """
+if [ -n "${SRETH_BIN:-}" ]; then
+  sreth="$SRETH_BIN"
+else
+  cargo build --manifest-path {{config_root}}/../seismic-reth/Cargo.toml --bin seismic-reth
+  sreth="{{config_root}}/../seismic-reth/target/debug/seismic-reth"
+fi
 rm -rf /tmp/seismic-reth-dev
-cargo run --bin seismic-reth -- node \
+"$sreth" node \
   --dev \
   --dev.block-time 2s \
   --chain ${usage_chain} \
@@ -76,7 +83,7 @@ depends_post = ["cargo::local-patches::off"]
 raw = true
 usage = '''
 flag "--port <port>" help="HTTP and WS port" default="8545"
-flag "--chain <chain>" help="Path to chain genesis file (relative to ../seismic-reth)" default="crates/seismic/chainspec/res/genesis/dev.json"
+flag "--chain <chain>" help="Built-in chain name (dev/testnet/mainnet) or path to a genesis file" default="dev"
 flag "-q --quiet" help="Silence all log output"
 '''
 run = "mise run sreth::start-local --port ${usage_port} --chain ${usage_chain} ${usage_quiet:+--quiet}"


### PR DESCRIPTION
Add a setup-sreth action beside setup-sfoundry that downloads a seismic-reth release binary (nightly by default) published by seismic-reth's seismic-release.yml
(https://github.com/SeismicSystems/seismic-reth/blob/seismic/.github/workflows/seismic-release.yml), and collapse the checkout+rust-cache+cargo-build blocks in client-py.yml's integration-test-reth and client-ts.yml's test-sreth jobs to it. Cold from-source builds cost ~20 min per cache miss; the ts job no longer needs the sibling seismic-reth checkout at all.

Both jobs pass the binary via SRETH_BIN: the py conftest now accepts it (mirroring SANVIL_BIN), and the sreth::start-local mise task runs it instead of building the sibling checkout (still the default for local dev, and what sreth::start-local-patch requires). The task's --chain default becomes the built-in `dev` chain — the binary embeds the same dev.json, so no source tree is required.