### PR TITLE
fix(seismic-viem): forward pollingInterval/cacheTime to shielded clients

### DIFF
--- a/clients/ts/packages/seismic-viem-tests/src/clients.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/clients.ts
@@ -1,0 +1,86 @@
+import {
+  createShieldedPublicClient,
+  createShieldedWalletClient,
+  localSeismicDevnet,
+  sanvil,
+} from 'seismic-viem'
+import type { ShieldedPublicClient, ShieldedWalletClient } from 'seismic-viem'
+import type {
+  Account,
+  Chain,
+  Hex,
+  HttpTransport,
+  WebSocketTransport,
+} from 'viem'
+import { http, webSocket } from 'viem'
+
+/**
+ * Receipt-polling interval for clients talking to a local dev node.
+ *
+ * Local nodes (sanvil, seismic-reth in dev mode) include a tx in a block
+ * near-instantly, so receipts are ready long before viem's default 4s
+ * polling tick fires — with the default, every receipt wait costs a full
+ * tick and dominates integration-suite wall-clock time.
+ */
+export const LOCAL_POLLING_INTERVAL_MS = 100
+
+const LOCAL_CHAIN_IDS: Set<number> = new Set([sanvil.id, localSeismicDevnet.id])
+
+/** Fast polling on local dev chains; viem's default (4s) everywhere else,
+ * so runs against shared endpoints (e.g. a live testnet) stay polite. */
+const pollingInterval = (chain: Chain): number | undefined =>
+  LOCAL_CHAIN_IDS.has(chain.id) ? LOCAL_POLLING_INTERVAL_MS : undefined
+
+export type PublicClientArgs = {
+  chain: Chain
+  url: string
+}
+
+export type WsPublicClientArgs = {
+  chain: Chain
+  wsUrl: string
+}
+
+export type WalletClientArgs = PublicClientArgs & {
+  account: Account
+  encryptionSk?: Hex
+}
+
+/** Shielded public client over HTTP, tuned for the target chain. */
+export const httpPublicClient = ({
+  chain,
+  url,
+}: PublicClientArgs): ShieldedPublicClient<HttpTransport, Chain> =>
+  createShieldedPublicClient({
+    chain,
+    transport: http(url),
+    pollingInterval: pollingInterval(chain),
+  })
+
+/** Shielded public client over WebSocket, tuned for the target chain. */
+export const wsPublicClient = ({
+  chain,
+  wsUrl,
+}: WsPublicClientArgs): ShieldedPublicClient<WebSocketTransport, Chain> =>
+  createShieldedPublicClient({
+    chain,
+    transport: webSocket(wsUrl),
+    pollingInterval: pollingInterval(chain),
+  })
+
+/** Shielded wallet client over HTTP, tuned for the target chain. */
+export const httpWalletClient = ({
+  chain,
+  url,
+  account,
+  encryptionSk,
+}: WalletClientArgs): Promise<
+  ShieldedWalletClient<HttpTransport, Chain, Account>
+> =>
+  createShieldedWalletClient({
+    chain,
+    transport: http(url),
+    account,
+    encryptionSk,
+    pollingInterval: pollingInterval(chain),
+  })

--- a/clients/ts/packages/seismic-viem-tests/src/index.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/index.ts
@@ -1,6 +1,18 @@
 export type { NodeConnection } from '@sviem-tests/connect.ts'
 export { connectToNode } from '@sviem-tests/connect.ts'
 
+export type {
+  PublicClientArgs,
+  WsPublicClientArgs,
+  WalletClientArgs,
+} from '@sviem-tests/clients.ts'
+export {
+  LOCAL_POLLING_INTERVAL_MS,
+  httpPublicClient,
+  httpWalletClient,
+  wsPublicClient,
+} from '@sviem-tests/clients.ts'
+
 export {
   TEST_ACCOUNT_PRIVATE_KEY,
   ENCRYPTION_SK,

--- a/clients/ts/packages/seismic-viem-tests/src/tests/concurrency.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/concurrency.ts
@@ -1,12 +1,8 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-  getShieldedContract,
-} from 'seismic-viem'
+import { getShieldedContract } from 'seismic-viem'
 import type { Account, Chain, Hex } from 'viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { deploySeismicCounter } from '@sviem-tests/tests/contract/deploy.ts'
 
@@ -25,15 +21,8 @@ export const testConcurrentShieldedTransactions = async ({
   url,
   account,
 }: ConcurrencyTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const address = await deploySeismicCounter({ publicClient, walletClient })
 
   const contract = getShieldedContract({
@@ -74,15 +63,8 @@ export const testConcurrentReads = async ({
   url,
   account,
 }: ConcurrencyTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const address = await deploySeismicCounter({ publicClient, walletClient })
 
   const contract = getShieldedContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/contract/contract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/contract/contract.ts
@@ -3,8 +3,6 @@ import {
   SEISMIC_TX_TYPE,
   TransactionSerializableSeismic,
   buildTxSeismicMetadata,
-  createShieldedPublicClient,
-  createShieldedWalletClient,
   getPlaintextCalldata,
   signSeismicTxTypedData,
 } from 'seismic-viem'
@@ -17,8 +15,8 @@ import {
   hexToNumber,
   parseGwei,
 } from 'viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { seismicCounterBytecode } from '@sviem-tests/tests/contract/bytecode.ts'
 
@@ -45,15 +43,8 @@ export const testSeismicTx = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const testContractBytecodeFormatted: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
   const TEST_NUMBER = BigInt(11)
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositContract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/contract/depositContract.ts
@@ -1,12 +1,9 @@
 import { expect } from 'bun:test'
 import { createHash } from 'crypto'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-} from 'seismic-viem'
 import { Account, Chain, concatHex, parseEther } from 'viem'
-import { http, parseEventLogs } from 'viem'
+import { parseEventLogs } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { depositContractAbi } from '@sviem-tests/tests/contract/depositContractAbi.ts'
 import { depositContractBytecode } from '@sviem-tests/tests/contract/depositContractBytecode.ts'
 import { summitDepositRequestFixture } from '@sviem-tests/tests/contract/depositRequestVectors.ts'
@@ -166,15 +163,8 @@ export const testDepositEventsMatchSummitVectors = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
 
   const bytecode: `0x${string}` = `0x${depositContractBytecode.object.replace(/^0x/, '')}`
   const deployTx = await walletClient.deployContract({
@@ -237,15 +227,8 @@ export const testDepositContract = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
 
   const testContractBytecodeFormatted: `0x${string}` = `0x${depositContractBytecode.object.replace(/^0x/, '')}`
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/encoding.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/encoding.ts
@@ -3,13 +3,13 @@ import {
   buildTxSeismicMetadata,
   serializeSeismicTransaction,
 } from 'seismic-viem'
-import { createShieldedWalletClient } from 'seismic-viem'
 import { compressPublicKey } from 'seismic-viem'
-import { http } from 'viem'
 import type { Account, Chain, Hex, TransactionSerializableLegacy } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { prepareTransactionRequest } from 'viem/actions'
 import { anvil } from 'viem/chains'
+
+import { httpWalletClient } from '@sviem-tests/clients.ts'
 
 type EncodingParams = {
   chain: Chain
@@ -29,12 +29,7 @@ export const testSeismicTxEncoding = async ({
   expect(encryptionPubkey).toBe(
     compressPublicKey(privateKeyToAccount(encryptionSk).publicKey)
   )
-  const client = await createShieldedWalletClient({
-    chain,
-    account,
-    transport: http(url),
-    encryptionSk,
-  })
+  const client = await httpWalletClient({ chain, url, account, encryptionSk })
 
   const plaintext =
     '0xfc3c2cf4943c327f19af0efaf3b07201f608dd5c8e3954399a919b72588d3872b6819ac3d13d3656cbb38833a39ffd1e73963196a1ddfa9e4a5d595fdbebb875'

--- a/clients/ts/packages/seismic-viem-tests/src/tests/errorPaths.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/errorPaths.ts
@@ -1,11 +1,7 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-} from 'seismic-viem'
 import type { Account, Chain } from 'viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { ZERO_ADDRESS } from '@sviem-tests/constants.ts'
 
 type NodeParams = {
@@ -14,10 +10,7 @@ type NodeParams = {
 }
 
 export const testGetStorageAtThrows = async ({ chain, url }: NodeParams) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   await expect(
     publicClient.getStorageAt({
       address: ZERO_ADDRESS,
@@ -37,11 +30,7 @@ export const testSignedCallWithoutToThrows = async ({
   url,
   account,
 }: SignedCallErrorParams) => {
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const walletClient = await httpWalletClient({ chain, url, account })
   await expect(
     walletClient.signedCall({
       data: '0xdeadbeef',

--- a/clients/ts/packages/seismic-viem-tests/src/tests/estimateGas.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/estimateGas.ts
@@ -7,14 +7,10 @@
  *   - Explicit gas bypasses estimation.
  */
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-  getShieldedContract,
-} from 'seismic-viem'
+import { getShieldedContract } from 'seismic-viem'
 import type { Account, Chain } from 'viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { seismicCounterBytecode } from '@sviem-tests/tests/contract/bytecode.ts'
 
@@ -25,15 +21,8 @@ export type EstimateGasTestArgs = {
 }
 
 const deployCounter = async (chain: Chain, url: string, account: Account) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
   const deployTx = await walletClient.deployContract({
     abi: seismicCounterAbi,

--- a/clients/ts/packages/seismic-viem-tests/src/tests/precompiles.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/precompiles.ts
@@ -1,9 +1,10 @@
 import { expect } from 'bun:test'
-import { createShieldedPublicClient } from 'seismic-viem'
 import { AesKeyDomain, generateAesKey } from 'seismic-viem'
 import { compressPublicKey } from 'seismic-viem'
-import { Chain, hexToBytes, http, recoverMessageAddress } from 'viem'
+import { Chain, hexToBytes, recoverMessageAddress } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+
+import { httpPublicClient } from '@sviem-tests/clients.ts'
 
 export type PublicClientConfig = {
   chain: Chain
@@ -14,10 +15,7 @@ export const testRng = async (
   { chain, url }: PublicClientConfig,
   size: number
 ) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const randomU8 = await publicClient.rng({ numBytes: size })
   expect(randomU8).toBeGreaterThan(0n)
   expect(randomU8).toBeLessThan(2n ** BigInt(8 * size))
@@ -27,10 +25,7 @@ export const testRngWithPers = async (
   { chain, url }: PublicClientConfig,
   size: number
 ) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const pers = new Uint8Array([1, 2, 3, 4])
   const randomU8 = await publicClient.rng({ numBytes: size, pers })
   expect(randomU8).toBeGreaterThan(0n)
@@ -38,10 +33,7 @@ export const testRngWithPers = async (
 }
 
 export const testEcdh = async ({ chain, url }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const sk1 = generatePrivateKey()
   const sk2 = generatePrivateKey()
   const pk2 = compressPublicKey(privateKeyToAccount(sk2).publicKey)
@@ -59,10 +51,7 @@ export const testEcdh = async ({ chain, url }: PublicClientConfig) => {
 }
 
 export const testHkdfString = async ({ chain, url }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const inputString = 'HelloHKDF'
   const key = await publicClient.hdfk(inputString)
   // from revm test
@@ -72,10 +61,7 @@ export const testHkdfString = async ({ chain, url }: PublicClientConfig) => {
 }
 
 export const testHkdfHex = async ({ chain, url }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const inputHex = '0x1234abcd'
   const key = await publicClient.hdfk(inputHex)
   // from revm test
@@ -85,10 +71,7 @@ export const testHkdfHex = async ({ chain, url }: PublicClientConfig) => {
 }
 
 export const testAesGcm = async ({ chain, url }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const aesKey =
     '0x0000000000000000000000000000000000000000000000000000000000000000'
   const nonce = 0
@@ -110,10 +93,7 @@ export const testAesGcm = async ({ chain, url }: PublicClientConfig) => {
 }
 
 export const testSecp256k1 = async ({ chain, url }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
   const sk =
     '0xaac6ccf1fdec03b4838a3c97628f381b34a949967f46d3f8a9a9c741ce982a87'
   const address = privateKeyToAccount(sk).address

--- a/clients/ts/packages/seismic-viem-tests/src/tests/privacy.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/privacy.ts
@@ -1,12 +1,8 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-  getShieldedContract,
-} from 'seismic-viem'
+import { getShieldedContract } from 'seismic-viem'
 import type { Account, Chain } from 'viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { deploySeismicCounter } from '@sviem-tests/tests/contract/deploy.ts'
 
@@ -23,15 +19,8 @@ export const testSeismicTxCalldataIsEncrypted = async ({
   url,
   account,
 }: PrivacyTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const address = await deploySeismicCounter({ publicClient, walletClient })
 
   const contract = getShieldedContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/rngUniqueness.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/rngUniqueness.ts
@@ -1,7 +1,7 @@
 import { expect } from 'bun:test'
-import { createShieldedPublicClient } from 'seismic-viem'
 import type { Chain } from 'viem'
-import { http } from 'viem'
+
+import { httpPublicClient } from '@sviem-tests/clients.ts'
 
 type PublicClientConfig = {
   chain: Chain
@@ -12,10 +12,7 @@ export const testRngDifferentPersProducesDifferentResults = async ({
   chain,
   url,
 }: PublicClientConfig) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const publicClient = httpPublicClient({ chain, url })
 
   const pers1 = new Uint8Array([1, 2, 3, 4])
   const pers2 = new Uint8Array([5, 6, 7, 8])

--- a/clients/ts/packages/seismic-viem-tests/src/tests/securityParams.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/securityParams.ts
@@ -1,10 +1,6 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-} from 'seismic-viem'
-import { http } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { seismicCounterBytecode } from '@sviem-tests/tests/contract/bytecode.ts'
 import type { ContractTestArgs } from '@sviem-tests/tests/contract/contract.ts'
@@ -14,15 +10,8 @@ export const testDwriteContractUsesSecurityParams = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/signedCallDirect.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/signedCallDirect.ts
@@ -1,12 +1,9 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-  getShieldedContract,
-} from 'seismic-viem'
+import { getShieldedContract } from 'seismic-viem'
 import type { Account, Chain } from 'viem'
-import { decodeFunctionResult, encodeFunctionData, http } from 'viem'
+import { decodeFunctionResult, encodeFunctionData } from 'viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { deploySeismicCounter } from '@sviem-tests/tests/contract/deploy.ts'
 
@@ -24,15 +21,8 @@ export const testSignedCallDirect = async ({
   url,
   account,
 }: SignedCallTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const address = await deploySeismicCounter({ publicClient, walletClient })
 
   const contract = getShieldedContract({
@@ -67,15 +57,8 @@ export const testSignedCallWithSecurityParams = async ({
   url,
   account,
 }: SignedCallTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const address = await deploySeismicCounter({ publicClient, walletClient })
 
   const calldata = encodeFunctionData({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/smartRouting/smartRouting.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/smartRouting/smartRouting.ts
@@ -1,12 +1,7 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-  getShieldedContract,
-  hasShieldedParams,
-} from 'seismic-viem'
-import { http } from 'viem'
+import { getShieldedContract, hasShieldedParams } from 'seismic-viem'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import { seismicCounterAbi } from '@sviem-tests/tests/contract/abi.ts'
 import { seismicCounterBytecode } from '@sviem-tests/tests/contract/bytecode.ts'
 import type { ContractTestArgs } from '@sviem-tests/tests/contract/contract.ts'
@@ -68,15 +63,8 @@ export const testSmartWriteShieldedParam = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -110,15 +98,8 @@ export const testSmartWriteTransparentParam = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -155,15 +136,8 @@ export const testSmartReadTransparentParam = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -198,15 +172,8 @@ export const testSmartReadAfterSmartWrite = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -253,15 +220,8 @@ export const testSwriteAlwaysShielded = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -295,15 +255,8 @@ export const testSreadAlwaysShielded = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -339,15 +292,8 @@ export const testSmartWalletWriteShielded = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -379,15 +325,8 @@ export const testSmartWalletWriteTransparent = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -418,15 +357,8 @@ export const testSmartWalletReadTransparent = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
+  const walletClient = await httpWalletClient({ chain, url, account })
+  const publicClient = httpPublicClient({ chain, url })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -458,15 +390,8 @@ export const testSwriteContractAlwaysShielded = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -497,15 +422,8 @@ export const testSreadContractAlwaysShielded = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -539,15 +457,8 @@ export const testTwriteRemapsShieldedTypes = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -584,15 +495,8 @@ export const testTwriteContractRemapsShieldedTypes = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -627,15 +531,8 @@ export const testSmartWriteTransparentContract = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${transparentCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -668,15 +565,8 @@ export const testSmartReadTransparentContract = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${transparentCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -712,15 +602,8 @@ export const testSmartRoutingLifecycle = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({
@@ -801,15 +684,8 @@ export const testSmartWalletActionsLifecycle = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const bytecode: `0x${string}` = `0x${seismicCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/trace.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/trace.ts
@@ -1,12 +1,11 @@
 import { expect } from 'bun:test'
 import {
   buildTxSeismicMetadata,
-  createShieldedPublicClient,
-  createShieldedWalletClient,
   encodeSeismicMetadataAsAAD,
 } from 'seismic-viem'
 import { Account, Chain, bytesToHex } from 'viem'
-import { http } from 'viem'
+
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 
 type ContractTestArgs = {
   chain: Chain
@@ -19,13 +18,10 @@ export const testSeismicTxTrace = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({
     chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
+    url,
     account,
     encryptionSk:
       '0x311d54d3bf8359c70827122a44a7b4458733adce3c51c6b59d9acfce85e07505',
@@ -73,15 +69,8 @@ export const testLegacyTxTrace = async ({
   url,
   account,
 }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
 
   const nonce = await publicClient.getTransactionCount({
     address: account.address,

--- a/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/tread-contract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/tread-contract.ts
@@ -1,26 +1,15 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-} from 'seismic-viem'
 import { getShieldedContract } from 'seismic-viem'
-import { http } from 'viem'
 import { readContract } from 'viem/actions'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import type { ContractTestArgs } from '@sviem-tests/tests/contract/contract.ts'
 import { transparentCounterABI } from '@sviem-tests/tests/transparentContract/abi.ts'
 import { transparentCounterBytecode } from '@sviem-tests/tests/transparentContract/bytecode.ts'
 
 const treadSetup = async ({ chain, url, account }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const testContractBytecodeFormatted: `0x${string}` = `0x${transparentCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/twrite-contract.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/transparentContract/twrite-contract.ts
@@ -1,13 +1,9 @@
 import { expect } from 'bun:test'
-import {
-  createShieldedPublicClient,
-  createShieldedWalletClient,
-} from 'seismic-viem'
 import { SEISMIC_TX_TYPE, getShieldedContract } from 'seismic-viem'
 import { Hex, hexToNumber } from 'viem'
-import { http } from 'viem'
 import { writeContract } from 'viem/actions'
 
+import { httpPublicClient, httpWalletClient } from '@sviem-tests/clients.ts'
 import type { ContractTestArgs } from '@sviem-tests/tests/contract/contract.ts'
 import { transparentCounterABI } from '@sviem-tests/tests/transparentContract/abi.ts'
 import { transparentCounterBytecode } from '@sviem-tests/tests/transparentContract/bytecode.ts'
@@ -15,15 +11,8 @@ import { transparentCounterBytecode } from '@sviem-tests/tests/transparentContra
 const TEST_NUMBER = BigInt(11)
 
 const twriteSetup = async ({ chain, url, account }: ContractTestArgs) => {
-  const publicClient = createShieldedPublicClient({
-    chain,
-    transport: http(url),
-  })
-  const walletClient = await createShieldedWalletClient({
-    chain,
-    transport: http(url),
-    account,
-  })
+  const publicClient = httpPublicClient({ chain, url })
+  const walletClient = await httpWalletClient({ chain, url, account })
   const testContractBytecodeFormatted: `0x${string}` = `0x${transparentCounterBytecode.object.replace(/^0x/, '')}`
 
   const deployTx = await walletClient.deployContract({

--- a/clients/ts/packages/seismic-viem-tests/src/tests/typedData.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/typedData.ts
@@ -1,15 +1,16 @@
 import { expect } from 'bun:test'
 import {
   buildTxSeismicMetadata,
-  createShieldedWalletClient,
   encodeSeismicMetadataAsAAD,
   randomEncryptionNonce,
   signSeismicTxTypedData,
 } from 'seismic-viem'
-import { bytesToHex, http } from 'viem'
+import { bytesToHex } from 'viem'
 import type { Account, Chain, TransactionSerializableLegacy } from 'viem'
 import type { Hex } from 'viem'
 import { parseEther } from 'viem/utils'
+
+import { httpWalletClient } from '@sviem-tests/clients.ts'
 
 type TestSeismicCallTypeDataArgs = {
   chain: Chain
@@ -26,12 +27,7 @@ export const testSeismicCallTypedData = async ({
   encryptionSk,
   encryptionPubkey,
 }: TestSeismicCallTypeDataArgs) => {
-  const client = await createShieldedWalletClient({
-    chain,
-    account,
-    transport: http(url),
-    encryptionSk,
-  })
+  const client = await httpWalletClient({ chain, url, account, encryptionSk })
 
   const nonce = await client.getTransactionCount({
     address: account.address,
@@ -82,12 +78,7 @@ export const testSeismicTxTypedData = async ({
   const recipientAddress = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
   const value = parseEther('1', 'wei')
 
-  const client = await createShieldedWalletClient({
-    chain,
-    account,
-    transport: http(url),
-    encryptionSk,
-  })
+  const client = await httpWalletClient({ chain, url, account, encryptionSk })
 
   const preTxBalance = await client.getBalance({ address: recipientAddress })
 

--- a/clients/ts/packages/seismic-viem-tests/src/tests/ws.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/ws.ts
@@ -1,5 +1,6 @@
-import { createShieldedPublicClient } from 'seismic-viem'
-import { Chain, webSocket } from 'viem'
+import { Chain } from 'viem'
+
+import { wsPublicClient } from '@sviem-tests/clients.ts'
 
 export const testWsConnection = async ({
   chain,
@@ -8,10 +9,7 @@ export const testWsConnection = async ({
   chain: Chain
   wsUrl: string
 }) => {
-  const client = await createShieldedPublicClient({
-    chain,
-    transport: webSocket(wsUrl),
-  })
+  const client = wsPublicClient({ chain, wsUrl })
   await client.getTeePublicKey()
   const rpcClient = await client.transport.getRpcClient()
   rpcClient.close()

--- a/clients/ts/packages/seismic-viem-tests/src/tests/wsExtended.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/wsExtended.ts
@@ -1,7 +1,7 @@
 import { expect } from 'bun:test'
-import { createShieldedPublicClient } from 'seismic-viem'
 import type { Chain } from 'viem'
-import { webSocket } from 'viem'
+
+import { wsPublicClient } from '@sviem-tests/clients.ts'
 
 type WsTestArgs = {
   chain: Chain
@@ -11,10 +11,7 @@ type WsTestArgs = {
 const RNG_SIZE_BYTES = 32
 
 export const testWsBlockSubscription = async ({ chain, wsUrl }: WsTestArgs) => {
-  const client = await createShieldedPublicClient({
-    chain,
-    transport: webSocket(wsUrl),
-  })
+  const client = wsPublicClient({ chain, wsUrl })
 
   // If the WS transport weren't wired up this would reject or hang;
   // the assertion proves we got a numeric block height back.
@@ -26,10 +23,7 @@ export const testWsBlockSubscription = async ({ chain, wsUrl }: WsTestArgs) => {
 }
 
 export const testWsPrecompileCall = async ({ chain, wsUrl }: WsTestArgs) => {
-  const client = await createShieldedPublicClient({
-    chain,
-    transport: webSocket(wsUrl),
-  })
+  const client = wsPublicClient({ chain, wsUrl })
 
   const teeKey = await client.getTeePublicKey()
   expect(teeKey.length).toBeGreaterThan(0)
@@ -39,10 +33,7 @@ export const testWsPrecompileCall = async ({ chain, wsUrl }: WsTestArgs) => {
 }
 
 export const testWsRngCall = async ({ chain, wsUrl }: WsTestArgs) => {
-  const client = await createShieldedPublicClient({
-    chain,
-    transport: webSocket(wsUrl),
-  })
+  const client = wsPublicClient({ chain, wsUrl })
 
   const randomValue = await client.rng({ numBytes: RNG_SIZE_BYTES })
   expect(randomValue).toBeLessThan(2n ** BigInt(8 * RNG_SIZE_BYTES))

--- a/clients/ts/packages/seismic-viem/src/client.ts
+++ b/clients/ts/packages/seismic-viem/src/client.ts
@@ -249,6 +249,8 @@ export const getSeismicClients = async <
   account,
   encryptionSk,
   publicClient,
+  cacheTime,
+  pollingInterval,
 }: GetSeismicClientsParameters<TTransport, TChain, TAccount>): Promise<
   SeismicClients<TTransport, TChain, TAccount>
 > => {
@@ -257,6 +259,8 @@ export const getSeismicClients = async <
     (await createShieldedPublicClient<TTransport, TChain>({
       chain,
       transport,
+      cacheTime,
+      pollingInterval,
     }))
 
   const networkPublicKey = await pubClient.getTeePublicKey()
@@ -265,11 +269,16 @@ export const getSeismicClients = async <
     encryptionSk
   )
 
+  // waitForTransactionReceipt and friends run on pubClient (see the
+  // publicActions extension below), but polling-driven actions bound to the
+  // wallet client itself read its own pollingInterval — set both.
   const wallet = createClient({
     account,
     chain,
     transport,
     rpcSchema: seismicRpcSchema,
+    cacheTime,
+    pollingInterval,
   })
     .extend(walletActions)
     // @ts-ignore
@@ -331,21 +340,9 @@ export const createShieldedWalletClient = async <
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account,
->({
-  chain,
-  transport,
-  account,
-  encryptionSk,
-  publicClient,
-}: GetSeismicClientsParameters<TTransport, TChain, TAccount>): Promise<
-  ShieldedWalletClient<TTransport, TChain, TAccount>
-> => {
-  const clients = await getSeismicClients({
-    chain,
-    transport,
-    account,
-    encryptionSk,
-    publicClient,
-  })
+>(
+  parameters: GetSeismicClientsParameters<TTransport, TChain, TAccount>
+): Promise<ShieldedWalletClient<TTransport, TChain, TAccount>> => {
+  const clients = await getSeismicClients(parameters)
   return clients.wallet
 }


### PR DESCRIPTION
getSeismicClients accepted viem's client config in its parameter type
but silently dropped pollingInterval and cacheTime when building both
the internal public client and the wallet client, so passing them to
createShieldedWalletClient was a no-op. Forward them to both clients —
waitForTransactionReceipt and friends are delegated to the internal
public client, so it needs the settings too.

createShieldedWalletClient now passes its parameters object through
rather than re-enumerating fields, so config can't silently drop there
again.