### PR TITLE
feat(std-lib): TxUtils via tx-type precompile (staticcall, no ssolc builtin)

### DIFF
--- a/contracts/src/seismic-std-lib/utils/TxUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/TxUtils.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+/// @title TxUtils
+/// @notice Helpers for reading transaction-level context on Seismic via the tx-info precompile.
+/// @dev Uses a `staticcall` to the tx-info precompile (0x6A) rather than a custom opcode, so it
+/// compiles with a stock Solidity compiler — no `ssolc` builtin required.
+library TxUtils {
+    /// @notice Address of the Seismic tx-info precompile.
+    address internal constant TX_INFO_PRECOMPILE = address(0x6A);
+
+    uint256 internal constant SEISMIC_TX_TYPE = 0x4A;
+
+    /// @notice EIP-2718 transaction-type byte of the current transaction (74 = Seismic).
+    function txType() internal view returns (uint256 t) {
+        (bool ok, bytes memory ret) = TX_INFO_PRECOMPILE.staticcall("");
+        require(ok && ret.length == 32, "TX_INFO");
+        t = abi.decode(ret, (uint256));
+    }
+
+    /// @notice True when executing in an authenticated Seismic context: a real Seismic
+    /// transaction (type 0x4A) or an authenticated signed read. False for a plain,
+    /// unauthenticated `eth_call`.
+    /// @dev Reports the transaction type only. This is NOT an authorization check, does not
+    /// prove the call is state-changing (authenticated signed reads also return true), and does
+    /// not by itself guarantee that every field of the RPC response is encrypted.
+    function isSeismicTx() internal view returns (bool) {
+        return txType() == SEISMIC_TX_TYPE;
+    }
+}

--- a/contracts/src/seismic-std-lib/utils/TxUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/TxUtils.sol
@@ -11,10 +11,16 @@ library TxUtils {
 
     uint256 internal constant SEISMIC_TX_TYPE = 0x4A;
 
+    /// @notice Thrown when the tx-type precompile is unavailable (e.g. on a non-Seismic EVM).
+    error TxTypePrecompileUnavailable();
+
     /// @notice EIP-2718 transaction-type byte of the current transaction (74 = Seismic).
+    /// @dev **Fail-closed:** reverts with {TxTypePrecompileUnavailable} on an EVM that lacks the
+    /// `0x6A` precompile — there the `staticcall` succeeds with empty returndata rather than a
+    /// 32-byte type, so this never silently returns 0.
     function txType() internal view returns (uint256 t) {
         (bool ok, bytes memory ret) = TX_TYPE_PRECOMPILE.staticcall("");
-        require(ok && ret.length == 32, "TX_INFO");
+        if (!ok || ret.length != 32) revert TxTypePrecompileUnavailable();
         t = abi.decode(ret, (uint256));
     }
 
@@ -23,7 +29,8 @@ library TxUtils {
     /// unauthenticated `eth_call`.
     /// @dev Reports the transaction type only. This is NOT an authorization check, does not
     /// prove the call is state-changing (authenticated signed reads also return true), and does
-    /// not by itself guarantee that every field of the RPC response is encrypted.
+    /// not by itself guarantee that every field of the RPC response is encrypted. **Reverts** (it
+    /// does not return `false`) on an EVM without the precompile — see {txType}.
     function isSeismicTx() internal view returns (bool) {
         return txType() == SEISMIC_TX_TYPE;
     }

--- a/contracts/src/seismic-std-lib/utils/TxUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/TxUtils.sol
@@ -2,18 +2,18 @@
 pragma solidity ^0.8.23;
 
 /// @title TxUtils
-/// @notice Helpers for reading transaction-level context on Seismic via the tx-info precompile.
-/// @dev Uses a `staticcall` to the tx-info precompile (0x6A) rather than a custom opcode, so it
+/// @notice Helpers for reading transaction-level context on Seismic via the tx-type precompile.
+/// @dev Uses a `staticcall` to the tx-type precompile (0x6A) rather than a custom opcode, so it
 /// compiles with a stock Solidity compiler — no `ssolc` builtin required.
 library TxUtils {
-    /// @notice Address of the Seismic tx-info precompile.
-    address internal constant TX_INFO_PRECOMPILE = address(0x6A);
+    /// @notice Address of the Seismic tx-type precompile.
+    address internal constant TX_TYPE_PRECOMPILE = address(0x6A);
 
     uint256 internal constant SEISMIC_TX_TYPE = 0x4A;
 
     /// @notice EIP-2718 transaction-type byte of the current transaction (74 = Seismic).
     function txType() internal view returns (uint256 t) {
-        (bool ok, bytes memory ret) = TX_INFO_PRECOMPILE.staticcall("");
+        (bool ok, bytes memory ret) = TX_TYPE_PRECOMPILE.staticcall("");
         require(ok && ret.length == 32, "TX_INFO");
         t = abi.decode(ret, (uint256));
     }

--- a/contracts/test/TxUtils.t.sol
+++ b/contracts/test/TxUtils.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import {TxUtils} from "../src/seismic-std-lib/utils/TxUtils.sol";
+
+/// Minimal view of the Seismic `txType` cheatcode (sets the EIP-2718 tx type for
+/// subsequent calls), until forge-std's Vm interface is regenerated with it.
+interface VmTxType {
+    function txType(uint8 newTxType) external;
+}
+
+contract TxUtilsHarness {
+    function txType() external view returns (uint256) {
+        return TxUtils.txType();
+    }
+
+    function isSeismicTx() external view returns (bool) {
+        return TxUtils.isSeismicTx();
+    }
+}
+
+contract TxUtilsTest is Test {
+    TxUtilsHarness internal harness;
+    VmTxType internal vmTx;
+
+    function setUp() public {
+        harness = new TxUtilsHarness();
+        vmTx = VmTxType(address(vm));
+    }
+
+    function test_txType_defaultsToStandardCall() public view {
+        assertEq(harness.txType(), 0);
+        assertFalse(harness.isSeismicTx());
+    }
+
+    function test_isSeismicTx_trueForSeismicTxType() public {
+        vmTx.txType(0x4A);
+        assertEq(harness.txType(), 0x4A);
+        assertTrue(harness.isSeismicTx());
+    }
+
+    function test_isSeismicTx_falseForStandardTxType() public {
+        vmTx.txType(2);
+        assertEq(harness.txType(), 2);
+        assertFalse(harness.isSeismicTx());
+    }
+}


### PR DESCRIPTION
Precompile-based alternative to #214: `TxUtils.txType()`/`isSeismicTx()` read the EIP-2718 type via `staticcall` to the `0x6A` tx-type precompile (seismic-revm #227), so the helper **compiles with a stock Solidity compiler** — no `ssolc` `txtype()` builtin. Same API and honest NatSpec as #214.