### PR TITLE
fix: ship dist/_cjs/package.json marker

### DIFF
--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "seismic-client",
@@ -53,7 +54,7 @@
     },
     "packages/seismic-react": {
       "name": "seismic-react",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "peerDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
         "react": "^18",
@@ -77,7 +78,7 @@
     },
     "packages/seismic-viem": {
       "name": "seismic-viem",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@noble/ciphers": "^1.2.0",
         "@noble/curves": "^1.8.0",

--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "seismic-client",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -2,8 +2,8 @@
   "name": "seismic-client",
   "private": true,
   "workspaces": [
-    "packages/**",
-    "tests/**"
+    "packages/*",
+    "tests/*"
   ],
   "type": "module",
   "scripts": {

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-react",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React components for Seismic.",
   "type": "module",
   "main": "./dist/_cjs/index.js",
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist/_cjs/*.js",
+    "dist/_cjs/package.json",
     "dist/_esm/*.js",
     "dist/_types/**/*.d.ts",
     "dist/_cjs/rainbowkit/*.js",
@@ -39,7 +40,7 @@
     "clean": "bun run rimraf dist",
     "typecheck": "tsc --noEmit --project tsconfig.types.json",
     "build": "bun build:cjs && bun build:esm && bun build:types",
-    "build:cjs": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_cjs --target browser --format cjs --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem",
+    "build:cjs": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_cjs --target browser --format cjs --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem && node -e \"require('fs').writeFileSync('dist/_cjs/package.json', JSON.stringify({type: 'commonjs'}))\"",
     "build:esm": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_esm --target browser --format esm --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem",
     "build:types": "tsc --project tsconfig.types.json && tsc-alias --project tsconfig.types.json",
     "postbuild": "bun run rimraf ./dist/tsconfig.types.tsbuildinfo",

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-viem",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Typescript interface for Seismic",
   "type": "module",
   "main": "./dist/_cjs/index.js",

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -26,7 +26,7 @@
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit --project tsconfig.types.json",
     "build": "bun build:cjs && bun build:esm && bun build:types",
-    "build:cjs": "BUN_ENV=production bun build src/index.ts --outdir dist/_cjs --target browser --format cjs --external viem && echo '{\"type\":\"commonjs\"}' > dist/_cjs/package.json",
+    "build:cjs": "BUN_ENV=production bun build src/index.ts --outdir dist/_cjs --target browser --format cjs --external viem && node -e \"require('fs').writeFileSync('dist/_cjs/package.json', JSON.stringify({type: 'commonjs'}))\"",
     "build:esm": "BUN_ENV=production bun build src/index.ts --outdir dist/_esm --target browser --format esm --external viem ",
     "build:types": "tsc --project tsconfig.types.json && tsc-alias --project tsconfig.types.json",
     "postbuild": "rimraf ./dist/tsconfig.types.tsbuildinfo"

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "dist/_cjs/*.js",
+    "dist/_cjs/package.json",
     "dist/_esm/*.js",
     "dist/_types/**/*.d.ts",
     "README.md"
@@ -25,7 +26,7 @@
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit --project tsconfig.types.json",
     "build": "bun build:cjs && bun build:esm && bun build:types",
-    "build:cjs": "BUN_ENV=production bun build src/index.ts --outdir dist/_cjs --target browser --format cjs --external viem ",
+    "build:cjs": "BUN_ENV=production bun build src/index.ts --outdir dist/_cjs --target browser --format cjs --external viem && echo '{\"type\":\"commonjs\"}' > dist/_cjs/package.json",
     "build:esm": "BUN_ENV=production bun build src/index.ts --outdir dist/_esm --target browser --format esm --external viem ",
     "build:types": "tsc --project tsconfig.types.json && tsc-alias --project tsconfig.types.json",
     "postbuild": "rimraf ./dist/tsconfig.types.tsbuildinfo"


### PR DESCRIPTION
Changes:
-  `build:cjs` now emits `dist/_cjs/package.json` with `{"type":"commonjs"}`