### PR TITLE
EXPERIMENT: what adding ERC-1271 to ShieldedDelegationAccount would cost

### DIFF
--- a/contracts/src/experiments/SDAWithERC1271.sol
+++ b/contracts/src/experiments/SDAWithERC1271.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ShieldedDelegationAccount} from "seismic-std-lib/ShieldedDelegationAccount.sol";
+import {IShieldedDelegationAccount} from "seismic-std-lib/interfaces/IShieldedDelegationAccount.sol";
+import "solady/utils/SignatureCheckerLib.sol";
+import "solady/utils/P256.sol";
+import "solady/utils/WebAuthn.sol";
+
+/// @title SDAWithERC1271
+/// @notice EXPERIMENT ONLY — do not ship. Models the "all keys answer ERC-1271" policy
+///         under evaluation for seismic-std-lib 0.3.0, so the transitive-trust flow it
+///         enables can be exercised in a test.
+/// @dev Deliberately mirrors the accept-any-authorized-key semantics: every key in the
+///      account's key set is consulted, with no inspection of what the digest commits to.
+///      A bare bytes32 carries no domain, so the account cannot tell an Execute digest for
+///      its OWN account from one belonging to a different account that merely trusts it.
+contract SDAWithERC1271 is ShieldedDelegationAccount {
+    bytes4 internal constant MAGIC = 0x1626ba7e;
+
+    function isValidSignature(bytes32 digest, bytes calldata signature) external view returns (bytes4) {
+        // Root-key path. Under 7702 address(this) IS the delegating EOA, so a raw ecrecover
+        // against it authenticates the account's own key. Uses the precompile directly rather
+        // than SignatureCheckerLib: the library would see code at address(this) and re-enter
+        // this very function, recursing until the call depth limit.
+        if (signature.length == 65) {
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+            assembly {
+                r := calldataload(signature.offset)
+                s := calldataload(add(signature.offset, 0x20))
+                v := byte(0, calldataload(add(signature.offset, 0x40)))
+            }
+            address recovered = ecrecover(digest, v, r, s);
+            if (recovered != address(0) && recovered == address(this)) return MAGIC;
+        }
+
+        Key[] storage keys = _expStorage().keys;
+        uint256 len = uint256(keys.length);
+        for (uint256 i = 0; i < len; i++) {
+            Key storage k = keys[i];
+            if (k.expiry != 0 && k.expiry <= block.timestamp) continue;
+            if (_verifyExperimental(k.keyType, k.publicKey, digest, signature)) {
+                return MAGIC;
+            }
+        }
+        return 0xffffffff;
+    }
+
+    /// @dev Mirrors the parent's private `_getStorage()` slot derivation.
+    struct ExpStorage {
+        suint256 aesKey;
+        bool aesKeyInitialized;
+        Key[] keys;
+        mapping(bytes32 => uint32) keyToSessionIndex;
+    }
+
+    function _expStorage() internal pure returns (ExpStorage storage $) {
+        uint256 s = uint72(bytes9(keccak256("SHIELDED_DELEGATION_STORAGE")));
+        assembly ("memory-safe") {
+            $.slot := s
+        }
+    }
+
+    /// @dev Copy of the parent's private verification logic; the parent's is `internal` but
+    ///      we re-declare to keep this experiment self-contained and obviously non-shipping.
+    function _verifyExperimental(KeyType keyType, bytes memory publicKey, bytes32 digest, bytes calldata signature)
+        internal
+        view
+        returns (bool isValid)
+    {
+        if (keyType == KeyType.P256) {
+            (bytes32 r, bytes32 s) = P256.tryDecodePointCalldata(signature);
+            (bytes32 x, bytes32 y) = P256.tryDecodePoint(publicKey);
+            isValid = P256.verifySignature(digest, r, s, x, y);
+        } else if (keyType == KeyType.WebAuthnP256) {
+            (bytes32 x, bytes32 y) = P256.tryDecodePoint(publicKey);
+            isValid = WebAuthn.verify(abi.encode(digest), false, WebAuthn.tryDecodeAuth(signature), x, y);
+        } else if (keyType == KeyType.Secp256k1) {
+            isValid =
+                SignatureCheckerLib.isValidSignatureNowCalldata(abi.decode(publicKey, (address)), digest, signature);
+        }
+    }
+}

--- a/contracts/test/experiments/ERC1271TransitiveTrust.t.sol
+++ b/contracts/test/experiments/ERC1271TransitiveTrust.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ShieldedDelegationAccount} from "seismic-std-lib/ShieldedDelegationAccount.sol";
+import {IShieldedDelegationAccount} from "seismic-std-lib/interfaces/IShieldedDelegationAccount.sol";
+import {SDAWithERC1271} from "../../src/experiments/SDAWithERC1271.sol";
+
+/// @notice EXPERIMENT — measures what adding ERC-1271 to ShieldedDelegationAccount would cost.
+///
+/// Cast:
+///   ALICE — account owner. Registers BOB's EOA as a Secp256k1 session key (the
+///           "add my colleague / my other device" flow), scoped to a spend limit.
+///   BOB   — a human wallet. Later 7702-delegates his own EOA to an SDA, entirely
+///           independently of Alice.
+///   K     — an ephemeral session key BOB grants to some dapp on HIS OWN account,
+///           tightly scoped there (small limit, short expiry).
+///   EVE   — steals K out of the dapp's browser storage.
+///
+/// The three phases below correspond to the three states of the codebase.
+contract ERC1271TransitiveTrustTest is Test {
+    ShieldedDelegationAccount aliceImpl;
+    ShieldedDelegationAccount bobPlainImpl;
+    SDAWithERC1271 bobUpgradedImpl;
+
+    uint256 aliceRootPk = 0xA11CE;
+    uint256 bobPk = 0xB0B;
+    uint256 kPk = 0xC0FFEE;
+
+    address alice;
+    address bob;
+    address kAddr;
+
+    address victimSink = address(0xDEAD);
+
+    function setUp() public {
+        alice = vm.addr(aliceRootPk);
+        bob = vm.addr(bobPk);
+        kAddr = vm.addr(kPk);
+
+        aliceImpl = new ShieldedDelegationAccount();
+        bobPlainImpl = new ShieldedDelegationAccount();
+        bobUpgradedImpl = new SDAWithERC1271();
+
+        // Alice's EOA is 7702-delegated to a stock SDA.
+        vm.etch(alice, address(aliceImpl).code);
+        vm.deal(alice, 100 ether);
+
+        // Alice authorizes BOB'S ADDRESS as a Secp256k1 session key, capped at 10 ether.
+        // authorizeKey is onlySelf, so it must come from the account itself.
+        vm.prank(alice);
+        ShieldedDelegationAccount(payable(alice)).authorizeKey(
+            IShieldedDelegationAccount.KeyType.Secp256k1, abi.encode(bob), 0, 10 ether
+        );
+    }
+
+    /// Builds the calls blob multiSend expects: operation(uint8) ‖ to(address) ‖ value(uint256)
+    /// ‖ dataLength(uint256) ‖ data. One plain value transfer, no calldata.
+    function _transferCall(address to, uint256 value) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint8(0), to, value, uint256(0));
+    }
+
+    /// Reproduces SDA's Execute digest for a given account (its own domain separator).
+    function _executeDigest(address account, uint256 keyNonce, bytes memory calls) internal view returns (bytes32) {
+        bytes32 domainSeparator = ShieldedDelegationAccount(payable(account)).getDomainSeparator();
+        bytes32 structHash =
+            keccak256(abi.encode(keccak256("Execute(uint256 nonce,bytes cipher)"), keyNonce, keccak256(calls)));
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function _sign(uint256 pk, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // PHASE 1 — today, Bob is a plain EOA. Everything works as designed.
+    // ─────────────────────────────────────────────────────────────────────
+    function test_phase1_plainEoaSessionKeyWorks() public {
+        bytes memory calls = _transferCall(victimSink, 1 ether);
+        bytes32 digest = _executeDigest(alice, 0, calls);
+        bytes memory sig = _sign(bobPk, digest);
+
+        uint256 before = victimSink.balance;
+        ShieldedDelegationAccount(payable(alice)).execute(0, calls, sig, 1);
+
+        // extcodesize(bob) == 0 → Solady took the ecrecover branch → key valid.
+        assertEq(victimSink.balance - before, 1 ether, "bob's session key should work");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // PHASE 2 — Bob delegates his OWN wallet. Alice's session key silently dies.
+    // This is the availability footgun, and it exists on main TODAY.
+    // ─────────────────────────────────────────────────────────────────────
+    function test_phase2_bobDelegating_breaksAlicesSessionKey() public {
+        // Bob 7702-delegates to a stock SDA — nothing to do with Alice.
+        vm.etch(bob, address(bobPlainImpl).code);
+
+        bytes memory calls = _transferCall(victimSink, 1 ether);
+        bytes32 digest = _executeDigest(alice, 0, calls);
+        bytes memory sig = _sign(bobPk, digest); // same key, same math as phase 1
+
+        // extcodesize(bob) != 0 → ecrecover is SKIPPED → staticcall to a missing
+        // isValidSignature → revert swallowed → false → SDA's own require fires.
+        vm.expectRevert("invalid signature");
+        ShieldedDelegationAccount(payable(alice)).execute(0, calls, sig, 1);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // PHASE 3 — Bob's account implements ERC-1271 with the all-keys policy.
+    // Phase 2 heals, and the transitive-trust flow opens.
+    // ─────────────────────────────────────────────────────────────────────
+    function test_phase3a_erc1271_healsTheAvailabilityBreak() public {
+        vm.etch(bob, address(bobUpgradedImpl).code);
+        // No key registration needed: the root-key path recovers to address(this).
+
+        bytes memory calls = _transferCall(victimSink, 1 ether);
+        bytes32 digest = _executeDigest(alice, 0, calls);
+        bytes memory sig = _sign(bobPk, digest);
+
+        uint256 before = victimSink.balance;
+        ShieldedDelegationAccount(payable(alice)).execute(0, calls, sig, 1);
+        assertEq(victimSink.balance - before, 1 ether, "1271 should heal the phase-2 break");
+    }
+
+    function test_phase3b_ATTACK_stolenEphemeralKeyDrainsAlice() public {
+        vm.etch(bob, address(bobUpgradedImpl).code);
+
+        // Bob grants K on HIS OWN account: 1 wei limit, expires in an hour.
+        // Scoped as tightly as the session-key UX allows.
+        vm.prank(bob);
+        SDAWithERC1271(payable(bob)).authorizeKey(
+            IShieldedDelegationAccount.KeyType.Secp256k1, abi.encode(kAddr), uint40(block.timestamp + 1 hours), 1 wei
+        );
+
+        // EVE steals K from the dapp and signs a digest for ALICE'S account —
+        // draining Alice's full 10 ether allowance, not Bob's 1 wei.
+        bytes memory calls = _transferCall(victimSink, 10 ether);
+        bytes32 digest = _executeDigest(alice, 0, calls);
+        bytes memory sigFromStolenK = _sign(kPk, digest);
+
+        uint256 before = victimSink.balance;
+        ShieldedDelegationAccount(payable(alice)).execute(0, calls, sigFromStolenK, 1);
+
+        // K was never authorized on Alice's account. Alice authorized BOB.
+        // Bob's account vouched for K against a digest it could not interpret.
+        assertEq(victimSink.balance - before, 10 ether, "ATTACK: stolen ephemeral key drained Alice");
+    }
+
+    /// Separate hazard found while building this: an account that registers its OWN address
+    /// as a Secp256k1 key makes isValidSignature self-referential. The key loop hands
+    /// address(this) to SignatureCheckerLib, which sees code and staticcalls back into
+    /// isValidSignature — recursing until the call-depth limit unwinds it. Not a theft path
+    /// (it fails closed), but it burns the caller's gas and is a trivially reachable
+    /// misconfiguration, so a real implementation must skip keys equal to address(this).
+    function test_selfReferentialKey_recursesUntilDepthLimit() public {
+        vm.etch(bob, address(bobUpgradedImpl).code);
+
+        vm.prank(bob);
+        SDAWithERC1271(payable(bob)).authorizeKey(
+            IShieldedDelegationAccount.KeyType.Secp256k1, abi.encode(bob), 0, type(uint256).max
+        );
+
+        // Signed by a key that is NOT bob, so the root path misses and the loop is forced
+        // to consult the self-referential entry.
+        bytes32 digest = keccak256("anything");
+        bytes memory sig = _sign(kPk, digest);
+
+        assertEq(
+            SDAWithERC1271(payable(bob)).isValidSignature(digest, sig),
+            bytes4(0xffffffff),
+            "self-referential key should fail closed, not validate"
+        );
+    }
+
+    /// Control: without the 1271 upgrade the same attack is dead on arrival.
+    function test_phase3b_control_attackFailsWithoutErc1271() public {
+        vm.etch(bob, address(bobPlainImpl).code);
+
+        bytes memory calls = _transferCall(victimSink, 10 ether);
+        bytes32 digest = _executeDigest(alice, 0, calls);
+        bytes memory sigFromStolenK = _sign(kPk, digest);
+
+        vm.expectRevert("invalid signature");
+        ShieldedDelegationAccount(payable(alice)).execute(0, calls, sigFromStolenK, 1);
+    }
+}


### PR DESCRIPTION
> **Draft / experiment — not for merge.** No change to shipping contracts; adds only `contracts/src/experiments/` and `contracts/test/experiments/`. Opened so the findings are reviewable and reproducible.

## Why

`balanceOfSigned` verifies with raw `ecrecover`, so contract accounts (Safe, 4337) can't authorize reads of their own balance. The obvious fix is an ERC-1271 fallback via OZ/Solady `SignatureChecker`. This measures what that would actually cost before anyone writes it.

The relevant surface already exists: `ShieldedDelegationAccount.sol:371` **already** calls `SignatureCheckerLib.isValidSignatureNowCalldata` on every `Secp256k1` session-key check. The library is `internal`, so both branches — `ecrecover` and the ERC-1271 staticcall — are already compiled into every deployed SDA. The 1271 path is live; it just dead-ends because no SDA answers `0x1626ba7e`.

## What the tests show

Each phase is a test; all 6 pass.

| Test | Shows |
|---|---|
| `phase1_plainEoaSessionKeyWorks` | Baseline — `extcodesize == 0`, ecrecover branch, key works. |
| `phase2_bobDelegating_breaksAlicesSessionKey` | **Runs against unmodified `main`.** A session key stops verifying once its own EOA is 7702-delegated. Same key, same signature, valid ECDSA — the granting account changed nothing. Availability break, present today. |
| `phase3a_erc1271_healsTheAvailabilityBreak` | ERC-1271 fixes phase 2. |
| `phase3b_ATTACK_stolenEphemeralKeyDrainsAlice` | **The cost.** A stolen key scoped to *1 wei / 1 hour* on its own account drains a *10 ether* allowance on a different account that merely trusts that account. |
| `phase3b_control_attackFailsWithoutErc1271` | Same attack reverts without the change — so the theft path is **created by** adding ERC-1271, not pre-existing. |
| `selfReferentialKey_recursesUntilDepthLimit` | Registering `address(this)` as a key makes `isValidSignature` re-enter itself via the checker until the depth limit (~6.7M gas). Fails closed. |

## The finding

**Scopes don't compose across ERC-1271.** A session key's limits bind the `execute()` path — what it may *do on its own account*. `isValidSignature` is a pure signing oracle over a bare `bytes32`: it cannot tell an `Execute` digest for its own account from one belonging to a different account that trusts it. Under an accept-all-keys policy, every ephemeral key silently carries its account's full 1271 identity everywhere that address is trusted.

Note the split: the **availability** half pre-exists and ERC-1271 *fixes* it. The **theft** half is created by the all-keys policy — not by ERC-1271 itself. A root-key-only `isValidSignature` gets the benefits with no transitive flow.

## Implementation notes, if this is ever picked up

- Skip `address(this)` in the key loop, or accept the recursion.
- The root-key path must call `ecrecover` directly, **not** the library — the library sees code at `address(this)` and re-enters. A stock mixin can't be inherited unexamined.
- Solady's `ERC1271` mixin implements ERC-7739 (nested envelope), which changes what clients must sign. Decide deliberately.
- Existing 7702 delegations point at the old deployed address and need re-delegation.

## Test plan

```sh
cd contracts && sforge test --match-path 'test/experiments/*' -vv
```

6/6 pass on sforge 1.3.5-v0.3.0, under both ssolc `cd9163d` (sforge default) and `2ebb36d` (mise-pinned) — identical gas, so the results aren't compiler artifacts. Full `mise run ci` still green (204 tests).