### PR TITLE
fix: ship CJS marker for seismic-react too, bump both to 3.0.1

### DIFF
--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "seismic-client",
@@ -53,7 +54,7 @@
     },
     "packages/seismic-react": {
       "name": "seismic-react",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "peerDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
         "react": "^18",
@@ -77,7 +78,7 @@
     },
     "packages/seismic-viem": {
       "name": "seismic-viem",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@noble/ciphers": "^1.2.0",
         "@noble/curves": "^1.8.0",

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-react",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React components for Seismic.",
   "type": "module",
   "main": "./dist/_cjs/index.js",
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist/_cjs/*.js",
+    "dist/_cjs/package.json",
     "dist/_esm/*.js",
     "dist/_types/**/*.d.ts",
     "dist/_cjs/rainbowkit/*.js",
@@ -39,7 +40,7 @@
     "clean": "bun run rimraf dist",
     "typecheck": "tsc --noEmit --project tsconfig.types.json",
     "build": "bun build:cjs && bun build:esm && bun build:types",
-    "build:cjs": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_cjs --target browser --format cjs --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem",
+    "build:cjs": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_cjs --target browser --format cjs --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem && node -e \"require('fs').writeFileSync('dist/_cjs/package.json', JSON.stringify({type: 'commonjs'}))\"",
     "build:esm": "BUN_ENV=production bun build src/index.ts src/rainbowkit/index.ts --outdir dist/_esm --target browser --format esm --external react --external wagmi --external @rainbow-me/rainbowkit --external viem --external seismic-viem",
     "build:types": "tsc --project tsconfig.types.json && tsc-alias --project tsconfig.types.json",
     "postbuild": "bun run rimraf ./dist/tsconfig.types.tsbuildinfo",

--- a/clients/ts/packages/seismic-viem/package.json
+++ b/clients/ts/packages/seismic-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-viem",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Typescript interface for Seismic",
   "type": "module",
   "main": "./dist/_cjs/index.js",


### PR DESCRIPTION
Targets #233.

## What this adds

**1. `seismic-react` has the identical bug** — #233 only fixes `seismic-viem`. Verified on the #233 branch:

```
$ node -e "console.log(Object.keys(require('seismic-react/dist/_cjs/index.js')).length)"
0     # ← silently empty, not an error
```

Because `seismic-react` also sets `"type": "module"` with no `dist/_cjs/package.json`, Node treats its CJS bundle as ESM. On Node 22 `require()` returns an **empty object** rather than throwing; under ts-node/NestJS it throws the `ReferenceError: module is not defined in ES module scope` the customer reported. The silent-empty case is arguably worse — no stack trace, just undefined hooks.

Applied the same fix (`build:cjs` marker emission + `files` entry). The single marker at `dist/_cjs/package.json` also covers the `./rainbowkit` subpath export, since Node's type resolution walks up to the nearest `package.json`.

After:

```
viem cjs:               75 exports
react cjs:               5 exports
react/rainbowkit cjs:    4 exports
react esm:               5 exports   (unchanged)
```

**2. Version bumps** to `3.0.1` for both packages, so the fix is publishable.

**3. Restored `configVersion` in `bun.lock`.** #233 drops that key; `bun install` on 1.3.10 re-adds it, so it looks like churn from an older bun. The lockfile diff here is now only the two version bumps.

## Note on the `packages/**` → `packages/*` change in #233

Keeping it — it is **required**, not drive-by. Once `dist/_cjs/package.json` exists, `packages/**` matches it as a workspace member and `bun install` hard-fails:

```
error: Missing "name" from package.json in packages/seismic-viem/dist/_cjs/package.json
```

Worth calling out in the #233 description so nobody "cleans it up" later.

## Verification

Clean build from scratch, then: `bun run lint:check`, `bun run typecheck`, `bun run viem:unit:test` (36 pass / 0 fail). CJS + ESM require/import checked for every entry point above.