### PR TITLE
add key rotations pre-deploy

### DIFF
--- a/contracts/script/genesis-contracts.txt
+++ b/contracts/script/genesis-contracts.txt
@@ -7,3 +7,4 @@ DepositContract
 Directory
 Intelligence
 ProtocolParams
+KeyRotationRegistry

--- a/contracts/src/enclave/KeyRotationRegistry.sol
+++ b/contracts/src/enclave/KeyRotationRegistry.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title KeyRotationRegistry
+/// @notice The on-chain schedule of purpose-key rotations: an authorized admin
+///         announces that the network's key epoch advances at a future activation
+///         block, and every node fetches the new epoch's keys from its local key
+///         custodian during the announcement window (announce-then-activate).
+/// @dev Nodes do not call this contract: seismic-reth reads its **raw storage
+///      slots** and filters its event by the raw topic (see `reth-seismic-keys`'s
+///      `registry` module in the seismic-reth repo, and
+///      `docs/design/purpose-key-rotation.md` there). The storage layout, entry
+///      packing, and event signature are therefore consensus-frozen against that
+///      mirror — changing any of them is a coordinated cross-repo change, never a
+///      refactor. This is also why the contract uses plain declaration-order
+///      storage (like ProtocolParams, whose slot 0 the ops-auth layer reads raw)
+///      rather than ERC-7201 namespaced storage:
+///
+///        slot 0             : admin (address)
+///        slot 1             : rotations.length
+///        keccak256(1) + i   : rotations[i], one word packing
+///                             (epoch | activationBlock << 64 | announcedAtBlock << 128)
+///        slot 2             : minActivationDelay (uint64)
+///
+///      Scheduling invariants enforced here keep the node-side logic trivial:
+///      epochs are dense (entry `i` is epoch `i + 1`; epoch 0 is the genesis epoch
+///      and never appears in the array), activations strictly increase, at most one
+///      rotation is pending at a time, and every activation is at least
+///      `minActivationDelay` blocks past its announcement — the window in which
+///      nodes fetch keys, wallets observe the pending rotation (via
+///      `seismic_getKeyEpochInfo`) and switch at the boundary, and the announcement
+///      becomes final. Activation is by block number, not timestamp: the host wall
+///      clock is untrusted in TEE deployments, and block-number activation makes
+///      the epoch of any block reorg-invariant by construction.
+///
+///      This contract is installed as a genesis predeploy at
+///      0x1000000000000000000000000000000000000007; on genesis networks the
+///      constructor does not run and `admin` (slot 0) plus `minActivationDelay`
+///      (slot 2) are written directly into genesis storage by deploy tooling. The
+///      constructor exists for dev/test deployments only. With
+///      `minActivationDelay` unset the registry fails closed: no rotation can be
+///      announced.
+contract KeyRotationRegistry {
+    /// @notice One announced rotation. Field order is consensus-frozen: Solidity
+    ///         packs the first declared field into the low-order bits of the slot
+    ///         word, which is exactly how nodes decode it.
+    struct Rotation {
+        /// The epoch this rotation activates; always its array index + 1.
+        uint64 epoch;
+        /// The first block executed with this epoch's keys.
+        uint64 activationBlock;
+        /// The block at which this rotation was announced.
+        uint64 announcedAtBlock;
+    }
+
+    /// @notice The announce authority. Slot 0; genesis-initialized.
+    address public admin;
+
+    /// @notice The append-only rotation history. Slot 1; empty until the first
+    ///         announcement (every block is epoch 0 until then).
+    Rotation[] public rotations;
+
+    /// @notice Minimum number of blocks between an announcement and its activation.
+    ///         Slot 2; genesis-initialized per network. Zero means unconfigured and
+    ///         disables announcements entirely (fail closed).
+    uint64 public minActivationDelay;
+
+    /// @notice Emitted for every announced rotation. Nodes use this as a
+    ///         low-latency hint only (storage is their source of truth), matching
+    ///         on the raw topic `keccak256("RotationAnnounced(uint64,uint64)")` —
+    ///         the signature is consensus-frozen.
+    /// @param epoch The epoch that will activate.
+    /// @param activationBlock The first block executed with the new epoch's keys.
+    event RotationAnnounced(uint64 indexed epoch, uint64 activationBlock);
+
+    /// @notice Emitted when the announce authority changes.
+    /// @param previousAdmin The address of the previous admin.
+    /// @param newAdmin The address of the new admin.
+    event AdminTransferred(address indexed previousAdmin, address indexed newAdmin);
+
+    error OnlyAdmin();
+    error ZeroAddress();
+    /// @notice `minActivationDelay` is unset; the registry refuses announcements.
+    error DelayNotConfigured();
+    /// @notice A rotation is already pending; at most one may be in flight.
+    error RotationPending(uint64 pendingEpoch, uint64 pendingActivationBlock);
+    /// @notice The requested activation is closer than `minActivationDelay` blocks.
+    error ActivationTooSoon(uint64 activationBlock, uint256 earliestAllowed);
+
+    modifier onlyAdmin() {
+        if (msg.sender != admin) revert OnlyAdmin();
+        _;
+    }
+
+    /// @notice Constructs the registry for dev/test deployments. Genesis predeploy
+    ///         installation bypasses this entirely and writes slots 0 and 2
+    ///         directly.
+    /// @param initialAdmin The announce authority.
+    /// @param initialMinActivationDelay The per-network announcement delay floor.
+    constructor(address initialAdmin, uint64 initialMinActivationDelay) {
+        if (initialAdmin == address(0)) revert ZeroAddress();
+        admin = initialAdmin;
+        minActivationDelay = initialMinActivationDelay;
+        emit AdminTransferred(address(0), initialAdmin);
+    }
+
+    /// @notice Announces the next key rotation: epoch `rotations.length + 1`
+    ///         activates at `activationBlock`.
+    /// @dev Enforces the scheduling invariants nodes rely on: configured delay
+    ///      (fail closed), no rotation already pending, and activation at least
+    ///      `minActivationDelay` blocks in the future — which also makes
+    ///      activations strictly increasing, since the previous rotation must have
+    ///      activated (its activation is <= block.number) before a new one is
+    ///      accepted.
+    /// @param activationBlock The first block to execute with the new epoch's keys.
+    function announceRotation(uint64 activationBlock) external onlyAdmin {
+        if (minActivationDelay == 0) revert DelayNotConfigured();
+
+        uint256 count = rotations.length;
+        if (count > 0) {
+            Rotation storage last = rotations[count - 1];
+            if (last.activationBlock > block.number) {
+                revert RotationPending(last.epoch, last.activationBlock);
+            }
+        }
+
+        uint256 earliestAllowed = block.number + minActivationDelay;
+        if (activationBlock < earliestAllowed) {
+            revert ActivationTooSoon(activationBlock, earliestAllowed);
+        }
+
+        uint64 epoch = uint64(count) + 1;
+        rotations.push(
+            Rotation({epoch: epoch, activationBlock: activationBlock, announcedAtBlock: uint64(block.number)})
+        );
+        emit RotationAnnounced(epoch, activationBlock);
+    }
+
+    /// @notice Transfers the announce authority.
+    /// @param newAdmin The new admin; must not be the zero address (there is no
+    ///        renounce — an admin-less registry could never rotate again).
+    function transferAdmin(address newAdmin) external onlyAdmin {
+        if (newAdmin == address(0)) revert ZeroAddress();
+        address previousAdmin = admin;
+        admin = newAdmin;
+        emit AdminTransferred(previousAdmin, newAdmin);
+    }
+
+    /// @notice Number of announced rotations (the current maximum epoch).
+    function rotationCount() external view returns (uint256) {
+        return rotations.length;
+    }
+
+    /// @notice The key epoch active at the current block: the greatest announced
+    ///         epoch whose activation is at or before `block.number`, or 0 if none.
+    function currentEpoch() external view returns (uint64) {
+        return epochAtBlock(uint64(block.number));
+    }
+
+    /// @notice The announced-but-not-yet-activated rotation, if any.
+    /// @return exists Whether a rotation is pending.
+    /// @return epoch The pending epoch (0 when none).
+    /// @return activationBlock Its activation block (0 when none).
+    function pendingRotation() external view returns (bool exists, uint64 epoch, uint64 activationBlock) {
+        uint256 count = rotations.length;
+        if (count > 0) {
+            Rotation storage last = rotations[count - 1];
+            if (last.activationBlock > block.number) {
+                return (true, last.epoch, last.activationBlock);
+            }
+        }
+        return (false, 0, 0);
+    }
+
+    /// @notice The key epoch active for `blockNumber` — the normative
+    ///         epoch-for-block function nodes implement over raw storage, exposed
+    ///         here for tooling. O(rotations) walking backward; rotations are rare
+    ///         operator events, and consensus code never calls this.
+    /// @param blockNumber The block to evaluate.
+    function epochAtBlock(uint64 blockNumber) public view returns (uint64) {
+        for (uint256 i = rotations.length; i > 0; i--) {
+            Rotation storage rotation = rotations[i - 1];
+            if (rotation.activationBlock <= blockNumber) {
+                return rotation.epoch;
+            }
+        }
+        return 0;
+    }
+}

--- a/contracts/test/KeyRotationRegistry.t.sol
+++ b/contracts/test/KeyRotationRegistry.t.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {KeyRotationRegistry} from "../src/enclave/KeyRotationRegistry.sol";
+
+contract KeyRotationRegistryTest is Test {
+    KeyRotationRegistry public registry;
+
+    address public admin;
+    address public alice;
+
+    uint64 public constant MIN_DELAY = 32;
+
+    event RotationAnnounced(uint64 indexed epoch, uint64 activationBlock);
+    event AdminTransferred(address indexed previousAdmin, address indexed newAdmin);
+
+    function setUp() public {
+        admin = address(this);
+        alice = makeAddr("alice");
+
+        registry = new KeyRotationRegistry(admin, MIN_DELAY);
+    }
+
+    // ============ Constructor Tests ============
+
+    function test_ConstructorSetsAdminAndDelay() public view {
+        assertEq(registry.admin(), admin);
+        assertEq(registry.minActivationDelay(), MIN_DELAY);
+        assertEq(registry.rotationCount(), 0);
+        assertEq(registry.currentEpoch(), 0);
+    }
+
+    function test_ConstructorRejectsZeroAdmin() public {
+        vm.expectRevert(KeyRotationRegistry.ZeroAddress.selector);
+        new KeyRotationRegistry(address(0), MIN_DELAY);
+    }
+
+    function test_ConstructorEmitsAdminTransferred() public {
+        vm.expectEmit(true, true, false, false);
+        emit AdminTransferred(address(0), admin);
+        new KeyRotationRegistry(admin, MIN_DELAY);
+    }
+
+    // ============ announceRotation Tests ============
+
+    function test_AnnounceRotation() public {
+        vm.roll(100);
+        uint64 activation = 200;
+
+        vm.expectEmit(true, false, false, true);
+        emit RotationAnnounced(1, activation);
+        registry.announceRotation(activation);
+
+        assertEq(registry.rotationCount(), 1);
+        (uint64 epoch, uint64 activationBlock, uint64 announcedAtBlock) = registry.rotations(0);
+        assertEq(epoch, 1);
+        assertEq(activationBlock, activation);
+        assertEq(announcedAtBlock, 100);
+    }
+
+    function test_AnnounceRotationOnlyAdmin() public {
+        vm.roll(100);
+        vm.prank(alice);
+        vm.expectRevert(KeyRotationRegistry.OnlyAdmin.selector);
+        registry.announceRotation(200);
+    }
+
+    function test_AnnounceRotationFailsClosedWithoutDelay() public {
+        // A genesis placement that forgot to write slot 2 must refuse rotations.
+        KeyRotationRegistry unconfigured = new KeyRotationRegistry(admin, 0);
+        vm.roll(100);
+        vm.expectRevert(KeyRotationRegistry.DelayNotConfigured.selector);
+        unconfigured.announceRotation(type(uint64).max);
+    }
+
+    function test_AnnounceRotationEnforcesMinDelay() public {
+        vm.roll(100);
+
+        // One block short of the floor reverts...
+        vm.expectRevert(
+            abi.encodeWithSelector(KeyRotationRegistry.ActivationTooSoon.selector, 100 + MIN_DELAY - 1, 100 + MIN_DELAY)
+        );
+        registry.announceRotation(uint64(100 + MIN_DELAY - 1));
+
+        // ...exactly at the floor passes.
+        registry.announceRotation(uint64(100 + MIN_DELAY));
+        assertEq(registry.rotationCount(), 1);
+    }
+
+    function test_AnnounceRotationRejectsSecondPending() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+
+        // Still pending at the block before activation.
+        vm.roll(199);
+        vm.expectRevert(abi.encodeWithSelector(KeyRotationRegistry.RotationPending.selector, 1, 200));
+        registry.announceRotation(400);
+
+        // At the activation block the rotation is active, so a new one may be
+        // announced.
+        vm.roll(200);
+        registry.announceRotation(uint64(200 + MIN_DELAY));
+        assertEq(registry.rotationCount(), 2);
+    }
+
+    function test_EpochsAreDenseAndActivationsIncrease() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+        vm.roll(200);
+        registry.announceRotation(300);
+        vm.roll(300);
+        registry.announceRotation(400);
+
+        for (uint256 i = 0; i < 3; i++) {
+            (uint64 epoch, uint64 activationBlock,) = registry.rotations(i);
+            assertEq(epoch, uint64(i) + 1);
+            assertEq(activationBlock, 200 + uint64(i) * 100);
+        }
+    }
+
+    // ============ View Tests ============
+
+    function test_EpochFlipsExactlyAtActivation() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+
+        assertEq(registry.epochAtBlock(0), 0);
+        assertEq(registry.epochAtBlock(199), 0);
+        assertEq(registry.epochAtBlock(200), 1);
+        assertEq(registry.epochAtBlock(type(uint64).max), 1);
+
+        vm.roll(199);
+        assertEq(registry.currentEpoch(), 0);
+        vm.roll(200);
+        assertEq(registry.currentEpoch(), 1);
+    }
+
+    function test_PendingRotationTracksTheWindow() public {
+        (bool exists,,) = registry.pendingRotation();
+        assertFalse(exists);
+
+        vm.roll(100);
+        registry.announceRotation(200);
+
+        vm.roll(150);
+        (bool pendingExists, uint64 epoch, uint64 activationBlock) = registry.pendingRotation();
+        assertTrue(pendingExists);
+        assertEq(epoch, 1);
+        assertEq(activationBlock, 200);
+
+        vm.roll(200);
+        (exists,,) = registry.pendingRotation();
+        assertFalse(exists);
+    }
+
+    function test_MultiRotationEpochAtBlock() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+        vm.roll(200);
+        registry.announceRotation(300);
+
+        assertEq(registry.epochAtBlock(199), 0);
+        assertEq(registry.epochAtBlock(200), 1);
+        assertEq(registry.epochAtBlock(299), 1);
+        assertEq(registry.epochAtBlock(300), 2);
+    }
+
+    // ============ transferAdmin Tests ============
+
+    function test_TransferAdmin() public {
+        vm.expectEmit(true, true, false, false);
+        emit AdminTransferred(admin, alice);
+        registry.transferAdmin(alice);
+        assertEq(registry.admin(), alice);
+
+        // The old admin loses the announce authority; the new one has it.
+        vm.roll(100);
+        vm.expectRevert(KeyRotationRegistry.OnlyAdmin.selector);
+        registry.announceRotation(200);
+        vm.prank(alice);
+        registry.announceRotation(200);
+    }
+
+    function test_TransferAdminRejectsZeroAddress() public {
+        vm.expectRevert(KeyRotationRegistry.ZeroAddress.selector);
+        registry.transferAdmin(address(0));
+    }
+
+    function test_TransferAdminOnlyAdmin() public {
+        vm.prank(alice);
+        vm.expectRevert(KeyRotationRegistry.OnlyAdmin.selector);
+        registry.transferAdmin(alice);
+    }
+
+    // ============ Raw Layout Golden Tests (cross-repo lockstep) ============
+    //
+    // seismic-reth never calls this contract: it reads these raw slots and filters
+    // logs by the raw topic (`reth-seismic-keys`'s `registry` module). These tests
+    // pin the exact bytes that side decodes; if any of them changes, the reth
+    // mirror must change in the same coordinated release.
+
+    function test_Golden_AdminLivesInSlotZero() public view {
+        bytes32 slot0 = vm.load(address(registry), bytes32(uint256(0)));
+        assertEq(address(uint160(uint256(slot0))), admin);
+    }
+
+    function test_Golden_RotationsLengthLivesInSlotOne() public {
+        assertEq(uint256(vm.load(address(registry), bytes32(uint256(1)))), 0);
+
+        vm.roll(100);
+        registry.announceRotation(200);
+        assertEq(uint256(vm.load(address(registry), bytes32(uint256(1)))), 1);
+    }
+
+    function test_Golden_MinDelayLivesInSlotTwo() public view {
+        bytes32 slot2 = vm.load(address(registry), bytes32(uint256(2)));
+        assertEq(uint256(slot2), uint256(MIN_DELAY));
+    }
+
+    /// @dev Mirrors the reth-side decode fixture byte for byte: announcing at
+    ///      block 100 with activation 200 must store exactly
+    ///      `announced (0x64) | activation (0xC8) | epoch (0x01)` packed low-order
+    ///      first at `keccak256(uint256(1))`.
+    function test_Golden_EntryPackingMatchesRethFixture() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+
+        bytes32 elementSlot = keccak256(abi.encode(uint256(1)));
+        assertEq(
+            elementSlot,
+            // keccak256(uint256(1)), pinned in reth-seismic-keys' slot test too.
+            bytes32(0xb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6)
+        );
+        assertEq(
+            vm.load(address(registry), elementSlot),
+            bytes32(0x0000000000000000000000000000006400000000000000c80000000000000001)
+        );
+    }
+
+    function test_Golden_SecondEntryAtBasePlusOne() public {
+        vm.roll(100);
+        registry.announceRotation(200);
+        vm.roll(200);
+        registry.announceRotation(300);
+
+        bytes32 base = keccak256(abi.encode(uint256(1)));
+        bytes32 word = vm.load(address(registry), bytes32(uint256(base) + 1));
+        // announced 200 (0xC8) | activation 300 (0x12C) | epoch 2
+        assertEq(word, bytes32(0x000000000000000000000000000000c8000000000000012c0000000000000002));
+    }
+
+    /// @dev The event signature string is consensus-frozen: reth filters on
+    ///      `keccak256("RotationAnnounced(uint64,uint64)")` as topic0.
+    function test_Golden_EventTopicMatchesFrozenSignature() public {
+        vm.roll(100);
+        vm.recordLogs();
+        registry.announceRotation(200);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], keccak256("RotationAnnounced(uint64,uint64)"));
+        // epoch is the sole indexed param; activationBlock rides in the data.
+        assertEq(logs[0].topics[1], bytes32(uint256(1)));
+        assertEq(abi.decode(logs[0].data, (uint256)), 200);
+    }
+}


### PR DESCRIPTION
Key rotation pre-deploy. 
See https://github.com/SeismicSystems/seismic-reth/pull/458
For full description