### PR TITLE
fix(seismic-react): widen react/react-dom peers to ^18 || ^19

### DIFF
--- a/clients/ts/bun.lock
+++ b/clients/ts/bun.lock
@@ -57,9 +57,9 @@
       "version": "3.0.1",
       "peerDependencies": {
         "@rainbow-me/rainbowkit": "^2.0.0",
-        "react": "^18",
-        "react-dom": "^18",
-        "seismic-viem": ">=1.1.1",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
+        "seismic-viem": ">=3.0.0",
         "typescript": ">=5.0.4",
         "viem": "2.x",
         "wagmi": "^2.0.0",

--- a/clients/ts/packages/seismic-react/package.json
+++ b/clients/ts/packages/seismic-react/package.json
@@ -48,8 +48,8 @@
   },
   "peerDependencies": {
     "@rainbow-me/rainbowkit": "^2.0.0",
-    "react": "^18",
-    "react-dom": "^18",
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19",
     "typescript": ">=5.0.4",
     "viem": "2.x",
     "wagmi": "^2.0.0",

--- a/docs/gitbook/clients/typescript/react/installation.md
+++ b/docs/gitbook/clients/typescript/react/installation.md
@@ -7,14 +7,14 @@ icon: download
 
 ## Prerequisites
 
-| Requirement            | Version | Notes                   |
-| ---------------------- | ------- | ----------------------- |
-| Node.js                | 18+     | LTS recommended         |
-| React                  | ^18     | Peer dependency         |
-| wagmi                  | ^2.0.0  | Peer dependency         |
-| viem                   | 2.x     | Peer dependency         |
-| seismic-viem           | >=1.1.1 | Seismic transport layer |
-| @rainbow-me/rainbowkit | ^2.0.0  | Optional, for wallet UI |
+| Requirement            | Version      | Notes                   |
+| ---------------------- | ------------ | ----------------------- |
+| Node.js                | 18+          | LTS recommended         |
+| React                  | ^18 \|\| ^19 | Peer dependency         |
+| wagmi                  | ^2.0.0       | Peer dependency         |
+| viem                   | 2.x          | Peer dependency         |
+| seismic-viem           | >=3.0.0      | Seismic transport layer |
+| @rainbow-me/rainbowkit | ^2.0.0       | Optional, for wallet UI |
 
 ## Install
 


### PR DESCRIPTION
Fixes #191

## Problem

`seismic-react` declares `react: "^18"` / `react-dom: "^18"` as peer dependencies, so any project on React 19 fails `npm install` with `ERESOLVE`. v1.1.1 shipped the looser `>=18`, so this is a regression for consumers upgrading to 2.x/3.x. Reproduced today against the registry package in a clean project with `react@19`:

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error Found: react@19.2.8
npm error   peer react@">=18" from @rainbow-me/rainbowkit@2.2.11
npm error     peer @rainbow-me/rainbowkit@"^2.0.0" from seismic-react@3.0.1
```

## Change

- Widen `react` / `react-dom` peers to `"^18 || ^19"` in `clients/ts/packages/seismic-react/package.json`
- Re-ran `bun install` to sync the embedded manifest in `bun.lock`. This also picks up the pre-existing `seismic-viem` peer drift (`>=1.1.1` → `>=3.0.0`, changed in the 3.0.0 release but never re-locked). Resolution is untouched — the workspace still installs `react@18.3.1`, so nothing changes for local dev or CI.
- Docs sync: updated the prerequisites table in `docs/gitbook/clients/typescript/react/installation.md` (React `^18 || ^19`, seismic-viem `>=3.0.0`)

## Why this is safe

- The rest of the peer chain already allows React 19: `@rainbow-me/rainbowkit@2.x` (`react: ">=18"`), `wagmi@2.x` (`react: ">=18"`), `@tanstack/react-query` (`^18 || ^19`)
- The workspace already typechecks against `@types/react@19.0.10` (current bun.lock)
- `src/` only uses hooks + context — no `defaultProps`, `propTypes`, legacy `ReactDOM.render`, or anything else removed in React 19

## Verification

- `bun run lint:check`, `bun run typecheck`, `bun run build`, `bun run encrypt:test` + `bun run viem:unit:test` (37 tests) all pass locally
- `npm pack` of the patched package, then in clean throwaway projects:
  - `react@19.2.8` + patched tarball → installs cleanly; both entry points (`seismic-react`, `seismic-react/rainbowkit`) import fine under React 19 and expose all expected exports
  - `react@18.3.1` + patched tarball → still installs cleanly (no regression)
  - `react@19` + registry `seismic-react@3.0.1` → reproduces the exact `ERESOLVE` from the issue

A patch release is needed for this to reach npm consumers — happy to adjust anything to fit your release process.
