### PR TITLE
fix(seismic-viem): encode numeric encryption nonces over the full 96 bits

### DIFF
--- a/clients/ts/packages/seismic-viem-tests/src/tests/encryptionNonce.ts
+++ b/clients/ts/packages/seismic-viem-tests/src/tests/encryptionNonce.ts
@@ -1,0 +1,85 @@
+import { expect } from 'bun:test'
+import { AesGcmCrypto } from 'seismic-viem'
+import type { Hex } from 'viem'
+
+const AES_KEY = `0x${'11'.repeat(32)}` as Hex
+
+const cipher = () => new AesGcmCrypto(AES_KEY)
+
+/**
+ * Reference vectors for the node's `U96` encryption nonce
+ * (`TxSeismicElements::encryption_nonce` in seismic-alloy), which is
+ * big-endian across all 12 bytes.
+ *
+ * Produced with the Python client's encoding, `int.to_bytes(12, 'big')`.
+ */
+const VECTORS: ReadonlyArray<readonly [bigint, Hex]> = [
+  [0n, '0x000000000000000000000000'],
+  [5n, '0x000000000000000000000005'],
+  [42n, '0x00000000000000000000002a'],
+  [2n ** 63n, '0x000000008000000000000000'],
+  [2n ** 64n, '0x000000010000000000000000'],
+  [2n ** 64n + 5n, '0x000000010000000000000005'],
+  [2n ** 95n, '0x800000000000000000000000'],
+  [2n ** 96n - 1n, '0xffffffffffffffffffffffff'],
+]
+
+/** Every value in the 96-bit range must encode like the node and the Python client. */
+export const testCreateNonceMatchesU96Encoding = () => {
+  for (const [value, expected] of VECTORS) {
+    expect(cipher().createNonce(value)).toBe(expected)
+  }
+}
+
+/**
+ * Values differing only above bit 63 must not collide.
+ *
+ * The nonce field is 96 bits wide, so writing only the low 64 silently maps
+ * `n` and `n + 2^64` to the same nonce — reusing an AES-GCM nonce under one
+ * key is a hard failure of the mode.
+ */
+export const testCreateNonceDoesNotCollideAboveU64 = () => {
+  const c = cipher()
+  expect(c.createNonce(5n)).not.toBe(c.createNonce(2n ** 64n + 5n))
+  expect(c.createNonce(0n)).not.toBe(c.createNonce(2n ** 64n))
+}
+
+/** Values that already fit in 64 bits keep their previous encoding. */
+export const testCreateNonceIsUnchangedBelowU64 = () => {
+  const c = cipher()
+  expect(c.createNonce(0)).toBe('0x000000000000000000000000')
+  expect(c.createNonce(42)).toBe('0x00000000000000000000002a')
+  expect(c.createNonce(2n ** 64n - 1n)).toBe('0x00000000ffffffffffffffff')
+}
+
+/** Out-of-range values must be rejected, not silently truncated. */
+export const testCreateNonceRejectsOversizedValues = () => {
+  expect(() => cipher().createNonce(2n ** 96n)).toThrow('96 bits')
+  expect(() => cipher().createNonce(2n ** 128n)).toThrow('96 bits')
+}
+
+/** Negative values must be rejected, matching the Python client's OverflowError. */
+export const testCreateNonceRejectsNegativeValues = () => {
+  expect(() => cipher().createNonce(-1)).toThrow('negative')
+}
+
+/**
+ * `encrypt` takes the same numeric nonce path, so a truncating conversion
+ * would encrypt under a different nonce than the one the node records.
+ */
+export const testEncryptUsesFullWidthNumericNonce = async () => {
+  const plaintext = '0xdeadbeef' as Hex
+  const c = cipher()
+
+  const viaNumber = await c.encrypt(plaintext, 2n ** 64n + 5n)
+  const viaHex = await c.encrypt(plaintext, '0x000000010000000000000005' as Hex)
+
+  expect(viaNumber).toBe(viaHex)
+
+  // And it must differ from the value the truncating conversion produced.
+  const truncated = await c.encrypt(
+    plaintext,
+    '0x000000000000000000000005' as Hex
+  )
+  expect(viaNumber).not.toBe(truncated)
+}

--- a/clients/ts/packages/seismic-viem/src/crypto/aes.ts
+++ b/clients/ts/packages/seismic-viem/src/crypto/aes.ts
@@ -8,7 +8,6 @@ import type { EncryptionNonce } from '@sviem/crypto/nonce.ts'
 
 export class AesGcmCrypto {
   private readonly NONCE_LENGTH = 12 // 96 bits is the recommended nonce length for GCM
-  private readonly U64_SIZE = 8 // Size of u64 in bytes
 
   constructor(private readonly key: Hex) {
     const keyBuffer = hexToBytes(key)
@@ -18,25 +17,31 @@ export class AesGcmCrypto {
   }
 
   /**
-   * Creates a nonce from a u64 number, matching Rust's implementation
-   * @param num - The number to convert (will be treated as u64)
+   * Creates a nonce from a number, matching the node's `U96` encryption nonce
+   * (`TxSeismicElements::encryption_nonce`), which is big-endian over all 12
+   * bytes.
+   *
+   * @param num - The number to convert. Must fit in 96 bits.
+   * @throws If `num` is negative or does not fit in 96 bits, rather than
+   *   silently truncating it to a colliding nonce.
    */
   private numberToNonce(num: bigint | number): Uint8Array {
     let value = BigInt(num)
+    if (value < 0n) {
+      throw new Error(`Nonce must not be negative, got ${num}`)
+    }
+    if (value >= 1n << 96n) {
+      throw new Error(`Nonce must fit in 96 bits (12 bytes), got ${num}`)
+    }
 
     // Create a buffer for the full nonce (12 bytes)
     const nonceBuffer = new Uint8Array(this.NONCE_LENGTH)
-    // Write the u64 value in big-endian format to the last 8 bytes
-    for (
-      let i = this.NONCE_LENGTH - 1;
-      i >= this.NONCE_LENGTH - this.U64_SIZE;
-      i--
-    ) {
+    // Write the value in big-endian format across all 12 bytes
+    for (let i = this.NONCE_LENGTH - 1; i >= 0; i--) {
       nonceBuffer[i] = Number(value & 0xffn)
       value = value >> 8n
     }
 
-    // First 4 bytes remain as zeros
     return nonceBuffer
   }
 

--- a/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
@@ -1,6 +1,14 @@
 import { describe, test } from 'bun:test'
 
 import {
+  testCreateNonceDoesNotCollideAboveU64,
+  testCreateNonceIsUnchangedBelowU64,
+  testCreateNonceMatchesU96Encoding,
+  testCreateNonceRejectsNegativeValues,
+  testCreateNonceRejectsOversizedValues,
+  testEncryptUsesFullWidthNumericNonce,
+} from '@sviem-tests/tests/encryptionNonce.ts'
+import {
   testAddressExplorerUrlBuildsCorrectUrl,
   testAddressExplorerUrlReturnsNullWithoutExplorer,
   testAddressExplorerUrlWithTab,
@@ -144,5 +152,26 @@ describe('Seismic EIP-712 typed data', () => {
   test(
     'includes authorizationListHash',
     testTypedDataIncludesAuthorizationListHash
+  )
+})
+
+describe('encryption nonce (U96)', () => {
+  test('matches the node U96 encoding', testCreateNonceMatchesU96Encoding)
+  test(
+    'does not collide for values differing above bit 63',
+    testCreateNonceDoesNotCollideAboveU64
+  )
+  test(
+    'is unchanged for values that fit in 64 bits',
+    testCreateNonceIsUnchangedBelowU64
+  )
+  test(
+    'rejects values wider than 96 bits',
+    testCreateNonceRejectsOversizedValues
+  )
+  test('rejects negative values', testCreateNonceRejectsNegativeValues)
+  test(
+    'encrypt uses the full-width numeric nonce',
+    testEncryptUsesFullWidthNumericNonce
   )
 })


### PR DESCRIPTION
Fixes #249

## What was wrong

`AesGcmCrypto.numberToNonce` wrote a numeric nonce into only the **low 64 bits** of the 12-byte AES-GCM nonce, leaving the top 4 bytes zero:

```ts
private readonly U64_SIZE = 8 // Size of u64 in bytes
...
// Write the u64 value in big-endian format to the last 8 bytes
for (let i = this.NONCE_LENGTH - 1; i >= this.NONCE_LENGTH - this.U64_SIZE; i--) {
```

The node's field is 96 bits wide — `pub encryption_nonce: U96` in [`seismic-alloy`](https://github.com/SeismicSystems/seismic-alloy/blob/seismic/crates/consensus/src/transaction/seismic.rs), converted to the AEAD nonce via `self.encryption_nonce.to_be_bytes()` — and the Python client encodes it that way (`int.to_bytes(12, "big")`).

So two values differing only above bit 63 produced the **same nonce**:

```ts
c.createNonce(5n)             // 0x000000000000000000000005
c.createNonce(2n ** 64n + 5n) // 0x000000000000000000000005   ← collision
```

Reusing an AES-GCM nonce under one key leaks the XOR of the plaintexts and can expose the authentication key, so a silent collision is the worst failure mode this API has. Nothing was thrown — the value was just quietly narrowed, while the Python client raises `OverflowError` for the same input.

The doc comment said this matched Rust's implementation. Rust's field is `U96`, not `u64`.

## The change

Write the value across all 12 bytes, and reject out-of-range input rather than truncating:

```diff
-  for (let i = this.NONCE_LENGTH - 1; i >= this.NONCE_LENGTH - this.U64_SIZE; i--) {
+  if (value < 0n) throw new Error(`Nonce must not be negative, got ${num}`)
+  if (value >= 1n << 96n) throw new Error(`Nonce must fit in 96 bits (12 bytes), got ${num}`)
+  for (let i = this.NONCE_LENGTH - 1; i >= 0; i--) {
```

Plus the corrected doc comment and the now-unused `U64_SIZE`.

**Backward compatible.** Any value below 2^64 encodes to exactly the same bytes as before — the top 4 bytes were already zero for those. Only previously-truncating inputs change behavior, and they change from a silent collision to either the correct encoding or an explicit error.

## Tests

Six unit tests in `packages/seismic-viem-tests/src/tests/encryptionNonce.ts`, wired into `viem-unit.test.ts` so CI's `test::unit` job runs them. No node required.

| Test | Before this change |
| --- | --- |
| matches the node U96 encoding | **FAILED** — 5 of 8 reference vectors wrong |
| does not collide for values differing above bit 63 | **FAILED** — `5` and `2^64+5` gave identical nonces |
| rejects values wider than 96 bits | **FAILED** — truncated silently |
| rejects negative values | **FAILED** — produced garbage |
| encrypt uses the full-width numeric nonce | **FAILED** — ciphertext matched the truncated nonce |
| is unchanged for values that fit in 64 bits | passes — backward-compatibility guard |

The reference vectors are cross-checked against the Python client's encoding:

```
5             -> 0x000000000000000000000005
2^63          -> 0x000000008000000000000000
2^64          -> 0x000000010000000000000000
2^64 + 5      -> 0x000000010000000000000005
2^95          -> 0x800000000000000000000000
2^96 - 1      -> 0xffffffffffffffffffffffff
2^96          -> OverflowError
-1            -> OverflowError
```

## Verification

Run locally from `clients/ts/`:

- `bun run viem:unit:test` — 42 pass, 0 fail (36 before, plus these 6; 5 of them fail without the fix)
- `bun run lint:check` — clean
- `bun run typecheck` — clean
- `bun run build` — clean

Integration tests against a node were not run locally; CI's sanvil and sreth lanes cover those.

## Scope note

The main transaction path carries `encryptionNonce` as `Hex` and never went through this conversion, so it was not affected. The exposure is the numeric nonce API — `createNonce`, and `encrypt`/`decrypt` with a `number | bigint` nonce — which the security-params docs point callers at for deterministic tests and for reproducing an exact encrypted request shape.
