### PR TITLE
fix(seismic-web3): remap fixed shielded arrays

### DIFF
--- a/clients/py/src/seismic_web3/contract/abi.py
+++ b/clients/py/src/seismic_web3/contract/abi.py
@@ -32,32 +32,10 @@ def _remap_type(solidity_type: str) -> tuple[str, bool]:
     Returns:
         Tuple of (remapped_type, was_shielded).
     """
-    # suint/sint with fixed-size array: suint256[5] → uint256[5]
-    m = re.match(r"^(s)(u?int\d+)(\[\d+\])$", solidity_type)
+    # Shielded scalar or array type: suint256[5] -> uint256[5].
+    m = re.match(r"^s(u?int\d+|bool|address)((?:\[\d*\])*)$", solidity_type)
     if m:
-        return f"{m.group(2)}{m.group(3)}", True
-
-    # suint/sint with dynamic array: suint256[] → uint256[]
-    m = re.match(r"^(s)(u?int\d+)(\[\])$", solidity_type)
-    if m:
-        return f"{m.group(2)}{m.group(3)}", True
-
-    # suint/sint scalar: suint256 → uint256
-    m = re.match(r"^s(u?int\d+)$", solidity_type)
-    if m:
-        return m.group(1), True
-
-    # sbool / sbool[]
-    if solidity_type == "sbool":
-        return "bool", True
-    if solidity_type == "sbool[]":
-        return "bool[]", True
-
-    # saddress / saddress[]
-    if solidity_type == "saddress":
-        return "address", True
-    if solidity_type == "saddress[]":
-        return "address[]", True
+        return f"{m.group(1)}{m.group(2)}", True
 
     return solidity_type, False
 

--- a/clients/py/tests/test_abi.py
+++ b/clients/py/tests/test_abi.py
@@ -48,14 +48,29 @@ class TestRemapSeismicParam:
         assert result["type"] == "bool[]"
         assert result["shielded"] is True
 
+    def test_sbool_fixed_array(self):
+        result = remap_seismic_param({"name": "x", "type": "sbool[2]"})
+        assert result["type"] == "bool[2]"
+        assert result["shielded"] is True
+
     def test_saddress_dynamic_array(self):
         result = remap_seismic_param({"name": "x", "type": "saddress[]"})
         assert result["type"] == "address[]"
         assert result["shielded"] is True
 
+    def test_saddress_fixed_array(self):
+        result = remap_seismic_param({"name": "x", "type": "saddress[2]"})
+        assert result["type"] == "address[2]"
+        assert result["shielded"] is True
+
     def test_sint64_dynamic_array(self):
         result = remap_seismic_param({"name": "x", "type": "sint64[]"})
         assert result["type"] == "int64[]"
+        assert result["shielded"] is True
+
+    def test_suint256_nested_array(self):
+        result = remap_seismic_param({"name": "x", "type": "suint256[2][]"})
+        assert result["type"] == "uint256[2][]"
         assert result["shielded"] is True
 
     def test_non_shielded_passthrough(self):
@@ -185,6 +200,23 @@ class TestEncodeShieldedCalldata:
         param_data = bytes(calldata[4:])
         assert len(param_data) == 32
         assert int.from_bytes(param_data, "big") == 42
+
+    def test_fixed_array_params_encoded_with_remapped_types(self):
+        abi = [
+            {
+                "type": "function",
+                "name": "setFlags",
+                "inputs": [{"name": "flags", "type": "sbool[2]"}],
+                "outputs": [],
+                "stateMutability": "nonpayable",
+            },
+        ]
+
+        calldata = encode_shielded_calldata(abi, "setFlags", [[True, False]])
+
+        expected_selector = keccak(b"setFlags(sbool[2])")[:4]
+        assert bytes(calldata[:4]) == expected_selector
+        assert bytes(calldata[4:]) == encode(["bool[2]"], [[True, False]])
 
     def test_no_args_function(self):
         calldata = encode_shielded_calldata(COUNTER_ABI, "increment", [])


### PR DESCRIPTION
Fixed Python ABI remapping for shielded array inputs like `sbool[2]`, `saddress[2]`, and nested integer arrays.

These are documented as supported shielded array forms, but `encode_shielded_calldata` left some of them as Seismic-specific ABI types, which `eth_abi` cannot encode.

Tested with:
- `uv run pytest tests/test_abi.py -q`
- `uv run pytest tests/ -q --ignore=tests/integration`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run ty check src/`