### PR TITLE
fix(seismic-encrypt): support legacy EIP-155 v values in toYParitySignatureArray parity calculation

### DIFF
--- a/clients/ts/packages/seismic-encrypt/src/index.ts
+++ b/clients/ts/packages/seismic-encrypt/src/index.ts
@@ -49,7 +49,9 @@ const toYParitySignatureArray = (signature?: {
   const { v, r, s } = signature
   const trimR = trim(r)
   const trimS = trim(s)
-  const yParity = v === 0n || v === 27n ? '0x' : toHex(1)
+  const isEvenParity =
+    v === 0n || v === 27n || (v >= 35n && (v - 35n) % 2n === 0n)
+  const yParity = isEvenParity ? '0x' : toHex(1)
   return [
     yParity,
     trimR === '0x00' ? '0x' : trimR,


### PR DESCRIPTION
Updated toYParitySignatureArray in clients/ts/packages/seismic-encrypt/src/index.ts to properly evaluate parity for legacy EIP-155 signature v values (v >= 35n). Previously, checking only v === 0n || v === 27n caused even-parity legacy signatures (e.g. v = 37n) to incorrectly map to toHex(1) odd parity.