### PR TITLE
validate RNG precompile output length to prevent malformed entropy acceptance

### DIFF
--- a/contracts/src/seismic-std-lib/utils/precompiles/CryptoUtils.sol
+++ b/contracts/src/seismic-std-lib/utils/precompiles/CryptoUtils.sol
@@ -9,6 +9,7 @@ library CryptoUtils {
     ////////////////////////////////////////////////////////////////////////
 
     error RNGPrecompileCallFailed();
+    error InvalidRNGOutputLength(uint256 returnedLength);
     error AESPrecompileCallFailed();
     error EncryptionReturnedNoOutput();
     error CiphertextCannotBeEmpty();
@@ -40,6 +41,7 @@ library CryptoUtils {
     function generateRandomNonce() internal view returns (uint96) {
         (bool success, bytes memory output) = RNG_PRECOMPILE.staticcall(abi.encodePacked(uint32(32)));
         if (!success) revert RNGPrecompileCallFailed();
+        if (output.length != 32) revert InvalidRNGOutputLength(output.length);
 
         bytes32 randomBytes;
         assembly {
@@ -57,6 +59,7 @@ library CryptoUtils {
 
         (bool success, bytes memory output) = RNG_PRECOMPILE.staticcall(input);
         if (!success) revert RNGPrecompileCallFailed();
+        if (output.length != 32) revert InvalidRNGOutputLength(output.length);
 
         bytes32 randomBytes;
         assembly {


### PR DESCRIPTION
This PR resolves a security defect in the cryptographic precompile wrappers where malformed RNG outputs could be accepted as valid entropy.

** Vulnerabilities & Anti-Patterns Remediated:**

*   **Malformed RNG output acceptance:** In `contracts/src/seismic-std-lib/utils/precompiles/CryptoUtils.sol`, specifically within `generateRandomNonce` and `generateRandomAESKey`, a successful RNG `staticcall` was previously followed by an unconditional 32-byte assembly load[cite: 1]. A successful short response could therefore be incorrectly interpreted as zero-padded or partial entropy[cite: 1].
    **Fix:** Both execution paths now explicitly require the output to be exactly 32 bytes before decoding[cite: 1]. If the condition is not met, the transaction reverts with `InvalidRNGOutputLength`[cite: 1].