### PR TITLE
enforce safe integer and u64 bounds for AES-GCM nonces

### DIFF
--- a/clients/ts/packages/seismic-viem/src/crypto/aes.ts
+++ b/clients/ts/packages/seismic-viem/src/crypto/aes.ts
@@ -22,7 +22,13 @@ export class AesGcmCrypto {
    * @param num - The number to convert (will be treated as u64)
    */
   private numberToNonce(num: bigint | number): Uint8Array {
+    if (typeof num === 'number' && !Number.isSafeInteger(num)) {
+      throw new RangeError('Nonce must be a safe integer')
+    }
     let value = BigInt(num)
+    if (value < 0n || value > 0xffffffffffffffffn) {
+      throw new RangeError('Nonce must fit in an unsigned 64-bit integer')
+    }
 
     // Create a buffer for the full nonce (12 bytes)
     const nonceBuffer = new Uint8Array(this.NONCE_LENGTH)

--- a/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
+++ b/clients/ts/tests/seismic-viem/src/viem-unit.test.ts
@@ -1,4 +1,6 @@
-import { describe, test } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
+import { AesGcmCrypto } from 'seismic-viem'
+import type { Hex } from 'viem'
 
 import {
   testAddressExplorerUrlBuildsCorrectUrl,
@@ -145,4 +147,28 @@ describe('Seismic EIP-712 typed data', () => {
     'includes authorizationListHash',
     testTypedDataIncludesAuthorizationListHash
   )
+})
+
+describe('AES-GCM numeric nonce bounds', () => {
+  const crypto = new AesGcmCrypto(
+    '0x0000000000000000000000000000000000000000000000000000000000000000' as Hex
+  )
+
+  test('rejects negative nonces', () => {
+    expect(() => crypto.createNonce(-1)).toThrow(
+      'Nonce must fit in an unsigned 64-bit integer'
+    )
+  })
+
+  test('rejects unsafe numeric nonces', () => {
+    expect(() => crypto.createNonce(Number.MAX_SAFE_INTEGER + 2)).toThrow(
+      'Nonce must be a safe integer'
+    )
+  })
+
+  test('rejects nonces larger than u64', () => {
+    expect(() => crypto.createNonce(0x1_0000_0000_0000_0000n)).toThrow(
+      'Nonce must fit in an unsigned 64-bit integer'
+    )
+  })
 })


### PR DESCRIPTION
This PR addresses the final security defect in the repository regarding nonce-domain boundaries and JavaScript precision loss.

** Vulnerabilities & Anti-Patterns Remediated:**

*   **Nonce-domain and JavaScript precision loss:** In `clients/ts/packages/seismic-viem/src/crypto/aes.ts`, the `AesGcmCrypto.numberToNonce` method previously allowed negative values, values above `u64`, and unsafe JavaScript numbers to be silently truncated or rounded into a completely different 12-byte AES-GCM nonce[cite: 1]. 
    **Fix:** The converter now explicitly rejects non-safe JavaScript integers, negative values, and values greater than `0xffffffffffffffffn`[cite: 1]. It strictly enforces the unsigned 64-bit domain before writing the final eight nonce bytes and executing serialization[cite: 1]. Additionally, regression coverage for negative, unsafe-number, and overflowing bigint inputs is confirmed in `clients/ts/tests/seismic-viem/src/viem-unit.test.ts`[cite: 1].