### PR TITLE
fix(react): reset isLoading when wallet client is not initialized in useShieldedWriteContract

### DIFF
--- a/clients/ts/packages/seismic-react/src/hooks/shieldedWriteContract.ts
+++ b/clients/ts/packages/seismic-react/src/hooks/shieldedWriteContract.ts
@@ -69,6 +69,7 @@ export function useShieldedWriteContract<
 
     if (!walletClient) {
       setError(new Error('Shielded wallet client not initialized'))
+      setIsLoading(false)
       return
     }
 


### PR DESCRIPTION
## Bug

`useShieldedWriteContract`'s `writeContract` callback sets `isLoading` to
`true` at the start, but if `walletClient` isn't initialized yet, it
returns early — before the `try/finally` block that resets `isLoading`.
The result: `isLoading` gets stuck `true` forever, even though an error
was already set. Any UI driven off this hook (e.g. a submit button showing
a spinner) would appear permanently loading.

The sibling hook `useSignedReadContract` (same file layout, same
early-return pattern) already handles this correctly — it calls
`setIsLoading(false)` before its early return:

```ts
if (!walletClient) {
  setError(new Error('Shielded wallet client not initialized'))
  setIsLoading(false)   // <- present in signedReadContract.ts
  return
}
```

`useShieldedWriteContract` is missing the equivalent line.

## Fix

Added the missing `setIsLoading(false)` call, matching the existing
pattern in `signedReadContract.ts` exactly.

## Testing

This package has no existing unit-test setup (only integration tests
against a running node under `tests/seismic-viem/`), and I wasn't able to
install `bun` in my sandbox to run `bun run lint:check` /
`bun run typecheck`. The change is a single line, adds no new imports, and
calls a state setter (`setIsLoading`) that's already used identically
elsewhere in the same function and in the sibling hook — happy to fix
anything CI flags, or to add a unit test for this hook if that's wanted
(would need to bring in a testing-library dependency, since there isn't
one in this package yet).