### PR TITLE
fix: use mise for contract artifact sync

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,11 +6,11 @@ This repository contains solidity smart contracts and libraries designed for the
 
 This project uses [Seismic-Foundry](https://github.com/SeismicSystems/seismic-foundry), which is needed to compile any contracts with shielded types or seismic precompiles.
 
-We recommend using our [Makefile](./Makefile) to run common tasks, as these will also be used in CI:
+We recommend using the [`mise`](https://mise.jdx.dev/) tasks in [`mise.toml`](./mise.toml) to run common tasks, as these will also be used in CI:
 ```bash
-make build
-make test
-make fmt
+mise run sforge -- build
+mise run test
+mise run fmt
 ...
 ```
 
@@ -45,7 +45,7 @@ contracts/
 
 The `artifacts/` directory contains compiled contract artifacts, including ABIs and bytecode. These are used for deployment and interaction with the contracts.
 
-These artifacts are currently generated manually using `make sync-artifacts`.
+These artifacts are currently generated manually using `mise run artifacts::sync`.
 
 TODO: we need to figure out a way to version these and make it more explicit which of these are deployed on each network, and at which block (or genesis).
 

--- a/contracts/script/sync-artifacts.sh
+++ b/contracts/script/sync-artifacts.sh
@@ -19,7 +19,7 @@ else
 fi
 
 echo "Building contracts..."
-make build
+mise run sforge -- build
 
 echo "Syncing genesis contracts..."
 mkdir -p artifacts


### PR DESCRIPTION
## Summary
- update contracts README examples to use the existing mise tasks instead of a missing Makefile
- change sync-artifacts.sh to build via the same mise/sforge task path
- update artifact sync docs to reference mise run artifacts::sync

Fixes #254.

## Testing
- git diff --check

Note: bash -n could not run locally because this Windows checkout's WSL install fails before starting with a missing Docker WSL VHD path.